### PR TITLE
refactor(row): spacing and line-height adjustment

### DIFF
--- a/packages/row/src/react/index.js
+++ b/packages/row/src/react/index.js
@@ -225,13 +225,15 @@ const formatActionBarWidth = ({ actionBar }) =>
     ? `(${actionBar.length} * ${actionBarActionWidth} + ${actionBar.length} * ${actionBarActionMarginLeft})`
     : '0px'
 
-const Words = glamorous.div({ flex: 1 }, props => ({
+const Words = glamorous.div({
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'column',
+    alignSelf: 'center'
+  }, props => ({
   maxWidth: `calc(100% - ${formatImageWidth(props)} - ${formatActionBarWidth(
     props
-  )})`,
-  display: 'flex',
-  flexDirection: 'column',
-  alignSelf: 'center'
+  )})`
 }))
 
 const styleTitleSize = ({ size }) =>

--- a/packages/row/src/react/index.js
+++ b/packages/row/src/react/index.js
@@ -111,7 +111,7 @@ const ActionBar = glamorous.div(
   ({ size }) =>
     ({
       [sizes.small]: { paddingTop: core.layout.spacingSmall },
-      [sizes.medium]: { paddingTop: core.layout.spacingLarge }
+      [sizes.medium]: { paddingTop: core.layout.spacingMedium }
     }[size]),
   styleActionBarFullOverlay,
   styleActionBarActionBarVisible
@@ -228,25 +228,29 @@ const formatActionBarWidth = ({ actionBar }) =>
 const Words = glamorous.div({ flex: 1 }, props => ({
   maxWidth: `calc(100% - ${formatImageWidth(props)} - ${formatActionBarWidth(
     props
-  )})`
+  )})`,
+  display: 'flex',
+  flexDirection: 'column',
+  alignSelf: 'center'
 }))
 
 const styleTitleSize = ({ size }) =>
   ({
     [sizes.small]: {
+      // marginTop: core.layout.spacingTiny,
       fontSize: core.type.fontSizeSmall,
-      lineHeight: core.lineHeightTight
+      lineHeight: core.type.lineHeightTight
     },
     [sizes.medium]: {
+      // marginTop: core.layout.spacingSmall,
       fontSize: core.type.fontSizeMedium,
-      lineHeight: core.lineHeightStandard
+      lineHeight: core.type.lineHeightStandard
     }
   }[size])
 
 const Title = glamorous.div(
   {
     display: 'block',
-    marginTop: core.layout.spacingSmall,
     fontWeight: core.type.fontWeightMedium,
     color: core.colors.white,
     textAlign: 'left'
@@ -293,9 +297,12 @@ Text.displayName = 'Row.Text'
 
 const styleMetadataSize = ({ size }) =>
   ({
-    [sizes.small]: { fontSize: core.type.fontSizeXSmall },
-    [sizes.medium]: { fontSize: core.type.fontSizeXSmall },
-    [sizes.large]: { fontSize: core.type.fontSizeSmall }
+    [sizes.small]: {
+      fontSize: core.type.fontSizeXSmall,
+      paddingTop: 0 },
+    [sizes.medium]: {
+      fontSize: core.type.fontSizeXSmall,
+      paddingTop: core.layout.spacingTiny }
   }[size])
 
 const Metadata = glamorous.div(
@@ -305,7 +312,8 @@ const Metadata = glamorous.div(
     fontWeight: core.type.fontWeightBook,
     lineHeight: core.type.lineHeightTight,
     color: core.colors.gray02,
-    maxWidth: '100%'
+    maxWidth: '100%',
+    paddingTop: core.layout.spacingTiny
   },
   styleMetadataSize
 )


### PR DESCRIPTION
A few spacing and line-height adjustment to match design.

There was a typo (missing .core.) that was causing title line-height not work.

Also, suggesting flex box center VS. padding for `words`, so that the text is centered regardless of string length or metadata inclusion.