### PR TITLE
fix(tab): set activeIndex state on children props update

### DIFF
--- a/packages/tab/src/react/list.js
+++ b/packages/tab/src/react/list.js
@@ -20,6 +20,12 @@ export default class extends React.Component {
     this.state = { activeIndex: findActiveIndex(this.props.children) }
     this.handleListItemClick = this.handleListItemClick.bind(this)
   }
+  componentWillReceiveProps(nextProps) {
+    const nextActiveIndex = findActiveIndex(nextProps.children)
+    if (this.state.activeIndex !== nextActiveIndex) {
+      this.setState({ activeIndex: nextActiveIndex })
+    }
+  }
   handleListItemClick(i, originalOnClick, evt) {
     this.setState({ activeIndex: i }, _ => {
       if (typeof originalOnClick === 'function') originalOnClick(i, evt)


### PR DESCRIPTION
### Active Tab not working properly

When you try to change the active tab from outside the `Tab.List`, by changing the active props on one of the children it doesn't work, but if you are changing the tabs by clicking on one of the tabs it works great.

### Design Decisions

Because we are using a state `activeIndex` to actually define the `active` prop passed to the children and this state is only being set on mount and on ListItem click, once you try to change the active tab by changing the `<Tab.ListItem active={true} />`, it won't change the state.

We need to implement `componentWillReceiveProps` and set activeIndex state when necessary.

### How to Verify

I found this problem because I'm using the route the user is on to define with tab should be active, but if you trigger a goBack action on history browser, it won't re-mount the component, so it needs to update the state on props changes
