### PR TITLE
link: add typescript typings for react component

### DIFF
--- a/packages/link/react.d.ts
+++ b/packages/link/react.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="react" />
+
+export type Appearance = 'default' | 'subtle'
+
+export interface LinkProps {
+  appearance?: Appearance
+}
+
+export default function Link(props: LinkProps): React.Component<LinkProps>
+

--- a/packages/link/react.d.ts
+++ b/packages/link/react.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="react" />
 
-export type Appearance = 'default' | 'subtle'
+type Appearance = 'default' | 'subtle'
 
 export interface LinkProps {
   appearance?: Appearance


### PR DESCRIPTION
### What You're Solving

- This change adds typescript typings for the React Link component

### Design Decisions

- I used a union type for two `appearance` values. I'm pretty new to typescript, so I'm not sure if that's a good/bad pattern. The downside to it is that if an appearance style is added, it will need to be updated in the type definition. Upside is compile time assurance that the value is correct.

### How to Verify

- The only way I really know to verify this is to pull it into a typescript/react app and see that it compiles. I've done this on the project I'm using the design system on and it seems to be working.