### PR TITLE
Row: prevent row image from shrinking

### DIFF
--- a/packages/row/src/react/index.js
+++ b/packages/row/src/react/index.js
@@ -261,7 +261,8 @@ const Words = glamorous.div(
     display: 'flex',
     flex: 1,
     flexDirection: 'column',
-    alignSelf: 'center'
+    alignSelf: 'center',
+    minWidth: 0
   },
   props => ({
     maxWidth: `calc(100% - ${formatImageWidth(props)} - ${formatActionBarWidth(


### PR DESCRIPTION
### What You're Solving

In certain cases, the row image and actions are shrinking when the Words
section runs out of space (see attached screenshot). This fix makes sure the Words section will collapse all the way to zero before the other flex items start collapsing.

### How to Verify

We've spent a while trying to reproduce this exact behavior and have not found a consistent way to do so outside our specific use case. We tested to make sure the fix did not change any of the examples in the design system site.

#### Before Fix
 ![screen shot](https://user-images.githubusercontent.com/679346/32678687-9372dc3e-c620-11e7-8e7c-c1b22331d365.png)

#### After Fix
![screen shot 2017-11-10 at 2 12 40 pm](https://user-images.githubusercontent.com/679346/32678827-4334a0bc-c621-11e7-8baa-81eabcee6f16.png)
