### PR TITLE
badge: extract css and vars modules

### DIFF
--- a/packages/badge/css.js
+++ b/packages/badge/css.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/css')

--- a/packages/badge/index.js
+++ b/packages/badge/index.js
@@ -1,3 +1,5 @@
+const css = require('./dist/css')
 const React = require('./dist/react')
+const vars = require('./dist/vars')
 
-module.exports = { React }
+module.exports = { css, React, vars }

--- a/packages/badge/src/css/index.js
+++ b/packages/badge/src/css/index.js
@@ -1,0 +1,62 @@
+import core from '@pluralsight/ps-design-system-core'
+
+import * as vars from '../vars'
+
+export default {
+  ['.badge']: {
+    display: 'inline-block',
+    padding: `0 ${core.layout.spacingXSmall}`,
+    fontWeight: core.type.fontWeightMedium,
+    fontSize: core.type.fontSizeXSmall,
+    lineHeight: core.type.lineHeightStandard,
+    borderRadius: '2px',
+    textTransform: 'uppercase'
+  },
+  // --appearance-stroke
+  ['.badge--appearance-stroke.badge--color-gray']: {
+    color: core.colors.gray02,
+    border: `1px solid ${core.colors.gray02}`
+  },
+  ['.badge--appearance-stroke.badge--color-green']: {
+    color: core.colors.green,
+    border: `1px solid ${core.colors.green}`
+  },
+  ['.badge--appearance-stroke.badge--color-yellow']: {
+    color: core.colors.yellow,
+    border: `1px solid ${core.colors.yellow}`
+  },
+  ['.badge--appearance-stroke.badge--color-red']: {
+    color: core.colors.red,
+    border: `1px solid ${core.colors.red}`
+  },
+  ['.badge--appearance-stroke.badge--color-blue']: {
+    color: core.colors.blue,
+    border: `1px solid ${core.colors.blue}`
+  },
+  // --appearance-default
+  ['.badge--appearance-default.badge--color-gray']: {
+    color: core.colors.white,
+    backgroundColor: core.colors.gray03,
+    border: `1px solid ${core.colors.gray03}`
+  },
+  ['.badge--appearance-default.badge--color-green']: {
+    color: core.colors.white,
+    backgroundColor: core.colors.green,
+    border: `1px solid ${core.colors.green}`
+  },
+  ['.badge--appearance-default.badge--color-yellow']: {
+    color: core.colors.black,
+    backgroundColor: core.colors.yellow,
+    border: `1px solid ${core.colors.yellow}`
+  },
+  ['.badge--appearance-default.badge--color-red']: {
+    color: core.colors.white,
+    backgroundColor: core.colors.red,
+    border: `1px solid ${core.colors.red}`
+  },
+  ['.badge--appearance-default.badge--color-blue']: {
+    color: core.colors.white,
+    backgroundColor: core.colors.blue,
+    border: `1px solid ${core.colors.blue}`
+  }
+}

--- a/packages/badge/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/badge/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -18,7 +18,7 @@ exports[`Storyshots appearance default 1`] = `
   }
 >
   <div
-    className="css-1rwlq8b"
+    className="css-vdc22r"
   >
     default Badge
   </div>
@@ -68,7 +68,7 @@ exports[`Storyshots color blue default 1`] = `
   }
 >
   <div
-    className="css-qko9jh"
+    className="css-1d3h730"
   >
     blue default Badge
   </div>
@@ -118,7 +118,7 @@ exports[`Storyshots color gray default 1`] = `
   }
 >
   <div
-    className="css-1rwlq8b"
+    className="css-vdc22r"
   >
     gray default Badge
   </div>
@@ -168,7 +168,7 @@ exports[`Storyshots color green default 1`] = `
   }
 >
   <div
-    className="css-eqw0k5"
+    className="css-jh132n"
   >
     green default Badge
   </div>
@@ -218,7 +218,7 @@ exports[`Storyshots color red default 1`] = `
   }
 >
   <div
-    className="css-6kw6e4"
+    className="css-17te2fi"
   >
     red default Badge
   </div>
@@ -268,7 +268,7 @@ exports[`Storyshots color yellow default 1`] = `
   }
 >
   <div
-    className="css-y1rz6v"
+    className="css-1q8b1lc"
   >
     yellow default Badge
   </div>

--- a/packages/badge/src/react/index.js
+++ b/packages/badge/src/react/index.js
@@ -3,56 +3,27 @@ import glamorous from 'glamorous'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const appearances = { default: 'default', stroke: 'stroke' }
-const colors = {
-  gray: 'gray',
-  green: 'green',
-  yellow: 'yellow',
-  red: 'red',
-  blue: 'blue'
-}
-
-const colorHexMap = {
-  [colors.gray]: { bg: core.colors.gray03, stroke: core.colors.gray02 },
-  [colors.green]: { bg: core.colors.green, stroke: core.colors.green },
-  [colors.yellow]: { bg: core.colors.yellow, stroke: core.colors.yellow },
-  [colors.red]: { bg: core.colors.red, stroke: core.colors.red },
-  [colors.blue]: { bg: core.colors.blue, stroke: core.colors.blue }
-}
+import css from '../css'
+import * as vars from '../vars'
 
 const Badge = glamorous.div(
-  {
-    display: 'inline-block',
-    padding: `0 ${core.layout.spacingXSmall}`,
-    fontWeight: core.type.fontWeightMedium,
-    fontSize: core.type.fontSizeXSmall,
-    lineHeight: core.type.lineHeightStandard,
-    borderRadius: '2px',
-    textTransform: 'uppercase'
-  },
+  css['.badge'],
   ({ color, appearance }) =>
-    appearance === appearances.stroke
-      ? {
-          color: colorHexMap[color].stroke,
-          border: `1px solid ${colorHexMap[color].stroke}`
-        }
-      : {
-          color:
-            color === colors.yellow ? core.colors.black : core.colors.white,
-          backgroundColor: colorHexMap[color].bg,
-          border: `1px solid ${colorHexMap[color].bg}`
-        }
+    css[`.badge--appearance-${appearance}.badge--color-${color}`]
 )
 
-Badge.appearances = appearances
-Badge.colors = colors
+Badge.appearances = vars.appearances
+Badge.colors = vars.colors
 
 Badge.propTypes = {
-  appearance: PropTypes.oneOf(Object.keys(appearances)),
-  color: PropTypes.oneOf(Object.keys(colors))
+  appearance: PropTypes.oneOf(Object.keys(vars.appearances)),
+  color: PropTypes.oneOf(Object.keys(vars.colors))
 }
 Badge.defaultProps = {
-  color: colors.gray
+  appearance: vars.appearances.default,
+  color: vars.colors.gray
 }
 
+export const appearances = vars.appearances
+export const colors = vars.colors
 export default Badge

--- a/packages/badge/src/vars/index.js
+++ b/packages/badge/src/vars/index.js
@@ -1,0 +1,9 @@
+export const appearances = { default: 'default', stroke: 'stroke' }
+
+export const colors = {
+  gray: 'gray',
+  green: 'green',
+  yellow: 'yellow',
+  red: 'red',
+  blue: 'blue'
+}

--- a/packages/badge/vars.js
+++ b/packages/badge/vars.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/vars')


### PR DESCRIPTION
Proof of concept for extracting css (and exported vars) from a design system component (badge, as the simple example).  It works in storybook and local reference site.  Feedback welcome.  

### Questions I'm Thinking About

- Is it worth it?  Good investment?  
- Are there better ways to do a similar thing?

### What You're Solving

- A potential way to allow sharing css between diff side-by-side or future component techs
- Or building/publishing raw css

### Design Decisions

- Plain JavaScript, compatible with that, at least
- JS could be built to JSON, converted to any other formats, including *.css
