### PR TITLE
feat(drawer): allow starting open

### DIFF
--- a/packages/drawer/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/drawer/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -437,6 +437,89 @@ exports[`Storyshots drawer using onToggle prop 1`] = `
 </div>
 `;
 
+exports[`Storyshots drawer using startOpen prop 1`] = `
+<div
+  style={
+    Object {
+      "background": "#181818",
+      "backgroundSize": "cover",
+      "bottom": 0,
+      "left": 0,
+      "overflow": "scroll",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+      "transition": "background 300ms",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "color": "white",
+        "fontSize": 24,
+        "padding": 48,
+      }
+    }
+  >
+    <div>
+      <div
+        className="css-a8p3d5"
+        onClick={[Function]}
+      >
+        <div
+          className="css-1lzobj4"
+        >
+          <div
+            className="css-1g6ond4"
+          >
+            <div>
+              Base here
+            </div>
+          </div>
+        </div>
+        <div
+          className="css-qs2rg7"
+        >
+          <button
+            className="css-wepra9"
+            onClick={[Function]}
+          >
+            <div
+              className="css-xnveog"
+            >
+              <div
+                className="css-otejxm"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 15.41l-5-5L8.41 9 12 12.58 15.59 9 17 10.41"
+                  />
+                </svg>
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+      <div
+        className="css-ule0ur"
+      >
+        <div
+          className="css-8nylan"
+        >
+          <div>
+            Panel here
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots drawer with row component 1`] = `
 <div
   style={

--- a/packages/drawer/src/react/index.js
+++ b/packages/drawer/src/react/index.js
@@ -92,7 +92,7 @@ const Rotatable = glamorous.div(
 class Drawer extends React.Component {
   constructor(props) {
     super(props)
-    this.state = { isOpen: false }
+    this.state = { isOpen: this.props.startOpen }
   }
 
   get isControlledByProps() {
@@ -151,7 +151,12 @@ Drawer.propTypes = {
   children: PropTypes.node.isRequired,
   base: PropTypes.node.isRequired,
   isOpen: PropTypes.bool,
-  onToggle: PropTypes.func
+  onToggle: PropTypes.func,
+  startOpen: PropTypes.bool
+}
+
+Drawer.defaultProps = {
+  startOpen: false
 }
 
 Drawer.contextTypes = {

--- a/packages/drawer/stories/index.js
+++ b/packages/drawer/stories/index.js
@@ -65,6 +65,11 @@ storiesOf('drawer', module)
     </Drawer>
   ))
   .add('controlled', () => <ControlledDrawerStory /> )
+  .add('using startOpen prop', () => (
+    <Drawer startOpen base={<div>Base here</div>}>
+      <div>Panel here</div>
+    </Drawer>
+  ))
   .add('using onToggle prop', () => <OnToggleDrawerStory />)
   .add('with row component', () => (
     <Drawer base={


### PR DESCRIPTION
## Instructions

### What You're Solving

Adds ability to start the drawer open. Currently only planed for use in examples in the DS site.

### How to Verify

Add the `startOpen` prop to the drawer component and verify it loads open and is able to be closed.
