### PR TITLE
fix(button): remove innerRef override

### DIFF
--- a/packages/button/src/react/index.js
+++ b/packages/button/src/react/index.js
@@ -350,7 +350,6 @@ class Btn extends React.Component {
       <Button
         {...props}
         iconOnly={React.Children.count(props.children) <= 0}
-        innerRef={el => (this.el = el)}
         style={isLoadingWithNoText ? { width: this.nonLoadingWidth } : {}}
         themeName={context.themeName}
       >


### PR DESCRIPTION
### What You're Solving

- Fix for issue #166

### How to Verify

-  Pass in a custom function to `Button.innerRef` _(something like a console log)_
