### PR TITLE
drawer: prevent tabbing into closed drawers

### DIFF
--- a/packages/drawer/src/react/collapsible.js
+++ b/packages/drawer/src/react/collapsible.js
@@ -5,6 +5,7 @@ import React from 'react'
 
 const Container = glamorous.div({
   overflow: 'hidden',
+  visibility: 'hidden',
   transition: `height ${core.motion.speedNormal}`,
 })
 
@@ -59,6 +60,7 @@ export default class Collapsible extends React.Component {
   }
   updateOverflowStyle(isOpen, isTransitioning = false) {
     this.containerElement.style.overflow = isTransitioning || !isOpen ? 'hidden' : 'visible'
+    this.containerElement.style.visibility = isTransitioning || isOpen ? 'visible' : 'hidden'
   }
   setHeightToAuto(element) {
     const prevHeight = element.style.height


### PR DESCRIPTION
### What You're Solving

- If a drawer is opened and then closed, you are able to tab into the invisible content. That seems bad.

### Design Decisions

Fixing this in collapsible makes sure that styles are updated only after animations have completed.

### How to Verify

- Add a focusable element inside a drawer
- Expand the drawer and verify that the element can be tabbed to
- Collapse the drawer and verify that the element can no longer be tabbed to
