### PR TITLE
Avatar: Style changes and Gravatar friendly

### DIFF
--- a/packages/avatar/CHANGELOG.md
+++ b/packages/avatar/CHANGELOG.md
@@ -10,11 +10,3 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Features
 
 * **avatar:** new component ([b35d3b2](https://github.com/pluralsight/design-system/commit/b35d3b2))
-
-
-
-
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/avatar/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/avatar/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -22,7 +22,7 @@ exports[`Storyshots Default large 1`] = `
   >
     <img
       data-css-1ba73bf=""
-      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400"
+      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=https://s2.pluralsight.com/design-system/assets/transparent.gif"
     />
   </div>
 </div>
@@ -50,7 +50,7 @@ exports[`Storyshots Default medium 1`] = `
   >
     <img
       data-css-1ba73bf=""
-      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400"
+      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=https://s2.pluralsight.com/design-system/assets/transparent.gif"
     />
   </div>
 </div>
@@ -78,7 +78,7 @@ exports[`Storyshots Default small 1`] = `
   >
     <img
       data-css-1ba73bf=""
-      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400"
+      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=https://s2.pluralsight.com/design-system/assets/transparent.gif"
     />
   </div>
 </div>
@@ -106,7 +106,7 @@ exports[`Storyshots Default xLarge 1`] = `
   >
     <img
       data-css-1ba73bf=""
-      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400"
+      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=https://s2.pluralsight.com/design-system/assets/transparent.gif"
     />
   </div>
 </div>
@@ -134,7 +134,7 @@ exports[`Storyshots Default xSmall 1`] = `
   >
     <img
       data-css-1ba73bf=""
-      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400"
+      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=https://s2.pluralsight.com/design-system/assets/transparent.gif"
     />
   </div>
 </div>
@@ -161,7 +161,7 @@ exports[`Storyshots Using Initials % Special Characters 1`] = `
     data-css-1m7zcb4=""
   >
     <div
-      data-css-2hpudj=""
+      data-css-1piqfk0=""
     >
       %C
     </div>
@@ -190,7 +190,7 @@ exports[`Storyshots Using Initials Anakin Skywalker 1`] = `
     data-css-1m7zcb4=""
   >
     <div
-      data-css-2hpudj=""
+      data-css-1piqfk0=""
     >
       AS
     </div>
@@ -219,7 +219,7 @@ exports[`Storyshots Using Initials Budapest Skywalker 1`] = `
     data-css-1m7zcb4=""
   >
     <div
-      data-css-awbda3=""
+      data-css-10aefha=""
     >
       BS
     </div>
@@ -248,7 +248,7 @@ exports[`Storyshots Using Initials Carlos Organa 1`] = `
     data-css-1m7zcb4=""
   >
     <div
-      data-css-o9l3rv=""
+      data-css-96mz0l=""
     >
       CO
     </div>
@@ -277,7 +277,7 @@ exports[`Storyshots Using Initials Dennis Pimenta 1`] = `
     data-css-1m7zcb4=""
   >
     <div
-      data-css-147nf7d=""
+      data-css-1ewxdui=""
     >
       DP
     </div>
@@ -306,7 +306,7 @@ exports[`Storyshots Using Initials Diz Blau 1`] = `
     data-css-1m7zcb4=""
   >
     <div
-      data-css-147nf7d=""
+      data-css-1ewxdui=""
     >
       DB
     </div>
@@ -335,7 +335,7 @@ exports[`Storyshots Using Initials Harry Potter 1`] = `
     data-css-1m7zcb4=""
   >
     <div
-      data-css-vyiqsv=""
+      data-css-e5wbco=""
     >
       HP
     </div>
@@ -364,7 +364,7 @@ exports[`Storyshots Using Initials Obi-Wan Kenobi 1`] = `
     data-css-1m7zcb4=""
   >
     <div
-      data-css-1w202mr=""
+      data-css-1f0e8wn=""
     >
       OK
     </div>
@@ -393,7 +393,7 @@ exports[`Storyshots Using Initials Peia Organa 1`] = `
     data-css-1m7zcb4=""
   >
     <div
-      data-css-14kwj5a=""
+      data-css-h0w4r3=""
     >
       PO
     </div>
@@ -422,7 +422,7 @@ exports[`Storyshots Using Initials Single 1`] = `
     data-css-1m7zcb4=""
   >
     <div
-      data-css-2hpudj=""
+      data-css-1piqfk0=""
     >
       SI
     </div>
@@ -451,7 +451,7 @@ exports[`Storyshots Using Initials Uy Marley 1`] = `
     data-css-1m7zcb4=""
   >
     <div
-      data-css-o9l3rv=""
+      data-css-96mz0l=""
     >
       UM
     </div>
@@ -504,5 +504,38 @@ exports[`Storyshots Using Initials null 1`] = `
     className={undefined}
     data-css-1m7zcb4=""
   />
+</div>
+`;
+
+exports[`Storyshots Using Initials with invalid gravatar image 1`] = `
+<div
+  style={
+    Object {
+      "background": "#181818",
+      "backgroundSize": "cover",
+      "bottom": 0,
+      "left": 0,
+      "overflow": "scroll",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+      "transition": "background 300ms",
+    }
+  }
+>
+  <div
+    className={undefined}
+    data-css-1m7zcb4=""
+  >
+    <img
+      data-css-1ba73bf=""
+      src="https://secure.gravatar.com/avatar/invalidhash?d=tmp&d=https://s2.pluralsight.com/design-system/assets/transparent.gif"
+    />
+    <div
+      data-css-1piqfk0=""
+    >
+      AT
+    </div>
+  </div>
 </div>
 `;

--- a/packages/avatar/src/react/__specs__/utils.spec.js
+++ b/packages/avatar/src/react/__specs__/utils.spec.js
@@ -1,4 +1,6 @@
+import { URL } from 'url'
 import * as utils from '../utils'
+import { defaultGravatarImage } from '../../vars'
 
 describe('avatar/utils', () => {
   describe('#getInitials', () => {
@@ -36,6 +38,22 @@ describe('avatar/utils', () => {
           /^#(?:[0-9a-fA-F]{3}){1,2}$/
         )
       })
+    })
+  })
+
+  describe('#transformSrc', () => {
+    test('should add default transparent image when gravatar', () => {
+      const src =
+        'https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7'
+      const url = new URL(utils.transformSrc(src))
+      expect(url.href).not.toBe(src)
+      expect(url.searchParams.get('d')).toEqual(defaultGravatarImage)
+    })
+
+    test('should not add default gravatar image when not gravatar', () => {
+      const src = 'https://test/123'
+      const url = new URL(utils.transformSrc(src))
+      expect(url.href).toBe(src)
     })
   })
 })

--- a/packages/avatar/src/react/index.js
+++ b/packages/avatar/src/react/index.js
@@ -2,11 +2,11 @@ import React from 'react'
 import { sizes } from '../vars'
 import PropTypes from 'prop-types'
 import styles from './styles'
-import { getInitials } from './utils'
+import { getInitials, transformSrc } from './utils'
 
 const Avatar = ({ name, src, size, className }) => (
   <div {...styles.body({ size })} className={className}>
-    {src && <img {...styles.img} src={src} />}
+    {src && <img {...styles.img} src={transformSrc(src)} />}
     {name && <div {...styles.initials({ name })}>{getInitials(name)}</div>}
   </div>
 )

--- a/packages/avatar/src/react/styles.js
+++ b/packages/avatar/src/react/styles.js
@@ -63,7 +63,7 @@ const initials = ({ name }) =>
     flexDirection: 'column',
     justifyContent: 'center',
     color: core.colors.white,
-    fontWeight: core.type.fontWeightXLight,
+    fontWeight: core.type.fontWeightBook,
     backgroundColor: getColorByName(name) || core.colors.bone
   })
 

--- a/packages/avatar/src/react/utils.js
+++ b/packages/avatar/src/react/utils.js
@@ -1,4 +1,4 @@
-import { colorByLetter, defaultColor } from '../vars'
+import { colorByLetter, defaultColor, defaultGravatarImage } from '../vars'
 
 export const getInitials = fullname => {
   if (!fullname || !fullname.length) return
@@ -14,4 +14,10 @@ export const getInitials = fullname => {
 export const getColorByName = name => {
   const initial = name[0].toUpperCase() || null
   return colorByLetter[initial] || defaultColor
+}
+
+export const transformSrc = src => {
+  if (!src.match(/gravatar/)) return src
+  const sep = src.match(/\?/) ? '&' : '?'
+  return `${src}${sep}d=${defaultGravatarImage}`
 }

--- a/packages/avatar/src/vars/index.js
+++ b/packages/avatar/src/vars/index.js
@@ -26,3 +26,6 @@ export const colorByLetter = letters.reduce((map, letter, i) => {
 }, {})
 
 export const defaultColor = colors[0]
+
+export const defaultGravatarImage =
+  'https://s2.pluralsight.com/design-system/assets/transparent.gif'

--- a/packages/avatar/stories/index.js
+++ b/packages/avatar/stories/index.js
@@ -37,6 +37,12 @@ const storyInitials = storiesOf('Using Initials', module)
   .addDecorator(themeDecorator(addons))
   .add('empty', () => <Avatar name={''} />)
   .add('null', () => <Avatar name={null} />)
+  .add('with invalid gravatar image', () => (
+    <Avatar
+      name="Alan Turing"
+      src="https://secure.gravatar.com/avatar/invalidhash?d=tmp"
+    />
+  ))
 
 names.forEach(name => {
   storyInitials.add(name, () => <Avatar name={name} />)


### PR DESCRIPTION
This PR implements the following:

- Change initials font-weight from `ExtraLight` to `Book`
- Adds a transparent image as default fallback on gravatar urls.
  - Add `[?|&]d=https://cdn/transparent.gif` param at the end of gravatar urls.

### Usage
```jsx
<Avatar src="https://secure.gravatar.com/..." name="Anakin Skywalker" />
```

When you pass a gravatar link that doesn't have a picture

Before             |  After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/2067022/35419041-11f10cb2-01f3-11e8-8ce9-3ff67ddbb1c0.png) | ![image](https://user-images.githubusercontent.com/2067022/35419031-03babb02-01f3-11e8-8559-9e37c5f0ad04.png)

