### PR TITLE
Disabled button click fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,7 @@ jspm_packages
 # Optional REPL history
 .node_repl_history
 
+# VsCode Settings
+.vscode/
+
 .env*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": false
-}

--- a/packages/button/src/react/__specs__/index.spec.js
+++ b/packages/button/src/react/__specs__/index.spec.js
@@ -18,6 +18,26 @@ test('click on button triggered once', () => {
   expect(callCount).toBe(1)
 })
 
+test('click on disabled button with href does not trigger onClick', () => {
+  let callCount = 0
+  const onClick = _ => {
+    callCount += 1
+  }
+  const button = mount(
+    <Button
+      disabled={true}
+      onClick={onClick}
+      href="https://foo.com"
+      icon={<Icon id={Icon.ids.check} />}
+    >
+      Can't Be Clicked
+    </Button>
+  )
+  button.simulate('click')
+
+  expect(callCount).toBe(0)
+})
+
 test('custom innerRef function called', done => {
   mount(<Button innerRef={done} />)
 })

--- a/packages/button/src/react/index.js
+++ b/packages/button/src/react/index.js
@@ -322,12 +322,17 @@ const whitelistProps = (props, whitelist) =>
 
 class Button extends React.Component {
   render() {
+    const whitelistedProps =
+      this.props.disabled && this.props.href
+        ? buttonHtmlPropsWhitelist.filter(prop => prop !== 'onClick')
+        : buttonHtmlPropsWhitelist
+
     return React.createElement(
       this.props.href ? 'a' : 'button',
       {
         ...(this.props.innerRef ? { ref: this.props.innerRef } : {}),
         ...getButtonStyles(this.props),
-        ...whitelistProps(this.props, buttonHtmlPropsWhitelist),
+        ...whitelistProps(this.props, whitelistedProps),
         disabled: this.props.disabled || this.props.loading
       },
       this.props.children


### PR DESCRIPTION
### What You're Solving

- Fix: Disabled buttons don't get disabled if they have an href prop
- When an href prop is passed, the button is rendered using an anchor tag. Anchor tags ignore the disabled attribute.

### Design Decisions

- I implemented this by removing (without mutating) onClick from the whitelisted props only when disabled and href are both passed.

### How to Verify

- Add a disabled prop to a Button that also has an href prop
