### PR TITLE
tag: change children propType from string to node

### DIFF
--- a/packages/tag/src/react/index.js
+++ b/packages/tag/src/react/index.js
@@ -43,8 +43,9 @@ const TagContainer = props => {
         textDecoration: 'none',
         border: 'none',
         overflow: 'hidden',
-        transition: `background-color ${core.motion
-          .speedXFast} linear, color ${core.motion.speedXFast} linear`,
+        transition: `background-color ${core.motion.speedXFast} linear, color ${
+          core.motion.speedXFast
+        } linear`,
         ...(({ href, onClick }) =>
           href || onClick
             ? {
@@ -134,7 +135,7 @@ Tag.sizes = sizes
 
 Tag.propTypes = {
   appearance: PropTypes.oneOf(Object.keys(appearances)),
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   href: PropTypes.string,
   icon: PropTypes.element,
   isPressed: PropTypes.bool,


### PR DESCRIPTION
### What You're Solving

- Allows passing a node as children instead of just a string. Makes it easier to
control the way children are ellipsified.
- Resolves issue #188 

### How to Verify

- Verify you can pass a node in as the children to a `tag` component
