### PR TITLE
fix(avatar): hide img or initials based on img load state

### DIFF
--- a/packages/avatar/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/avatar/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -21,8 +21,49 @@ exports[`Storyshots Default large 1`] = `
   >
     <img
       data-css-1ba73bf=""
-      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=https://s2.pluralsight.com/design-system/assets/transparent.gif"
+      onError={[Function]}
+      onLoad={[Function]}
+      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=404"
     />
+  </div>
+</div>
+`;
+
+exports[`Storyshots Default light image 1`] = `
+<div
+  style={
+    Object {
+      "background": "#181818",
+      "backgroundSize": "cover",
+      "bottom": 0,
+      "left": 0,
+      "overflow": "scroll",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+      "transition": "background 300ms",
+    }
+  }
+>
+  <div
+    data-css-1m7zcb4=""
+  >
+    <img
+      data-css-1ba73bf=""
+      onError={[Function]}
+      onLoad={[Function]}
+      src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg?d=404"
+    />
+    <div
+      data-css-1t1cogi=""
+      style={
+        Object {
+          "backgroundColor": "#49897C",
+        }
+      }
+    >
+      JT
+    </div>
   </div>
 </div>
 `;
@@ -48,7 +89,9 @@ exports[`Storyshots Default medium 1`] = `
   >
     <img
       data-css-1ba73bf=""
-      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=https://s2.pluralsight.com/design-system/assets/transparent.gif"
+      onError={[Function]}
+      onLoad={[Function]}
+      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=404"
     />
   </div>
 </div>
@@ -75,7 +118,9 @@ exports[`Storyshots Default small 1`] = `
   >
     <img
       data-css-1ba73bf=""
-      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=https://s2.pluralsight.com/design-system/assets/transparent.gif"
+      onError={[Function]}
+      onLoad={[Function]}
+      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=404"
     />
   </div>
 </div>
@@ -102,7 +147,9 @@ exports[`Storyshots Default xLarge 1`] = `
   >
     <img
       data-css-1ba73bf=""
-      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=https://s2.pluralsight.com/design-system/assets/transparent.gif"
+      onError={[Function]}
+      onLoad={[Function]}
+      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=404"
     />
   </div>
 </div>
@@ -129,7 +176,9 @@ exports[`Storyshots Default xSmall 1`] = `
   >
     <img
       data-css-1ba73bf=""
-      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=https://s2.pluralsight.com/design-system/assets/transparent.gif"
+      onError={[Function]}
+      onLoad={[Function]}
+      src="https://secure.gravatar.com/avatar/0f792a763ebf08411c7f566079e4adc7?s=400&d=404"
     />
   </div>
 </div>
@@ -498,7 +547,7 @@ exports[`Storyshots Using Initials Uy Marley 1`] = `
 </div>
 `;
 
-exports[`Storyshots Using Initials empty 1`] = `
+exports[`Storyshots Using Initials empty name, no src 1`] = `
 <div
   style={
     Object {
@@ -522,7 +571,46 @@ exports[`Storyshots Using Initials empty 1`] = `
 </div>
 `;
 
-exports[`Storyshots Using Initials null 1`] = `
+exports[`Storyshots Using Initials error-out image src, with name 1`] = `
+<div
+  style={
+    Object {
+      "background": "#181818",
+      "backgroundSize": "cover",
+      "bottom": 0,
+      "left": 0,
+      "overflow": "scroll",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+      "transition": "background 300ms",
+    }
+  }
+>
+  <div
+    data-css-1m7zcb4=""
+  >
+    <img
+      data-css-1ba73bf=""
+      onError={[Function]}
+      onLoad={[Function]}
+      src="https://jaketrent.com/fake.jpg"
+    />
+    <div
+      data-css-1t1cogi=""
+      style={
+        Object {
+          "backgroundColor": "#9A171B",
+        }
+      }
+    >
+      BD
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Using Initials null name, no src 1`] = `
 <div
   style={
     Object {
@@ -565,7 +653,9 @@ exports[`Storyshots Using Initials with invalid gravatar image 1`] = `
   >
     <img
       data-css-1ba73bf=""
-      src="https://secure.gravatar.com/avatar/invalidhash?d=tmp&d=https://s2.pluralsight.com/design-system/assets/transparent.gif"
+      onError={[Function]}
+      onLoad={[Function]}
+      src="https://secure.gravatar.com/avatar/invalidhash?d=tmp&d=404"
     />
     <div
       data-css-1t1cogi=""
@@ -577,6 +667,35 @@ exports[`Storyshots Using Initials with invalid gravatar image 1`] = `
     >
       AT
     </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Using Initials with invalid gravatar image, no name 1`] = `
+<div
+  style={
+    Object {
+      "background": "#181818",
+      "backgroundSize": "cover",
+      "bottom": 0,
+      "left": 0,
+      "overflow": "scroll",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+      "transition": "background 300ms",
+    }
+  }
+>
+  <div
+    data-css-1m7zcb4=""
+  >
+    <img
+      data-css-1ba73bf=""
+      onError={[Function]}
+      onLoad={[Function]}
+      src="https://secure.gravatar.com/avatar/invalidhash?d=tmp&d=404"
+    />
   </div>
 </div>
 `;

--- a/packages/avatar/src/react/index.js
+++ b/packages/avatar/src/react/index.js
@@ -16,25 +16,52 @@ const styles = {
   initials: ({ name }) => glamor.css(css['.psds-avatar__initials'])
 }
 
-const Avatar = ({ className, name, size, src, style }) => {
-  const avatarProps = {
-    ...styles.avatar({ size }),
-    ...(className ? { className } : null),
-    ...(style ? { style } : null)
+class Avatar extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { imageState: 'loading' }
+    this.handleImageLoadSuccess = this.handleImageLoadSuccess.bind(this)
+    this.handleImageLoadError = this.handleImageLoadError.bind(this)
   }
-  return (
-    <div {...avatarProps}>
-      {src && <img {...styles.image()} src={transformSrc(src)} />}
-      {name && (
-        <div
-          {...styles.initials({ name })}
-          style={{ backgroundColor: getColorByName(name) }}
-        >
-          {getInitials(name)}
-        </div>
-      )}
-    </div>
-  )
+  handleImageLoadSuccess() {
+    this.setState({ imageState: 'success' })
+  }
+  handleImageLoadError() {
+    this.setState({ imageState: 'error' })
+  }
+  render() {
+    const { className, name, size, src, style } = this.props
+    const { imageState } = this.state
+    const avatarProps = {
+      ...styles.avatar({ size }),
+      ...(className ? { className } : null),
+      ...(style ? { style } : null)
+    }
+    const shouldShowImg = src && imageState !== 'error'
+    const shouldShowInitials =
+      name && (imageState === 'error' || imageState === 'loading')
+
+    return (
+      <div {...avatarProps}>
+        {shouldShowImg && (
+          <img
+            onError={this.handleImageLoadError}
+            onLoad={this.handleImageLoadSuccess}
+            {...styles.image()}
+            src={transformSrc(src)}
+          />
+        )}
+        {shouldShowInitials && (
+          <div
+            {...styles.initials({ name })}
+            style={{ backgroundColor: getColorByName(name) }}
+          >
+            {getInitials(name)}
+          </div>
+        )}
+      </div>
+    )
+  }
 }
 
 Avatar.defaultProps = {

--- a/packages/avatar/src/vars/index.js
+++ b/packages/avatar/src/vars/index.js
@@ -27,5 +27,4 @@ export const colorByLetter = letters.reduce((map, letter, i) => {
 
 export const defaultColor = colors[0]
 
-export const defaultGravatarImage =
-  'https://s2.pluralsight.com/design-system/assets/transparent.gif'
+export const defaultGravatarImage = '404'

--- a/packages/avatar/stories/index.js
+++ b/packages/avatar/stories/index.js
@@ -18,6 +18,12 @@ Object.keys(Avatar.sizes).forEach(size =>
     />
   ))
 )
+storySizes.add('light image', () => (
+  <Avatar
+    src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg"
+    name="Jake Trent"
+  />
+))
 
 const names = [
   '% Special Characters',
@@ -35,13 +41,19 @@ const names = [
 
 const storyInitials = storiesOf('Using Initials', module)
   .addDecorator(themeDecorator(addons))
-  .add('empty', () => <Avatar name={''} />)
-  .add('null', () => <Avatar name={null} />)
+  .add('empty name, no src', () => <Avatar name={''} />)
+  .add('null name, no src', () => <Avatar name={null} />)
+  .add('error-out image src, with name', () => (
+    <Avatar name="Bill Dill" src="https://jaketrent.com/fake.jpg" />
+  ))
   .add('with invalid gravatar image', () => (
     <Avatar
       name="Alan Turing"
       src="https://secure.gravatar.com/avatar/invalidhash?d=tmp"
     />
+  ))
+  .add('with invalid gravatar image, no name', () => (
+    <Avatar src="https://secure.gravatar.com/avatar/invalidhash?d=tmp" />
   ))
 
 names.forEach(name => {


### PR DESCRIPTION
Help remove color halo that bled out from behind loaded images.  Had to
change the gravatar fallback strategy to support this.  Otherwise, the
rule was that we always show initials in the case of gravatar images.
But we don't want this, because depending on the color combo, the halo
is visible.  Instead, now we fail gravatar images like any other.

Closes #191