### PR TITLE
refactor(button): whitelist role for button

### DIFF
--- a/packages/button/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/button/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -1853,6 +1853,37 @@ exports[`Storyshots props pass through not supported 1`] = `
 </div>
 `;
 
+exports[`Storyshots props pass through role 1`] = `
+<div
+  style={
+    Object {
+      "background": "#181818",
+      "backgroundSize": "cover",
+      "bottom": 0,
+      "left": 0,
+      "overflow": "scroll",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+      "transition": "background 300ms",
+    }
+  }
+>
+  <button
+    data-css-1sql3pc=""
+    disabled={false}
+    role="link"
+    style={Object {}}
+  >
+    <span
+      className="css-1en8fmq"
+    >
+      Role Link
+    </span>
+  </button>
+</div>
+`;
+
 exports[`Storyshots props pass through title 1`] = `
 <div
   style={

--- a/packages/button/src/react/index.js
+++ b/packages/button/src/react/index.js
@@ -166,6 +166,7 @@ const buttonHtmlPropsWhitelist = [
   'onClick',
   'disabled',
   'className',
+  'role',
   'style',
   'title',
   'tabIndex',

--- a/packages/button/stories/index.js
+++ b/packages/button/stories/index.js
@@ -118,6 +118,7 @@ const propsExample = storiesOf('props pass through', module)
   .add('aria-expanded', _ => (
     <Button aria-expanded={true}>aria-expanded</Button>
   ))
+  .add('role', _ => <Button role="link">Role Link</Button>)
   .add('data-something', _ => (
     <Button data-something="wow">Custom data attributes</Button>
   ))


### PR DESCRIPTION
In a spa we often wrap the button within a Link tag, and need a way to assign a role to the button. This pull-request adds `role` to the whitelist and allows it to be attached to the generated comp. 