### PR TITLE
switch:Remove switch checkbox input from the tab order

### DIFF
--- a/packages/switch/src/react/index.js
+++ b/packages/switch/src/react/index.js
@@ -63,6 +63,7 @@ const Switch = (props, context) => {
         type="checkbox"
         readOnly
         checked={allProps.checked}
+        tabIndex="-1"
         {...styles.checkbox(allProps)}
       />
       <label {...styles.label(allProps)}>{allProps.children}</label>


### PR DESCRIPTION
### What You're Solving

Solves [issue #212](https://github.com/pluralsight/design-system/issues/212)

### Steps to verify

Attempt to tab to the input. You can't. That's what tabIndex="-1" does!