### PR TITLE
actionmenu: allow custom icons

### DIFF
--- a/packages/actionmenu/CHANGELOG.md
+++ b/packages/actionmenu/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.6.2"></a>
+## [2.6.2](https://github.com/pluralsight/design-system/compare/@pluralsight/ps-design-system-actionmenu@2.6.1...@pluralsight/ps-design-system-actionmenu@2.6.2) (2018-06-06)
+
+
+### Bug Fixes
+
+* **actionmenu:** focus and link color fixes ([#219](https://github.com/pluralsight/design-system/issues/219)) ([a399c44](https://github.com/pluralsight/design-system/commit/a399c44))
+* **actionmenu:** restore snapshot ([06bb002](https://github.com/pluralsight/design-system/commit/06bb002))
+
+
+
+
 <a name="2.6.1"></a>
 ## [2.6.1](https://github.com/pluralsight/design-system/compare/@pluralsight/ps-design-system-actionmenu@2.6.0...@pluralsight/ps-design-system-actionmenu@2.6.1) (2018-06-05)
 

--- a/packages/actionmenu/package.json
+++ b/packages/actionmenu/package.json
@@ -44,7 +44,7 @@
     "babel-preset-env": "^1.4.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
-    "jest": "^20.0.4",
+    "jest": "^21.2.1",
     "npm-run-all": "^4.1.2"
   }
 }

--- a/packages/actionmenu/package.json
+++ b/packages/actionmenu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pluralsight/ps-design-system-actionmenu",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Design System component for actionmenu ui",
   "main": "index.js",
   "module": "index.js",

--- a/packages/actionmenu/src/css/index.js
+++ b/packages/actionmenu/src/css/index.js
@@ -97,8 +97,8 @@ export default {
     color: core.colors.gray05
   },
 
-  // __item--iconId
-  '.psds-actionmenu__item--iconId': {
+  // __item--icon
+  '.psds-actionmenu__item--icon': {
     paddingLeft: core.layout.spacingXSmall
   },
 

--- a/packages/actionmenu/src/react/index.js
+++ b/packages/actionmenu/src/react/index.js
@@ -10,7 +10,7 @@ import css from '../css'
 import * as vars from '../vars'
 
 const styles = {
-  item: ({ iconId, isActive, nested }) =>
+  item: ({ icon, iconId, isActive, nested }) =>
     glamor.css(
       css['.psds-actionmenu__item'],
       {
@@ -19,17 +19,23 @@ const styles = {
         ':active': css['.psds-actionmenu__item--link'],
         ':visited': css['.psds-actionmenu__item--link']
       },
-      iconId ? css['.psds-actionmenu__item--iconId'] : null,
+      icon || iconId ? css['.psds-actionmenu__item--icon'] : null,
       nested ? css['.psds-actionmenu__item--nested'] : null,
       isActive ? css['.psds-actionmenu__item--isActive'] : null
     )
 }
 
-const IconComponent = props => (
-  <div {...glamor.css(css['.psds-actionmenu__item__icon'])}>
-    <Icon id={props.iconId} size={Icon.sizes.medium} />
-  </div>
-)
+const IconComponent = props => {
+  return (
+    <div {...glamor.css(css['.psds-actionmenu__item__icon'])}>
+      {props.iconId ? (
+        <Icon id={props.iconId} size={Icon.sizes.medium} />
+      ) : (
+        React.cloneElement(props.children, { size: Icon.sizes.medium })
+      )}
+    </div>
+  )
+}
 
 const NestedArrow = _ => (
   <div {...glamor.css(css['.psds-actionmenu__item__arrow'])}>
@@ -73,7 +79,12 @@ class ItemComponent extends React.Component {
     if (this.props.isActive && this.props.shouldFocusOnMount) this.item.focus()
   }
   componentDidUpdate(prevProps) {
-    if (!prevProps.isActive && this.props.isActive && !this.state.isNestedRendered) this.item.focus()
+    if (
+      !prevProps.isActive &&
+      this.props.isActive &&
+      !this.state.isNestedRendered
+    )
+      this.item.focus()
   }
   handleKeyDown(evt) {
     if (
@@ -90,8 +101,7 @@ class ItemComponent extends React.Component {
     this.item.focus()
   }
   handleMouseOver() {
-    if (this.props.nested)
-      this.setState({ isNestedRendered: true })
+    if (this.props.nested) this.setState({ isNestedRendered: true })
     this.props._onMouseOver(this.props._i)
   }
   handleMouseOut() {
@@ -136,7 +146,11 @@ class ItemComponent extends React.Component {
             role: 'menuitem',
             ...styles.item(this.props)
           },
-          this.props.iconId && <IconComponent iconId={this.props.iconId} />,
+          (this.props.iconId || this.props.icon) && (
+            <IconComponent iconId={this.props.iconId}>
+              {this.props.icon}
+            </IconComponent>
+          ),
           this.props.children,
           this.props.nested && <NestedArrow />
         )}
@@ -149,6 +163,7 @@ ItemComponent.displayName = 'ActionMenu.Item'
 ItemComponent.propTypes = {
   href: PropTypes.string,
   iconId: PropTypes.oneOf(Object.keys(Icon.ids)),
+  icon: PropTypes.node,
   isActive: PropTypes.bool,
   nested: PropTypes.element, // ActionMenu
   onClick: PropTypes.func,
@@ -266,7 +281,9 @@ class ActionMenuComponent extends React.Component {
     const direction = evt.shiftKey ? 'up' : 'down'
     const { activeIndex } = this.state
     const lastIndex = React.Children.count(this.props.children) - 1
-    const atEdge = (direction === 'up' && activeIndex === 0) || (direction === 'down' && activeIndex === lastIndex)
+    const atEdge =
+      (direction === 'up' && activeIndex === 0) ||
+      (direction === 'down' && activeIndex === lastIndex)
 
     if (atEdge) {
       this.navigateOut(evt)

--- a/packages/site/CHANGELOG.md
+++ b/packages/site/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="9.40.2"></a>
+## [9.40.2](https://github.com/pluralsight/design-system/compare/@pluralsight/ps-design-system-site@9.40.1...@pluralsight/ps-design-system-site@9.40.2) (2018-06-06)
+
+
+
+
+**Note:** Version bump only for package @pluralsight/ps-design-system-site
+
 <a name="9.40.1"></a>
 ## [9.40.1](https://github.com/pluralsight/design-system/compare/@pluralsight/ps-design-system-site@9.40.0...@pluralsight/ps-design-system-site@9.40.1) (2018-06-06)
 

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pluralsight/ps-design-system-site",
   "private": true,
-  "version": "9.40.1",
+  "version": "9.40.2",
   "description": "Reference site",
   "main": "index.js",
   "engines": {
@@ -15,7 +15,7 @@
   "author": "jaketrent",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@pluralsight/ps-design-system-actionmenu": "^2.6.1",
+    "@pluralsight/ps-design-system-actionmenu": "^2.6.2",
     "@pluralsight/ps-design-system-avatar": "^1.6.1",
     "@pluralsight/ps-design-system-badge": "^2.1.1",
     "@pluralsight/ps-design-system-banner": "^1.2.1",


### PR DESCRIPTION
### What You're Solving

- Allow passing custom icons to action menu items via an icon prop
- Needed custom social media icons for share menu

### How to Verify

- Pass a custom icon component to an action menu item and verify it shows up
