### PR TITLE
Fix typos on site pages

### DIFF
--- a/packages/site/pages/components/breadcrumb.js
+++ b/packages/site/pages/components/breadcrumb.js
@@ -130,7 +130,7 @@ export default withServerProps(_ => (
       />
 
       <P>
-        Breadcrumbs should be written in sentece case, except for proper nouns
+        Breadcrumbs should be written in sentence case, except for proper nouns
         or product titles.
       </P>
       <Guideline

--- a/packages/site/pages/core/typography.js
+++ b/packages/site/pages/core/typography.js
@@ -114,7 +114,7 @@ const FontWeight = props => (
 // TODO: pull from core js vars
 const sizes = [
   { label: 'Gigantic', size: '60px', varName: 'psTypeFontSizeGigantic' },
-  { label: 'Jumbo', size: '48px', varName: 'psTypefontSizeJumbo' },
+  { label: 'Jumbo', size: '48px', varName: 'psTypeFontSizeJumbo' },
   { label: 'XX-Large', size: '36px', varName: 'psTypeFontSizeXXLarge' },
   { label: 'X-Large', size: '30px', varName: 'psTypeFontSizeXLarge' },
   { label: 'Large', size: '24px', varName: 'psTypeFontSizeLarge' },


### PR DESCRIPTION
## Instructions

- fill in title: "Fix typos on site pages"
- label: bug

### What You're Solving

- Fixing two typos on the static site pages - one under 'Breadcrumb' and one under 'Typography'

### Design Decisions

- N/A

### How to Verify

- N/A
