### PR TITLE
WIP: button,icon: add custom element conversion script

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -30,7 +30,8 @@
     "@pluralsight/ps-design-system-theme": "^1.3.1",
     "@pluralsight/ps-design-system-util": "^1.2.1",
     "polished": "^1.7.0",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "web-react-components": "lizardruss/web-react-components#master"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.1",

--- a/packages/button/src/web/index.js
+++ b/packages/button/src/web/index.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { register } from 'web-react-components'
+import Button from '../react'
+import Icon from '@pluralsight/ps-design-system-icon/react'
+
+export default register(
+  Button,
+  'ps-button',
+  [
+    'appearance',
+    '!!disabled',
+    'icon',
+    'iconAlign',
+    '!!iconOnly',
+    '!!loading',
+    'onClick()',
+    'size'
+  ],
+  {},
+  { useShadowDOM: true, inheritStyles: true }
+)
+
+export function createButtonWithIcon(selector, icon) {
+  class ButtonWithIcon extends React.Component {
+    render() {
+      const { props } = this
+      return <Button icon={<Icon id={icon} />} {...props} />
+    }
+  }
+
+  return register(
+    ButtonWithIcon,
+    selector,
+    [
+      'appearance',
+      '!!disabled',
+      'iconAlign',
+      '!!iconOnly',
+      '!!loading',
+      'onClick()',
+      'size'
+    ],
+    {},
+    { useShadowDOM: true, inheritStyles: true }
+  )
+}

--- a/packages/button/web.js
+++ b/packages/button/web.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/web')

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.1",
     "glamorous": "^4.1.0",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "web-react-components": "lizardruss/web-react-components#master"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.1",

--- a/packages/icon/src/react/index.js
+++ b/packages/icon/src/react/index.js
@@ -24,15 +24,19 @@ const rmNonHtmlProps = props => {
 }
 
 const Icon = props => {
+  const children =
+    props.children && props.children.type !== 'slot' ? props.children : null
+  const svgFactory = icons[props.id] || icons[props.icon]
   return (
     <IconContainer {...rmNonHtmlProps(props)}>
-      {props.children || icons[props.id](React)}
+      {children || (svgFactory && svgFactory(React))}
     </IconContainer>
   )
 }
 
 Icon.propTypes = {
   color: PropTypes.oneOf(Object.keys(vars.colors)),
+  icon: PropTypes.oneOf(Object.keys(vars.ids)),
   id: PropTypes.oneOf(Object.keys(vars.ids)),
   size: PropTypes.oneOf(Object.keys(vars.sizes))
 }

--- a/packages/icon/web.js
+++ b/packages/icon/web.js
@@ -1,0 +1,12 @@
+const Icon = require('./react').default
+const register = require('web-react-components').register
+
+const IconWebComponent = register(
+  Icon,
+  'ps-icon',
+  ['icon', 'color'],
+  {},
+  { useShadowDOM: true, inheritStyles: true }
+)
+
+module.exports = IconWebComponent


### PR DESCRIPTION
## Instructions

- fill in title: format of "button,icon: add custom element conversion script"
- label: enhancement

### What You're Solving

- This is a work in progress, and should be treated as a starting point for discussion
- This uses [web-react-components](https://github.com/ChristophP/web-react-components) to convert react components into custom elements in order to consume them in non-react applications
- Separate `/web` scripts have been created to allow opting in to custom elements
- [Example angular application](https://github.com/lizardruss/angular-react-interop) showing how the custom elements can be consumed

### Design Decisions

- This uses a [fork](https://github.com/lizardruss/web-react-components) of [web-react-components](https://github.com/ChristophP/web-react-components) that allows inheriting of styles into the custom element's shadow dom. This is enabled by passing the `inheritStyles` option when calling `register()`.
- Styles could also be included in the custom element, however accomplishing that would require revising the current build process.
- Mirroring the React practice of passing components in attributes isn't easily mapped to custom elements. The custom element way would be to design  the component with `<slot name="foo"></slot>` elements in it's template, and provide the slotted content when using the custom element. I've included a factory function, `createButtonWithIcon()`, to demonstrate how one might work around this limitation by first generating a react component and converting it into a custom element.
- Any feedback on whether this approach is practical would be appreciated.

### How to Verify

- [Example angular application](https://github.com/lizardruss/angular-react-interop)
