### PR TITLE
fix(site): tooltip flicker on hover

### DIFF
--- a/packages/site/pages/components/tooltip.js
+++ b/packages/site/pages/components/tooltip.js
@@ -4,6 +4,7 @@ import Icon from '@pluralsight/ps-design-system-icon/react'
 import React from 'react'
 import Theme from '@pluralsight/ps-design-system-theme/react'
 import Tooltip from '@pluralsight/ps-design-system-tooltip/react'
+import * as funcUtil from '@pluralsight/ps-design-system-util/func'
 
 import {
   Chrome,
@@ -108,8 +109,11 @@ class InAppExample extends React.Component {
       isHovered: false,
       isClicked: false
     }
-    this.handleMouseOver = this.handleMouseOver.bind(this)
-    this.handleMouseOut = this.handleMouseOut.bind(this)
+    this.handleMouseOver = funcUtil.debounce(
+      this.handleMouseOver.bind(this),
+      100
+    )
+    this.handleMouseOut = funcUtil.debounce(this.handleMouseOut.bind(this), 100)
     this.handleClick = this.handleClick.bind(this)
   }
   componentDidMount() {

--- a/packages/util/func.js
+++ b/packages/util/func.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/func')

--- a/packages/util/index.js
+++ b/packages/util/index.js
@@ -1,5 +1,11 @@
+const func = require('./func')
 const propDefs = require('./prop-defs')
 const props = require('./props')
 const string = require('./string')
 
-module.exports = { propDefs: propDefs, props: props, string: string }
+module.exports = {
+  func: func,
+  propDefs: propDefs,
+  props: props,
+  string: string
+}

--- a/packages/util/src/__specs__/func.spec.js
+++ b/packages/util/src/__specs__/func.spec.js
@@ -1,0 +1,42 @@
+import { debounce } from '../func'
+
+describe('#debounce', () => {
+  describe('with valid arguments', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+    })
+
+    test('with func and delay arguments', () => {
+      const spy = jest.fn()
+      const result = debounce(spy, 100)
+      expect(result).toBeInstanceOf(Function)
+      result('foo')
+      jest.runTimersToTime(100)
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith('foo')
+    })
+  })
+
+  test('empty', () => {
+    expect(debounce).toThrow(/^debounce expects a function/)
+  })
+
+  test('with func and no delay', () => {
+    expect(_ => debounce(Function.prototype)).toThrow(
+      /^debounce expects a number/
+    )
+  })
+
+  test('with no func and delay', () => {
+    expect(_ => debounce(null, 100)).toThrow(/^debounce expects a function/)
+  })
+
+  test('non-func', () => {
+    expect(_ => debounce(123)).toThrow(/^debounce expects a function/)
+    expect(_ => debounce(true)).toThrow(/^debounce expects a function/)
+    expect(_ => debounce(false)).toThrow(/^debounce expects a function/)
+    expect(_ => debounce(['123', 'abc'])).toThrow(
+      /^debounce expects a function/
+    )
+  })
+})

--- a/packages/util/src/func.js
+++ b/packages/util/src/func.js
@@ -1,0 +1,15 @@
+export const debounce = (func, delay) => {
+  if (typeof func !== 'function') {
+    throw new Error('debounce expects a function as the first parameter')
+  }
+  if (typeof delay !== 'number') {
+    throw new Error('debounce expects a number as the second parameter')
+  }
+  let timer = null
+  return (...args) => {
+    clearTimeout(timer)
+    timer = setTimeout(() => {
+      func.apply(this, args)
+    }, delay)
+  }
+}

--- a/packages/util/src/index.js
+++ b/packages/util/src/index.js
@@ -1,9 +1,11 @@
-import * as string from './string'
+import * as func from './func'
 import * as propDefs from './prop-defs'
 import * as props from './props'
+import * as string from './string'
 
 export default {
-  string,
+  func,
   propDefs,
-  props
+  props,
+  string
 }


### PR DESCRIPTION
### Instructions

- site: fix tooltip flicker on hover [chrome]
- label: bug

### What I'm Solving

- see #194 

### Design Decisions

- After a bit of debugging, the issue here appeared to be driven by mouse events firing too quickly. One solution to this problem is limiting the rate of invocation for callbacks that `setState` within the underlying component. To achieve this, I put together a small `debounce` util function that will not invoke the provided callback prior to a delay timeout.

- There are lots of other implementations of `debounce` out there readily available via `npm`, however I saw from the existing documentation here that `util` may be the place to drop something like this. In addition, there is value in limiting the number of dependencies we take on as we are shipping a library here!
 
- I also decided to throw immediately from `debounce` if the callsite provides incorrectly typed arguments. My thinking was that developers would like to know sooner rather than later that they are not going to get a debounced invocation.

- There may be some additional discussion warranted around using a `throttle` implementation here as opposed to `debounce`. Or reworking the `debounce` implementation to fire immediately, then using timeouts for subsequent invocations. These types of features would have added additional complexity so I figured I would leave that decision to follow up discussion here on github 😅 

### How to Verify

- See `Hover me` example under http://localhost:1337/components/tooltip#in-app-example while 
   running the design system locally with this branch checked out.
