### PR TITLE
datepicker: remove console.log statement from parseDate

### DIFF
--- a/packages/datepicker/src/js/index.js
+++ b/packages/datepicker/src/js/index.js
@@ -59,7 +59,6 @@ export const getMonthName = mm =>
 
 export const parseDate = value => {
   const [mm, dd, yyyy] = (value || '').split('/')
-  console.log('parseDate', mm, dd, yyyy)
   return mm && dd && yyyy
     ? {
         dd: forceValidDay({ dd, mm, yyyy }),


### PR DESCRIPTION
### What You're Solving

This has been logging quite a bit in our tests and elsewhere. I'm assuming it's an oversight so submitting a quick PR -- if not let me know :)