### PR TITLE
fix(site): tooltip flicker on hover

### DIFF
--- a/packages/button/src/css/index.js
+++ b/packages/button/src/css/index.js
@@ -267,7 +267,8 @@ export default {
   },
   // __text
   [`.psds-button__text`]: {
+    alignItems: 'center',
     display: 'inline-flex',
-    alignItems: 'center'
+    pointerEvents: 'none'
   }
 }


### PR DESCRIPTION
### Instructions

- site: fix tooltip flicker on hover [chrome]
- label: bug

### What I'm Solving

- see #194 and an imperfect solution [in this first round pull request](https://github.com/pluralsight/design-system/pull/245)

### Design Decisions

- Round Two! 🥊 I spent some additional time looking into this bug after reviewing the excellent feedback from @jaketrent in the [original PR](https://github.com/pluralsight/design-system/pull/245).

- I noticed the tooltip flicker only occurred on webkit browsers, and only when the cursor moved across the boundary of the child `<span />` text element nested within the `<button />`. Applying a `pointer-events: none` style to that `<span />` prevented the `onMouseOut` callback from being fired for the parent `<button />` and eliminated the flicker! 

### How to Verify

- See `Hover me` example under http://localhost:1337/components/tooltip#in-app-example while 
   running the design system locally with this branch checked out.

![hover-me](https://user-images.githubusercontent.com/3100810/44787005-de085480-ab63-11e8-8591-7079eb604b72.gif)

