### PR TITLE
dropdown: add ability to override selectedLabel

### DIFF
--- a/packages/dropdown/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/dropdown/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -860,7 +860,9 @@ exports[`Storyshots labels label 1`] = `
           <span
             aria-hidden={true}
             data-css-e6fvyw=""
-          />
+          >
+            Three item
+          </span>
           <span
             data-css-5m5yd6=""
           />
@@ -934,7 +936,9 @@ exports[`Storyshots labels label and subLabel 1`] = `
           <span
             aria-hidden={true}
             data-css-e6fvyw=""
-          />
+          >
+            Three item
+          </span>
           <span
             data-css-5m5yd6=""
           />
@@ -1008,7 +1012,9 @@ exports[`Storyshots labels none 1`] = `
           <span
             aria-hidden={true}
             data-css-e6fvyw=""
-          />
+          >
+            Three item
+          </span>
           <span
             data-css-5m5yd6=""
           />
@@ -1110,6 +1116,79 @@ exports[`Storyshots labels placeholder 1`] = `
 </div>
 `;
 
+exports[`Storyshots labels selectedLabel 1`] = `
+<div
+  style={
+    Object {
+      "background": "#181818",
+      "backgroundSize": "cover",
+      "bottom": 0,
+      "left": 0,
+      "overflow": "scroll",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+      "transition": "background 300ms",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "padding": "24px",
+      }
+    }
+  >
+    <label
+      data-css-1hniuff=""
+      onKeyDown={[Function]}
+    >
+      <div
+        data-css-1812rv9=""
+      >
+        <button
+          data-css-8bndf1=""
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+        >
+          <span
+            aria-hidden={true}
+            data-css-e6fvyw=""
+          >
+            Some selectedLabel
+          </span>
+          <span
+            data-css-5m5yd6=""
+          >
+            Some selectedLabel
+          </span>
+        </button>
+        <div
+          data-css-1uv5m12=""
+        >
+          <div
+            className="css-otejxm"
+          >
+            <svg
+              aria-label="caret down icon"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12.5 14L8 10h9z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`Storyshots labels subLabel 1`] = `
 <div
   style={
@@ -1150,7 +1229,9 @@ exports[`Storyshots labels subLabel 1`] = `
           <span
             aria-hidden={true}
             data-css-e6fvyw=""
-          />
+          >
+            Three item
+          </span>
           <span
             data-css-5m5yd6=""
           />

--- a/packages/dropdown/src/react/index.js
+++ b/packages/dropdown/src/react/index.js
@@ -199,7 +199,10 @@ class Dropdown extends React.Component {
     }
 
     return getLongestState(
-      { hasIcon: false, label: this.props.placeholder || '' },
+      {
+        hasIcon: false,
+        label: this.props.selectedLabel || this.props.placeholder || ''
+      },
       this.props.menu
     )
   }
@@ -248,7 +251,9 @@ class Dropdown extends React.Component {
                 {longestMenuItemState.label || allProps.placeholder}
               </span>
               <span {...styles.placeholder(allProps)}>
-                {state.selectedLabel || allProps.placeholder}
+                {props.selectedLabel ||
+                state.selectedLabel ||
+                allProps.placeholder}
               </span>
             </button>
             <div {...styles.icon(allProps)}>
@@ -300,6 +305,7 @@ Dropdown.propTypes = {
   label: PropTypes.node,
   menu: PropTypes.element.isRequired,
   placeholder: PropTypes.string,
+  selectedLabel: PropTypes.string,
   subLabel: PropTypes.node
 }
 Dropdown.defaultProps = {

--- a/packages/dropdown/stories/index.js
+++ b/packages/dropdown/stories/index.js
@@ -13,21 +13,46 @@ const PaddingDecorator = storyFn => (
   <div style={{ padding: core.layout.spacingLarge }}>{storyFn()}</div>
 )
 
+const actionMenuWithThreeItems = (
+  <ActionMenu>
+    <ActionMenu.Item onClick={action('one')}>One item</ActionMenu.Item>
+    <ActionMenu.Item onClick={action('two')}>Two item</ActionMenu.Item>
+    <ActionMenu.Item onClick={action('three')}>Three item</ActionMenu.Item>
+  </ActionMenu>
+)
+
 const labelStory = storiesOf('labels', module)
   .addDecorator(PaddingDecorator)
   .addDecorator(themeDecorator(addons))
-  .add('none', _ => <Dropdown />)
-  .add('placeholder', _ => <Dropdown placeholder="some placeholder" />)
-  .add('label', _ => <Dropdown label="Some label" />)
-  .add('subLabel', _ => <Dropdown subLabel="Some sublabel" />)
+  .add('none', _ => <Dropdown menu={actionMenuWithThreeItems} />)
+  .add('placeholder', _ => (
+    <Dropdown placeholder="some placeholder" menu={actionMenuWithThreeItems} />
+  ))
+  .add('label', _ => (
+    <Dropdown label="Some label" menu={actionMenuWithThreeItems} />
+  ))
+  .add('subLabel', _ => (
+    <Dropdown subLabel="Some sublabel" menu={actionMenuWithThreeItems} />
+  ))
+  .add('selectedLabel', _ => (
+    <Dropdown
+      selectedLabel="Some selectedLabel"
+      menu={actionMenuWithThreeItems}
+    />
+  ))
   .add('label and subLabel', _ => (
-    <Dropdown label="Some label" subLabel="Some sublabel" />
+    <Dropdown
+      label="Some label"
+      subLabel="Some sublabel"
+      menu={actionMenuWithThreeItems}
+    />
   ))
   .add('all', _ => (
     <Dropdown
       label="Some label"
       subLabel="Some sublabel"
       placeholder="Some placeholder"
+      menu={actionMenuWithThreeItems}
     />
   ))
 


### PR DESCRIPTION
### What You're Solving

When you're using a dropdown outside a form it's useful to be able to give more context about the field and selected value inside the dropdown itself. I've come across a few cases where I've been unable to use the Dropdown component without the ability to do this. Right now I'm trying to build this:

![image](https://user-images.githubusercontent.com/679346/46445302-5b128500-c733-11e8-8459-37b639b4c20b.png)

In order to prefix the selected value with `Sort:` I need to be able to override the selected label.

### Design Decisions

We should get Dmitry's approval on this design. I understand that most of the times, when you're using a dropdown inside a form, you're going to want to use the regular field label and sublabel to communicate, but when you're outside a form it's useful to be able to provide more context without a label.

### How to Verify

The dropdown storybook is updated with a new story. Make sure that when a `selectedLabel` is provided it is always show even after selecting an item from the menu.
