### PR TITLE
dropdown: increase dropdown overlay z-index

### DIFF
--- a/packages/dropdown/src/css/index.js
+++ b/packages/dropdown/src/css/index.js
@@ -213,13 +213,14 @@ export default {
   // __menu
   '.psds-dropdown__menu': {
     position: 'absolute',
-    zIndex: '1',
+    zIndex: 980,
     marginTop: core.layout.spacingXXSmall
   },
 
   // __page-overlay
   '.psds-dropdown__page-overlay': {
     position: 'fixed',
+    zIndex: 970,
     top: 0,
     right: 0,
     bottom: 0,


### PR DESCRIPTION
### What You're Solving

- Fixes #278 
- Fixes issue where the dropdown overlay was not covering the entire page so
the dropdown would not always close when clicking outside of the open menu.


### Design Decisions

- Chose a z-index of `970` for the overlay because we want it to cover prism (the sidebar has a z-index of `960`)
- Chose a z-index of `980` for the menu so it appears above the overlay.

### How to Verify

1. Add a dropdown to a page
2. Add an element later in the DOM with `position: relative`
3. Open the dropdown
4. Click the other element and/or Prism - the dropdown should close
