### PR TITLE
textinput: fix focus ring not showing

### DIFF
--- a/packages/textinput/package.json
+++ b/packages/textinput/package.json
@@ -43,7 +43,7 @@
     "babel-preset-env": "^1.4.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
-    "jest": "^20.0.4",
+    "jest": "^21.2.1",
     "npm-run-all": "^4.1.2"
   }
 }

--- a/packages/textinput/src/css/index.js
+++ b/packages/textinput/src/css/index.js
@@ -67,7 +67,8 @@ export default {
     alignItems: 'center',
     minWidth: `calc(192px + ${iconVars.widths.medium} + ${
       core.layout.spacingXSmall
-    })`
+    })`,
+    zIndex: 0
   },
   '.psds-text-input__field-container:focus:before': {
     content: ' ',

--- a/packages/textinput/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/textinput/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -32,7 +32,7 @@ exports[`Storyshots appearance default w/ error 1`] = `
         Problem field
       </div>
       <div
-        data-css-mdufbt=""
+        data-css-o8fadz=""
       >
         <input
           data-css-ly16us=""
@@ -92,7 +92,7 @@ exports[`Storyshots appearance default w/ iconAlign left 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-1bkxplq=""
@@ -152,7 +152,7 @@ exports[`Storyshots appearance default w/ iconAlign right 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-i8twf8=""
@@ -217,7 +217,7 @@ exports[`Storyshots appearance subtle w/ error 1`] = `
         Problem field
       </div>
       <div
-        data-css-mdufbt=""
+        data-css-o8fadz=""
       >
         <input
           data-css-1fhke6k=""
@@ -277,7 +277,7 @@ exports[`Storyshots appearance subtle w/ iconAlign left 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-1u1pc12=""
@@ -337,7 +337,7 @@ exports[`Storyshots appearance subtle w/ iconAlign right 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-11d30wl=""
@@ -403,7 +403,7 @@ exports[`Storyshots disabled compare 1`] = `
           Normal
         </div>
         <div
-          data-css-1ghdxx6=""
+          data-css-17d9xcr=""
         >
           <input
             data-css-ly16us=""
@@ -428,7 +428,7 @@ exports[`Storyshots disabled compare 1`] = `
           I'm not usable
         </div>
         <div
-          data-css-1ghdxx6=""
+          data-css-17d9xcr=""
         >
           <input
             data-css-ly16us=""
@@ -481,7 +481,7 @@ exports[`Storyshots labels all 1`] = `
         Some label
       </div>
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-ly16us=""
@@ -533,7 +533,7 @@ exports[`Storyshots labels label 1`] = `
         Some label
       </div>
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-ly16us=""
@@ -580,7 +580,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
         Some label
       </div>
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-ly16us=""
@@ -627,7 +627,7 @@ exports[`Storyshots labels none 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-ly16us=""
@@ -669,7 +669,7 @@ exports[`Storyshots labels placeholder 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-ly16us=""
@@ -711,7 +711,7 @@ exports[`Storyshots labels subLabel 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-ly16us=""
@@ -777,7 +777,7 @@ exports[`Storyshots layouts full width 1`] = `
           First
         </div>
         <div
-          data-css-1ghdxx6=""
+          data-css-17d9xcr=""
         >
           <input
             data-css-ly16us=""
@@ -803,7 +803,7 @@ exports[`Storyshots layouts full width 1`] = `
           Second
         </div>
         <div
-          data-css-mdufbt=""
+          data-css-o8fadz=""
         >
           <input
             data-css-ly16us=""
@@ -847,7 +847,7 @@ exports[`Storyshots layouts full width 1`] = `
           Third
         </div>
         <div
-          data-css-1ghdxx6=""
+          data-css-17d9xcr=""
         >
           <input
             data-css-1fhke6k=""
@@ -873,7 +873,7 @@ exports[`Storyshots layouts full width 1`] = `
           Fourth
         </div>
         <div
-          data-css-mdufbt=""
+          data-css-o8fadz=""
         >
           <input
             data-css-1fhke6k=""
@@ -949,7 +949,7 @@ exports[`Storyshots layouts right-aligned 1`] = `
           data-css-w0yocm=""
         >
           <div
-            data-css-1ghdxx6=""
+            data-css-17d9xcr=""
           >
             <input
               data-css-1u1pc12=""
@@ -1021,7 +1021,7 @@ exports[`Storyshots style override css 1`] = `
           data-css-lsmfyz=""
         >
           <div
-            data-css-1ghdxx6=""
+            data-css-17d9xcr=""
           >
             <input
               data-css-ly16us=""
@@ -1038,7 +1038,7 @@ exports[`Storyshots style override css 1`] = `
           data-css-lsmfyz=""
         >
           <div
-            data-css-mdufbt=""
+            data-css-o8fadz=""
           >
             <input
               data-css-ly16us=""
@@ -1100,7 +1100,7 @@ exports[`Storyshots whitelist name 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-ly16us=""
@@ -1143,7 +1143,7 @@ exports[`Storyshots whitelist onChange 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-ly16us=""
@@ -1186,7 +1186,7 @@ exports[`Storyshots whitelist type=date 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-ly16us=""
@@ -1229,7 +1229,7 @@ exports[`Storyshots whitelist type=password 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ghdxx6=""
+        data-css-17d9xcr=""
       >
         <input
           data-css-ly16us=""


### PR DESCRIPTION
### What You're Solving

Fixes issue where the textinput's focus ring was not showing if it was in a
container that had a background. Fix was to give the component its own z-index
stacking context by adding a z-index of 0.

Fixes #283 

### How to Verify

- Add a textinput to a container that has a background.
- Focus the input - the focus ring should show up.
