### PR TITLE
button: update focus styles to allow transparent backgrounds

### DIFF
--- a/packages/button/.storybook/center-decorator.js
+++ b/packages/button/.storybook/center-decorator.js
@@ -1,0 +1,34 @@
+// TODO: move to separate package
+
+import React from 'react'
+import { css } from 'glamor'
+
+const styles = {
+  outer: css({
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100vh',
+    width: '100vw',
+    overflow: 'auto'
+  }),
+  inner: css({
+    margin: 'auto',
+    maxHeight: '100%' // IE Hack
+  })
+}
+
+const Center = props => (
+  <div {...styles.outer}>
+    <div {...styles.inner}>{props.children}</div>
+  </div>
+)
+
+const centerDecorator = storyFn => <Center>{storyFn()}</Center>
+
+export default centerDecorator

--- a/packages/button/.storybook/config.js
+++ b/packages/button/.storybook/config.js
@@ -1,9 +1,16 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 
-import { configure } from '@storybook/react';
+import addons from '@storybook/addons'
+import { addDecorator, configure } from '@storybook/react'
+import themeDecorator from '@pluralsight/ps-design-system-storybook-addon-theme'
+
+import centerDecorator from './center-decorator'
+
+addDecorator(centerDecorator)
+addDecorator(themeDecorator(addons))
 
 function loadStories() {
-  require('../stories');
+  require('../stories')
 }
 
-configure(loadStories, module);
+configure(loadStories, module)

--- a/packages/button/src/css/index.js
+++ b/packages/button/src/css/index.js
@@ -46,37 +46,13 @@ export default {
   '.psds-button:focus:before': {
     content: ' ',
     position: 'absolute',
-    top: '-1px',
-    left: '-1px',
-    right: '-1px',
-    bottom: '-1px',
-    background: core.colors.black,
-    zIndex: '-1',
-    borderRadius: '2px'
-  },
-  [`.psds-button.psds-theme--${themeNames.light}:focus:before`]: {
-    top: '-2px',
-    left: '-2px',
-    right: '-2px',
-    bottom: '-2px',
-    background: core.colors.bone
-  },
-  '.psds-button:focus:after': {
-    content: ' ',
-    position: 'absolute',
     top: '-4px',
     left: '-4px',
     right: '-4px',
     bottom: '-4px',
-    zIndex: '-2',
-    borderRadius: '4px',
-    background: core.colors.blue
-  },
-  [`.psds-button.psds-theme--${themeNames.light}:focus:after`]: {
-    top: '-5px',
-    left: '-5px',
-    right: '-5px',
-    bottom: '-5px'
+    zIndex: '-1',
+    border: `3px solid ${core.colors.blue}`,
+    borderRadius: '4px'
   },
 
   // --size

--- a/packages/button/src/css/index.js
+++ b/packages/button/src/css/index.js
@@ -50,7 +50,6 @@ export default {
     left: '-4px',
     right: '-4px',
     bottom: '-4px',
-    zIndex: '-1',
     border: `3px solid ${core.colors.blue}`,
     borderRadius: '4px'
   },

--- a/packages/button/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/button/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -22,7 +22,7 @@ exports[`Storyshots appearance flat 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Click me
     </span>
@@ -52,7 +52,7 @@ exports[`Storyshots appearance primary 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Click me
     </span>
@@ -82,7 +82,7 @@ exports[`Storyshots appearance stroke 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Click me
     </span>
@@ -113,7 +113,7 @@ exports[`Storyshots as link default 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Click as link
     </span>
@@ -147,7 +147,7 @@ exports[`Storyshots as link with icon 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="pencil icon"
@@ -162,7 +162,7 @@ exports[`Storyshots as link with icon 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Click as link
     </span>
@@ -193,7 +193,7 @@ exports[`Storyshots disabled flat 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Disabled
     </span>
@@ -224,7 +224,7 @@ exports[`Storyshots disabled primary 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Disabled
     </span>
@@ -255,7 +255,7 @@ exports[`Storyshots disabled stroke 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Disabled
     </span>
@@ -288,7 +288,7 @@ exports[`Storyshots disabled with icon 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="pencil icon"
@@ -303,7 +303,7 @@ exports[`Storyshots disabled with icon 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Disabled
     </span>
@@ -336,7 +336,7 @@ exports[`Storyshots icon flat 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -351,7 +351,7 @@ exports[`Storyshots icon flat 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       With Icon
     </span>
@@ -384,7 +384,7 @@ exports[`Storyshots icon large 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -399,7 +399,7 @@ exports[`Storyshots icon large 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       With Icon
     </span>
@@ -432,7 +432,7 @@ exports[`Storyshots icon left 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -447,7 +447,7 @@ exports[`Storyshots icon left 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       With Icon
     </span>
@@ -480,7 +480,7 @@ exports[`Storyshots icon lone flat large 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -495,7 +495,7 @@ exports[`Storyshots icon lone flat large 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -526,7 +526,7 @@ exports[`Storyshots icon lone flat medium 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -541,7 +541,7 @@ exports[`Storyshots icon lone flat medium 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -572,7 +572,7 @@ exports[`Storyshots icon lone flat small 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -587,7 +587,7 @@ exports[`Storyshots icon lone flat small 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -618,7 +618,7 @@ exports[`Storyshots icon lone flat xSmall 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-12f5sv2"
+        className="css-index--iconcontainer-1faf6pt"
       >
         <svg
           aria-label="check icon"
@@ -633,7 +633,7 @@ exports[`Storyshots icon lone flat xSmall 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -664,7 +664,7 @@ exports[`Storyshots icon lone primary large 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -679,7 +679,7 @@ exports[`Storyshots icon lone primary large 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -710,7 +710,7 @@ exports[`Storyshots icon lone primary medium 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -725,7 +725,7 @@ exports[`Storyshots icon lone primary medium 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -756,7 +756,7 @@ exports[`Storyshots icon lone primary small 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -771,7 +771,7 @@ exports[`Storyshots icon lone primary small 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -802,7 +802,7 @@ exports[`Storyshots icon lone primary xSmall 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-12f5sv2"
+        className="css-index--iconcontainer-1faf6pt"
       >
         <svg
           aria-label="check icon"
@@ -817,7 +817,7 @@ exports[`Storyshots icon lone primary xSmall 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -848,7 +848,7 @@ exports[`Storyshots icon lone stroke large 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -863,7 +863,7 @@ exports[`Storyshots icon lone stroke large 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -894,7 +894,7 @@ exports[`Storyshots icon lone stroke medium 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -909,7 +909,7 @@ exports[`Storyshots icon lone stroke medium 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -940,7 +940,7 @@ exports[`Storyshots icon lone stroke small 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -955,7 +955,7 @@ exports[`Storyshots icon lone stroke small 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -986,7 +986,7 @@ exports[`Storyshots icon lone stroke xSmall 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-12f5sv2"
+        className="css-index--iconcontainer-1faf6pt"
       >
         <svg
           aria-label="check icon"
@@ -1001,7 +1001,7 @@ exports[`Storyshots icon lone stroke xSmall 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -1032,7 +1032,7 @@ exports[`Storyshots icon medium 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -1047,7 +1047,7 @@ exports[`Storyshots icon medium 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       With Icon
     </span>
@@ -1080,7 +1080,7 @@ exports[`Storyshots icon primary 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -1095,7 +1095,7 @@ exports[`Storyshots icon primary 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       With Icon
     </span>
@@ -1128,7 +1128,7 @@ exports[`Storyshots icon right 1`] = `
       data-css-8b1vtw=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -1143,7 +1143,7 @@ exports[`Storyshots icon right 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       With Icon
     </span>
@@ -1176,7 +1176,7 @@ exports[`Storyshots icon small 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -1191,7 +1191,7 @@ exports[`Storyshots icon small 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       With Icon
     </span>
@@ -1224,7 +1224,7 @@ exports[`Storyshots icon stroke 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -1239,7 +1239,7 @@ exports[`Storyshots icon stroke 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       With Icon
     </span>
@@ -1272,7 +1272,7 @@ exports[`Storyshots icon xSmall 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-12f5sv2"
+        className="css-index--iconcontainer-1faf6pt"
       >
         <svg
           aria-label="check icon"
@@ -1287,7 +1287,7 @@ exports[`Storyshots icon xSmall 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       With Icon
     </span>
@@ -1320,7 +1320,7 @@ exports[`Storyshots loading flat 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <span
           data-css-1ec065u=""
@@ -1328,7 +1328,7 @@ exports[`Storyshots loading flat 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Loading...
     </span>
@@ -1362,7 +1362,7 @@ exports[`Storyshots loading large 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <span
           data-css-10bxom6=""
@@ -1370,7 +1370,7 @@ exports[`Storyshots loading large 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Loading...
     </span>
@@ -1403,7 +1403,7 @@ exports[`Storyshots loading lone icon 1`] = `
       data-css-y80vay=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <span
           data-css-10bxom6=""
@@ -1411,7 +1411,7 @@ exports[`Storyshots loading lone icon 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     />
   </button>
 </div>
@@ -1443,7 +1443,7 @@ exports[`Storyshots loading medium 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <span
           data-css-10bxom6=""
@@ -1451,7 +1451,7 @@ exports[`Storyshots loading medium 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Loading...
     </span>
@@ -1481,7 +1481,7 @@ exports[`Storyshots loading no icon, hidden text 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Text doesnt show when loading if no icon
     </span>
@@ -1514,7 +1514,7 @@ exports[`Storyshots loading primary 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <span
           data-css-10bxom6=""
@@ -1522,7 +1522,7 @@ exports[`Storyshots loading primary 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Loading...
     </span>
@@ -1556,7 +1556,7 @@ exports[`Storyshots loading small 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <span
           data-css-10bxom6=""
@@ -1564,7 +1564,7 @@ exports[`Storyshots loading small 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Loading...
     </span>
@@ -1597,7 +1597,7 @@ exports[`Storyshots loading stroke 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <span
           data-css-1jut5p0=""
@@ -1605,7 +1605,7 @@ exports[`Storyshots loading stroke 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Loading...
     </span>
@@ -1639,7 +1639,7 @@ exports[`Storyshots loading xSmall 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-12f5sv2"
+        className="css-index--iconcontainer-1faf6pt"
       >
         <span
           data-css-10bxom6=""
@@ -1647,7 +1647,7 @@ exports[`Storyshots loading xSmall 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Loading...
     </span>
@@ -1685,7 +1685,7 @@ exports[`Storyshots override styles with className 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -1700,7 +1700,7 @@ exports[`Storyshots override styles with className 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Green Button
     </span>
@@ -1737,7 +1737,7 @@ exports[`Storyshots override styles with style 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -1752,7 +1752,7 @@ exports[`Storyshots override styles with style 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Red Button
     </span>
@@ -1783,7 +1783,7 @@ exports[`Storyshots props pass through aria-expanded 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       aria-expanded
     </span>
@@ -1814,7 +1814,7 @@ exports[`Storyshots props pass through data-something 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Custom data attributes
     </span>
@@ -1845,7 +1845,7 @@ exports[`Storyshots props pass through not supported 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Should not mouseover
     </span>
@@ -1876,7 +1876,7 @@ exports[`Storyshots props pass through role 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Role Link
     </span>
@@ -1907,7 +1907,7 @@ exports[`Storyshots props pass through title 1`] = `
     title="My caption"
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       With title
     </span>
@@ -1937,7 +1937,7 @@ exports[`Storyshots size large 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Click me
     </span>
@@ -1967,7 +1967,7 @@ exports[`Storyshots size medium 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Click me
     </span>
@@ -1997,7 +1997,7 @@ exports[`Storyshots size small 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Click me
     </span>
@@ -2027,7 +2027,7 @@ exports[`Storyshots size xSmall 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Click me
     </span>
@@ -2061,7 +2061,7 @@ exports[`Storyshots with onClick clicks once 1`] = `
       data-css-1mgd019=""
     >
       <div
-        className="css-otejxm"
+        className="css-index--iconcontainer-1o7wiin"
       >
         <svg
           aria-label="check icon"
@@ -2076,7 +2076,7 @@ exports[`Storyshots with onClick clicks once 1`] = `
       </div>
     </div>
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Clicks once
     </span>
@@ -2106,7 +2106,7 @@ exports[`Storyshots with ref ref to handle focus 1`] = `
     style={Object {}}
   >
     <span
-      data-css-1en8fmq=""
+      data-css-15b13by=""
     >
       Should be focused
     </span>

--- a/packages/button/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/button/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -16,17 +16,9 @@ exports[`Storyshots appearance flat 1`] = `
     }
   }
 >
-  <button
-    data-css-1t7k1em=""
-    disabled={false}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Click me
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -46,17 +38,9 @@ exports[`Storyshots appearance primary 1`] = `
     }
   }
 >
-  <button
-    data-css-gl46pt=""
-    disabled={false}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Click me
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -76,17 +60,9 @@ exports[`Storyshots appearance stroke 1`] = `
     }
   }
 >
-  <button
-    data-css-kbg59g=""
-    disabled={false}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Click me
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -106,18 +82,9 @@ exports[`Storyshots as link default 1`] = `
     }
   }
 >
-  <a
-    data-css-gl46pt=""
-    disabled={false}
-    href="https://duckduckgo.com"
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Click as link
-    </span>
-  </a>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -137,36 +104,9 @@ exports[`Storyshots as link with icon 1`] = `
     }
   }
 >
-  <a
-    data-css-6fhnty=""
-    disabled={false}
-    href="https://duckduckgo.com"
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="pencil icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5.2762 15.862L5 19l3.1392-.275 8.0858-8.0858-2.863-2.863-8.0858 8.0858zm12.363-6.637l.7668-.7667c.384-.3842.5922-.887.5922-1.4318 0-.5455-.208-1.048-.5932-1.4328-.3838-.3838-.885-.5912-1.4308-.5912-.5446 0-1.047.208-1.4318.5932l-.7662.7663 2.863 2.863zm-.665-6.2225c1.076 0 2.086.418 2.845 1.177.761.76 1.179 1.772 1.179 2.847 0 1.074-.418 2.086-1.178 2.846l-10.409 10.409c-.128.128-.289.22-.464.263l-4.705.427c-.34.085-.702-.015-.949-.264-.248-.247-.348-.608-.264-.949l.427-4.704c.044-.176.135-.336.263-.464l10.409-10.409c.76-.761 1.772-1.179 2.846-1.179z"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      Click as link
-    </span>
-  </a>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -186,18 +126,9 @@ exports[`Storyshots disabled flat 1`] = `
     }
   }
 >
-  <button
-    data-css-1epxvd5=""
-    disabled={true}
-    onClick={[Function]}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Disabled
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -217,18 +148,9 @@ exports[`Storyshots disabled primary 1`] = `
     }
   }
 >
-  <button
-    data-css-16m6vo5=""
-    disabled={true}
-    onClick={[Function]}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Disabled
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -248,18 +170,9 @@ exports[`Storyshots disabled stroke 1`] = `
     }
   }
 >
-  <button
-    data-css-1pow6ex=""
-    disabled={true}
-    onClick={[Function]}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Disabled
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -279,35 +192,9 @@ exports[`Storyshots disabled with icon 1`] = `
     }
   }
 >
-  <button
-    data-css-1k3kc48=""
-    disabled={true}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="pencil icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5.2762 15.862L5 19l3.1392-.275 8.0858-8.0858-2.863-2.863-8.0858 8.0858zm12.363-6.637l.7668-.7667c.384-.3842.5922-.887.5922-1.4318 0-.5455-.208-1.048-.5932-1.4328-.3838-.3838-.885-.5912-1.4308-.5912-.5446 0-1.047.208-1.4318.5932l-.7662.7663 2.863 2.863zm-.665-6.2225c1.076 0 2.086.418 2.845 1.177.761.76 1.179 1.772 1.179 2.847 0 1.074-.418 2.086-1.178 2.846l-10.409 10.409c-.128.128-.289.22-.464.263l-4.705.427c-.34.085-.702-.015-.949-.264-.248-.247-.348-.608-.264-.949l.427-4.704c.044-.176.135-.336.263-.464l10.409-10.409c.76-.761 1.772-1.179 2.846-1.179z"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      Disabled
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -327,35 +214,9 @@ exports[`Storyshots icon flat 1`] = `
     }
   }
 >
-  <button
-    data-css-ygj22v=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      With Icon
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -375,35 +236,9 @@ exports[`Storyshots icon large 1`] = `
     }
   }
 >
-  <button
-    data-css-16uzyo3=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      With Icon
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -423,35 +258,9 @@ exports[`Storyshots icon left 1`] = `
     }
   }
 >
-  <button
-    data-css-6fhnty=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      With Icon
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -471,33 +280,9 @@ exports[`Storyshots icon lone flat large 1`] = `
     }
   }
 >
-  <button
-    data-css-186z8r0=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -517,33 +302,9 @@ exports[`Storyshots icon lone flat medium 1`] = `
     }
   }
 >
-  <button
-    data-css-1kvw38x=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -563,33 +324,9 @@ exports[`Storyshots icon lone flat small 1`] = `
     }
   }
 >
-  <button
-    data-css-1od30u4=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -609,33 +346,9 @@ exports[`Storyshots icon lone flat xSmall 1`] = `
     }
   }
 >
-  <button
-    data-css-eyr4pd=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1faf6pt"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -655,33 +368,9 @@ exports[`Storyshots icon lone primary large 1`] = `
     }
   }
 >
-  <button
-    data-css-1dyka97=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -701,33 +390,9 @@ exports[`Storyshots icon lone primary medium 1`] = `
     }
   }
 >
-  <button
-    data-css-fxvrr1=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -747,33 +412,9 @@ exports[`Storyshots icon lone primary small 1`] = `
     }
   }
 >
-  <button
-    data-css-120vbg3=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -793,33 +434,9 @@ exports[`Storyshots icon lone primary xSmall 1`] = `
     }
   }
 >
-  <button
-    data-css-1jkhhbz=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1faf6pt"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -839,33 +456,9 @@ exports[`Storyshots icon lone stroke large 1`] = `
     }
   }
 >
-  <button
-    data-css-176djec=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -885,33 +478,9 @@ exports[`Storyshots icon lone stroke medium 1`] = `
     }
   }
 >
-  <button
-    data-css-endbx2=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -931,33 +500,9 @@ exports[`Storyshots icon lone stroke small 1`] = `
     }
   }
 >
-  <button
-    data-css-zu526a=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -977,33 +522,9 @@ exports[`Storyshots icon lone stroke xSmall 1`] = `
     }
   }
 >
-  <button
-    data-css-q765s9=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1faf6pt"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1023,35 +544,9 @@ exports[`Storyshots icon medium 1`] = `
     }
   }
 >
-  <button
-    data-css-6fhnty=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      With Icon
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1071,35 +566,9 @@ exports[`Storyshots icon primary 1`] = `
     }
   }
 >
-  <button
-    data-css-6fhnty=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      With Icon
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1119,35 +588,9 @@ exports[`Storyshots icon right 1`] = `
     }
   }
 >
-  <button
-    data-css-1z05niy=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-8b1vtw=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      With Icon
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1167,35 +610,9 @@ exports[`Storyshots icon small 1`] = `
     }
   }
 >
-  <button
-    data-css-j6xdwj=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      With Icon
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1215,35 +632,9 @@ exports[`Storyshots icon stroke 1`] = `
     }
   }
 >
-  <button
-    data-css-c2qwlq=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      With Icon
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1263,35 +654,9 @@ exports[`Storyshots icon xSmall 1`] = `
     }
   }
 >
-  <button
-    data-css-aa0j3a=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1faf6pt"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      With Icon
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1311,28 +676,9 @@ exports[`Storyshots loading flat 1`] = `
     }
   }
 >
-  <button
-    data-css-eslwan=""
-    disabled={true}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <span
-          data-css-1ec065u=""
-        />
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      Loading...
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1352,29 +698,9 @@ exports[`Storyshots loading large 1`] = `
     }
   }
 >
-  <button
-    data-css-1uaejkq=""
-    disabled={true}
-    onClick={[Function]}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <span
-          data-css-10bxom6=""
-        />
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      Loading...
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1394,26 +720,9 @@ exports[`Storyshots loading lone icon 1`] = `
     }
   }
 >
-  <button
-    data-css-1dyka97=""
-    disabled={true}
-    style={Object {}}
-  >
-    <div
-      data-css-y80vay=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <span
-          data-css-10bxom6=""
-        />
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    />
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1433,29 +742,9 @@ exports[`Storyshots loading medium 1`] = `
     }
   }
 >
-  <button
-    data-css-gl46pt=""
-    disabled={true}
-    onClick={[Function]}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <span
-          data-css-10bxom6=""
-        />
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      Loading...
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1475,17 +764,9 @@ exports[`Storyshots loading no icon, hidden text 1`] = `
     }
   }
 >
-  <button
-    data-css-1uaejkq=""
-    disabled={false}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Text doesnt show when loading if no icon
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1505,28 +786,9 @@ exports[`Storyshots loading primary 1`] = `
     }
   }
 >
-  <button
-    data-css-1uaejkq=""
-    disabled={true}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <span
-          data-css-10bxom6=""
-        />
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      Loading...
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1546,29 +808,9 @@ exports[`Storyshots loading small 1`] = `
     }
   }
 >
-  <button
-    data-css-1v0x9ld=""
-    disabled={true}
-    onClick={[Function]}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <span
-          data-css-10bxom6=""
-        />
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      Loading...
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1588,28 +830,9 @@ exports[`Storyshots loading stroke 1`] = `
     }
   }
 >
-  <button
-    data-css-1sth75=""
-    disabled={true}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <span
-          data-css-1jut5p0=""
-        />
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      Loading...
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1629,29 +852,9 @@ exports[`Storyshots loading xSmall 1`] = `
     }
   }
 >
-  <button
-    data-css-jyv8uk=""
-    disabled={true}
-    onClick={[Function]}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1faf6pt"
-      >
-        <span
-          data-css-10bxom6=""
-        />
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      Loading...
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1671,40 +874,9 @@ exports[`Storyshots override styles with className 1`] = `
     }
   }
 >
-  <button
-    className={
-      Object {
-        "data-css-jxpnuu": "",
-      }
-    }
-    data-css-6fhnty=""
-    disabled={false}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      Green Button
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1724,39 +896,9 @@ exports[`Storyshots override styles with style 1`] = `
     }
   }
 >
-  <button
-    data-css-6fhnty=""
-    disabled={false}
-    style={
-      Object {
-        "background": "red",
-      }
-    }
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      Red Button
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1776,18 +918,9 @@ exports[`Storyshots props pass through aria-expanded 1`] = `
     }
   }
 >
-  <button
-    aria-expanded={true}
-    data-css-gl46pt=""
-    disabled={false}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      aria-expanded
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1807,18 +940,9 @@ exports[`Storyshots props pass through data-something 1`] = `
     }
   }
 >
-  <button
-    data-css-gl46pt=""
-    data-something="wow"
-    disabled={false}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Custom data attributes
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1838,18 +962,9 @@ exports[`Storyshots props pass through not supported 1`] = `
     }
   }
 >
-  <button
-    data-css-gl46pt=""
-    disabled={false}
-    onMouseOver={[Function]}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Should not mouseover
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1869,18 +984,9 @@ exports[`Storyshots props pass through role 1`] = `
     }
   }
 >
-  <button
-    data-css-gl46pt=""
-    disabled={false}
-    role="link"
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Role Link
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1900,18 +1006,9 @@ exports[`Storyshots props pass through title 1`] = `
     }
   }
 >
-  <button
-    data-css-gl46pt=""
-    disabled={false}
-    style={Object {}}
-    title="My caption"
-  >
-    <span
-      data-css-15b13by=""
-    >
-      With title
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1931,17 +1028,9 @@ exports[`Storyshots size large 1`] = `
     }
   }
 >
-  <button
-    data-css-1uaejkq=""
-    disabled={false}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Click me
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1961,17 +1050,9 @@ exports[`Storyshots size medium 1`] = `
     }
   }
 >
-  <button
-    data-css-gl46pt=""
-    disabled={false}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Click me
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -1991,17 +1072,9 @@ exports[`Storyshots size small 1`] = `
     }
   }
 >
-  <button
-    data-css-1v0x9ld=""
-    disabled={false}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Click me
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -2021,17 +1094,9 @@ exports[`Storyshots size xSmall 1`] = `
     }
   }
 >
-  <button
-    data-css-jyv8uk=""
-    disabled={false}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Click me
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -2051,36 +1116,9 @@ exports[`Storyshots with onClick clicks once 1`] = `
     }
   }
 >
-  <button
-    data-css-6fhnty=""
-    disabled={false}
-    onClick={[Function]}
-    style={Object {}}
-  >
-    <div
-      data-css-1mgd019=""
-    >
-      <div
-        className="css-index--iconcontainer-1o7wiin"
-      >
-        <svg
-          aria-label="check icon"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9.59 14.58l-3.17-3.17L5 12.82l4.59 4.59 10-10L18.18 6"
-          />
-        </svg>
-      </div>
-    </div>
-    <span
-      data-css-15b13by=""
-    >
-      Clicks once
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;
 
@@ -2100,16 +1138,8 @@ exports[`Storyshots with ref ref to handle focus 1`] = `
     }
   }
 >
-  <button
-    data-css-gl46pt=""
-    disabled={false}
-    style={Object {}}
-  >
-    <span
-      data-css-15b13by=""
-    >
-      Should be focused
-    </span>
-  </button>
+  <div
+    data-storybook-center-decorator={true}
+  />
 </div>
 `;

--- a/packages/button/src/react/__specs__/storyshots.spec.js
+++ b/packages/button/src/react/__specs__/storyshots.spec.js
@@ -1,3 +1,11 @@
+import React from 'react'
 import initStoryshots from '@storybook/addon-storyshots'
+
+jest.mock('../../../.storybook/center-decorator.js', () => {
+  const CenterDecorator = props => (
+    <div data-storybook-center-decorator {...props} />
+  )
+  return CenterDecorator
+})
 
 initStoryshots()

--- a/packages/button/stories/index.js
+++ b/packages/button/stories/index.js
@@ -10,19 +10,17 @@ import themeDecorator from '@pluralsight/ps-design-system-storybook-addon-theme'
 
 import Button from '../react'
 
-const appearanceStory = storiesOf('appearance', module).addDecorator(
-  themeDecorator(addons)
-)
+const appearanceStory = storiesOf('appearance', module)
 Object.keys(Button.appearances).forEach(app =>
   appearanceStory.add(app, _ => <Button appearance={app}>Click me</Button>)
 )
 
-const sizeStory = storiesOf('size', module).addDecorator(themeDecorator(addons))
+const sizeStory = storiesOf('size', module)
 Object.keys(Button.sizes).forEach(size =>
   sizeStory.add(size, _ => <Button size={size}>Click me</Button>)
 )
 
-const iconStory = storiesOf('icon', module).addDecorator(themeDecorator(addons))
+const iconStory = storiesOf('icon', module)
 Object.keys(Button.appearances).forEach(app =>
   iconStory.add(app, _ => (
     <Button appearance={app} icon={<Icon id={Icon.ids.check} />}>
@@ -56,9 +54,7 @@ Object.keys(Button.appearances).forEach(app =>
   )
 )
 
-const disabledStory = storiesOf('disabled', module).addDecorator(
-  themeDecorator(addons)
-)
+const disabledStory = storiesOf('disabled', module)
 Object.keys(Button.appearances).forEach(app =>
   disabledStory.add(app, _ => (
     <Button onClick={action('should never click')} disabled appearance={app}>
@@ -73,7 +69,6 @@ disabledStory.add('with icon', _ => (
 ))
 
 const asLink = storiesOf('as link', module)
-  .addDecorator(themeDecorator(addons))
   .add('default', _ => (
     <Button href="https://duckduckgo.com">Click as link</Button>
   ))
@@ -83,22 +78,21 @@ const asLink = storiesOf('as link', module)
     </Button>
   ))
 
-const refExample = storiesOf('with ref', module)
-  .addDecorator(themeDecorator(addons))
-  .add('ref to handle focus', _ => (
-    <Button innerRef={el => el && el.focus()}>Should be focused</Button>
-  ))
+const refExample = storiesOf('with ref', module).add(
+  'ref to handle focus',
+  _ => <Button innerRef={el => el && el.focus()}>Should be focused</Button>
+)
 
-const onClickExample = storiesOf('with onClick', module)
-  .addDecorator(themeDecorator(addons))
-  .add('clicks once', _ => (
+const onClickExample = storiesOf('with onClick', module).add(
+  'clicks once',
+  _ => (
     <Button onClick={action('click count')} icon={<Icon id={Icon.ids.check} />}>
       Clicks once
     </Button>
-  ))
+  )
+)
 
 const overrideStylesExample = storiesOf('override styles', module)
-  .addDecorator(themeDecorator(addons))
   .add('with style', _ => (
     <Button style={{ background: 'red' }} icon={<Icon id={Icon.ids.check} />}>
       Red Button
@@ -114,7 +108,6 @@ const overrideStylesExample = storiesOf('override styles', module)
   })
 
 const propsExample = storiesOf('props pass through', module)
-  .addDecorator(themeDecorator(addons))
   .add('aria-expanded', _ => (
     <Button aria-expanded={true}>aria-expanded</Button>
   ))
@@ -127,9 +120,7 @@ const propsExample = storiesOf('props pass through', module)
     <Button onMouseOver={action('mouse over')}>Should not mouseover</Button>
   ))
 
-const loadingExample = storiesOf('loading', module).addDecorator(
-  themeDecorator(addons)
-)
+const loadingExample = storiesOf('loading', module)
 Object.keys(Button.sizes).forEach(size =>
   loadingExample.add(size, _ => (
     <Button onClick={action('is disabled')} size={size} loading>


### PR DESCRIPTION
fixes: #290

### Design Decisions
The button had two pseudo elements that were used to display our focus state. One of the pseudo elements was the entirety of the button background and defined a theme specific background color. This caused the `flat` appearance to have a background color on focus that was unwanted (#290).

I removed the `:after` pseudo element and updated the styles for the `:before` pseudo element to use a border only. Originally, through the use of two pseudo elements, we were able to achieve a nice rounded inner border on the focus outline that matched the rounded corner of the button. This change results in a less than ideal inner border rounding because i don't have a second pseudo element to overlay over the first to give the illusion of a rounded inner border.

<img width="593" alt="screen shot 2018-10-19 at 1 51 14 pm" src="https://user-images.githubusercontent.com/226356/47240610-15e28a00-d3a6-11e8-8295-4a878aecd552.png">

I also introduced a new storybook decorator to center the story in the viewport. I needed this to see the fill focus state of the button and I think it looks better. I would like to separate that into a separate package and use in other components - i'll need some help to accomplish that :)

fixes: #290

![selfie-0](https://i.imgur.com/3oCuAzr.png)
[_GitHub Selfies_](https://github.com/thieman/github-selfies/)
