### PR TITLE
lint and format on precommit hook

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['standard', 'standard-react', 'plugin:jest/recommended'],
+  plugins: ['jest'],
+  env: {
+    'jest/globals': true
+  }
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,7 @@
 const Repository = require('lerna/lib/Repository')
 const PackageUtilities = require('lerna/lib/PackageUtilities')
 
-function getPackageAbbreviations() {
+function getPackageAbbreviations () {
   const cwd = process.cwd()
   const repo = new Repository(cwd)
   return PackageUtilities.getPackages({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,11 +4,12 @@ const gulp = require('gulp')
 const octo = require('@octopusdeploy/gulp-octo')
 const path = require('path')
 
-function verifyApp() {
-  if (!argv.app || !argv.pkgVersion)
+function verifyApp () {
+  if (!argv.app || !argv.pkgVersion) {
     throw new Error(
       'So which app and version did you want to publish then? Set with --app {name} --pkgVersion {semVer}'
     )
+  }
 }
 
 gulp.task('bump', () => {
@@ -22,8 +23,9 @@ gulp.task('bump', () => {
 
 gulp.task('octopus-publish', ['bump'], () => {
   verifyApp()
-  if (!argv.host || !argv.apiKey)
+  if (!argv.host || !argv.apiKey) {
     throw new Error('Forgot to include --host or --apiKey')
+  }
 
   const pkg = [
     `packages/${argv.app}/dist/**/*`,

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
   "lerna": "2.0.0",
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "design-system",
   "version": "1.0.0",
-  "private": true,
   "description": "Pluralsight design system",
-  "main": "packages/site/index.js",
+  "license": "Apache-2.0",
+  "private": true,
   "engines": {
     "node": ">= 7.9",
     "npm": ">= 4.2"
   },
+  "author": "jaketrent",
+  "main": "packages/site/index.js",
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean",
@@ -20,21 +22,44 @@
     "site": "cd packages/site && npm start",
     "start": "npm run site",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
+  "lint-staged": {
+    "**/*.js": [
+      "eslint --fix",
+      "git add"
+    ],
+    "package.json": [
+      "format-package -w",
+      "git add"
+    ],
+    "packages/**/*.css": [
+      "node_modules/.bin/prettier --single-quote --no-semi --write",
+      "git add"
+    ]
+  },
+  "browserslist": "last 4 versions",
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "\\.css$": "identity-obj-proxy",
+      "\\.svg$": "<rootDir>/test/__mocks__/svg-mock.js"
+    },
+    "testRegex": "packages/.*(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$",
+    "transformIgnorePatterns": [
+      "<rootDir>.*(node_modules)(?!.*@pluralsight.*).*$"
+    ]
   },
   "keywords": [
     "pluralsight",
     "design system",
     "pattern library"
   ],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
   "dependencies": {
     "glamor": "^2.20.39",
     "react": "^16.2.0",
@@ -61,6 +86,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-standard": "^4.0.0",
+    "format-package": "^4.5.0",
     "gulp": "^3.9.1",
     "gulp-bump": "^3.1.0",
     "husky": "^0.15.0-rc.13",
@@ -73,26 +99,5 @@
     "prettier-eslint": "^8.8.2",
     "react-test-renderer": "^16.3.2",
     "yargs": "^11.0.0"
-  },
-  "lint-staged": {
-    "**/*.js": [
-      "eslint --fix",
-      "git add"
-    ],
-    "packages/**/*.css": [
-      "node_modules/.bin/prettier --single-quote --no-semi --write",
-      "git add"
-    ]
-  },
-  "jest": {
-    "moduleNameMapper": {
-      "\\.css$": "identity-obj-proxy",
-      "\\.svg$": "<rootDir>/test/__mocks__/svg-mock.js"
-    },
-    "testRegex": "packages/.*(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$",
-    "transformIgnorePatterns": [
-      "<rootDir>.*(node_modules)(?!.*@pluralsight.*).*$"
-    ]
-  },
-  "browserslist": "last 4 versions"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "lint-staged": {
     "**/*.js": [
-      "eslint --fix",
+      "prettier-eslint --write",
       "git add"
     ],
     "package.json": [
@@ -96,7 +96,7 @@
     "lint-staged": "^4.0.2",
     "octopus-deploy": "^4.0.0",
     "prettier": "^1.7.4",
-    "prettier-eslint": "^8.8.2",
+    "prettier-eslint-cli": "^4.7.1",
     "react-test-renderer": "^16.3.2",
     "yargs": "^11.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean",
     "commitmsg": "commitlint -e",
+    "lint": "eslint --ignore-path .gitignore .",
     "octopus:deploy": "octopus-deploy-create-release-and-deploy",
     "octopus:publish": "gulp octopus-publish",
     "publish": "lerna publish --conventional-commits --message \"chore: publish\"",
@@ -51,6 +52,15 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "camelize": "^1.0.0",
+    "eslint": "^5.7.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-config-standard-react": "^7.0.2",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jest": "^21.25.1",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-standard": "^4.0.0",
     "gulp": "^3.9.1",
     "gulp-bump": "^3.1.0",
     "husky": "^0.15.0-rc.13",
@@ -60,12 +70,13 @@
     "lint-staged": "^4.0.2",
     "octopus-deploy": "^4.0.0",
     "prettier": "^1.7.4",
+    "prettier-eslint": "^8.8.2",
     "react-test-renderer": "^16.3.2",
     "yargs": "^11.0.0"
   },
   "lint-staged": {
-    "packages/**/*.js": [
-      "node_modules/.bin/prettier --single-quote --no-semi --write",
+    "**/*.js": [
+      "eslint --fix",
       "git add"
     ],
     "packages/**/*.css": [

--- a/packages/actionmenu/package.json
+++ b/packages/actionmenu/package.json
@@ -2,34 +2,34 @@
   "name": "@pluralsight/ps-design-system-actionmenu",
   "version": "3.1.10",
   "description": "Design System component for actionmenu ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-icon": "^8.13.0",
     "glamorous": "^4.1.0",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -2,32 +2,32 @@
   "name": "@pluralsight/ps-design-system-avatar",
   "version": "1.7.7",
   "description": "Design System component for avatar ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "assisantunes",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
-    "test": "jest",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test": "jest",
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "assisantunes",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
+  "dependencies": {
+    "@pluralsight/ps-design-system-core": "^4.3.3",
+    "prop-types": "^15.5.10"
+  },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
     "react": ">=0.15.0 < 17.0.0"
-  },
-  "dependencies": {
-    "@pluralsight/ps-design-system-core": "^4.3.3",
-    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -2,34 +2,34 @@
   "name": "@pluralsight/ps-design-system-badge",
   "version": "2.1.12",
   "description": "Design System component for badge ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
-  "style": "dist/css/index.css",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "node build/css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
+  "style": "dist/css/index.css",
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "glamorous": "^4.1.0",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -2,34 +2,34 @@
   "name": "@pluralsight/ps-design-system-banner",
   "version": "1.2.12",
   "description": "Design System component for banner ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-icon": "^8.13.0",
     "@pluralsight/ps-design-system-link": "^5.7.12",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -2,33 +2,36 @@
   "name": "@pluralsight/ps-design-system-breadcrumb",
   "version": "1.2.12",
   "description": "Design System component for breadcrumb ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
-    "test": "jest",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
+    "test": "jest",
     "test:watch": "npm run test -- --watchAll"
   },
-  "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+  "jest": {
+    "setupTestFrameworkScriptFile": "<rootDir>/test/test-setup.js"
   },
+  "keywords": [],
   "dependencies": {
     "@pluralsight/ps-design-system-button": "^10.8.15",
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-icon": "^8.13.0",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",
@@ -49,8 +52,5 @@
     "npm-run-all": "^4.1.2",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
-  },
-  "jest": {
-    "setupTestFrameworkScriptFile": "<rootDir>/test/test-setup.js"
   }
 }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -2,18 +2,18 @@
   "name": "@pluralsight/ps-design-system-build",
   "version": "1.8.3",
   "description": "Utilities for building and configuring Design System packages",
-  "main": "index.js",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "bin": {
     "build-css": "./bin/build-css.js"
   },
+  "main": "index.js",
   "scripts": {
     "test": "jest",
     "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
   "dependencies": {
     "babel-core": "^6.25.0",
     "babel-loader": "^7.0.0",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -2,28 +2,26 @@
   "name": "@pluralsight/ps-design-system-button",
   "version": "10.8.15",
   "description": "Design System component for button ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "node build/css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
-    "test": "jest",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test": "jest",
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
+  },
+  "jest": {
+    "setupTestFrameworkScriptFile": "<rootDir>/test/test-setup.js"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-icon": "^8.13.0",
@@ -31,6 +29,11 @@
     "@pluralsight/ps-design-system-util": "^1.2.2",
     "polished": "^1.7.0",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",
@@ -50,8 +53,5 @@
     "npm-run-all": "^4.1.2",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
-  },
-  "jest": {
-    "setupTestFrameworkScriptFile": "<rootDir>/test/test-setup.js"
   }
 }

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -2,29 +2,27 @@
   "name": "@pluralsight/ps-design-system-card",
   "version": "8.5.0",
   "description": "Design System component for card ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
-    "test": "jest",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test": "jest",
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
+  },
+  "jest": {
+    "setupTestFrameworkScriptFile": "<rootDir>/test/test-setup.js"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-icon": "^8.13.0",
@@ -32,6 +30,11 @@
     "polished": "^1.7.0",
     "prop-types": "^15.5.10",
     "shiitake": "^2.1.1"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",
@@ -51,8 +54,5 @@
     "jest": "^20.0.4",
     "npm-run-all": "^4.1.2",
     "react": "^16.2.0"
-  },
-  "jest": {
-    "setupTestFrameworkScriptFile": "<rootDir>/test/test-setup.js"
   }
 }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -2,34 +2,34 @@
   "name": "@pluralsight/ps-design-system-checkbox",
   "version": "0.3.7",
   "description": "Design system components for checkbox",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-theme": "^1.3.2",
     "@pluralsight/ps-design-system-util": "^1.2.2",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/circularprogress/package.json
+++ b/packages/circularprogress/package.json
@@ -2,34 +2,34 @@
   "name": "@pluralsight/ps-design-system-circularprogress",
   "version": "1.5.12",
   "description": "Design System component for circular progress ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
-    "test": "jest",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test": "jest",
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-theme": "^1.3.2",
     "polished": "^1.7.0",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,18 +2,18 @@
   "name": "@pluralsight/ps-design-system-core",
   "version": "4.3.3",
   "description": "Collection of Core design elements for the Design System",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "js/index.js",
   "module": "js/index.js",
-  "style": "css/index.css",
   "scripts": {
     "build": "node ./build",
     "prepublish": "npm run build",
     "test": "echo \"Error: tests are run as a single design system suite\" && exit 1"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
+  "style": "css/index.css",
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",
     "autoprefixer": "^7.1.1",

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -2,29 +2,24 @@
   "name": "@pluralsight/ps-design-system-datepicker",
   "version": "0.4.12",
   "description": "Design system components for date picker",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-button": "^10.8.15",
     "@pluralsight/ps-design-system-core": "^4.3.3",
@@ -33,6 +28,11 @@
     "@pluralsight/ps-design-system-util": "^1.2.2",
     "polished": "^1.9.2",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -2,34 +2,34 @@
   "name": "@pluralsight/ps-design-system-dialog",
   "version": "2.2.14",
   "description": "Design System component for dialog ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "node build/css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
-    "test": "jest",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test": "jest",
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-theme": "^1.3.2",
     "polished": "^1.7.0",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -2,29 +2,24 @@
   "name": "@pluralsight/ps-design-system-drawer",
   "version": "1.5.2",
   "description": "Design System component for drawer ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "devstar",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "devstar",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-icon": "^8.13.0",
@@ -33,6 +28,11 @@
     "glamorous": "^4.1.0",
     "polished": "^1.7.0",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -2,29 +2,24 @@
   "name": "@pluralsight/ps-design-system-dropdown",
   "version": "0.5.3",
   "description": "Design system components for dropdown",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-actionmenu": "^3.1.10",
     "@pluralsight/ps-design-system-core": "^4.3.3",
@@ -33,6 +28,11 @@
     "@pluralsight/ps-design-system-util": "^1.2.2",
     "polished": "^1.9.2",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -2,30 +2,25 @@
   "name": "@pluralsight/ps-design-system-errors",
   "version": "1.3.4",
   "description": "Design system components for errors",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css build:html",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
-    "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:html": "node build/html",
+    "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-button": "^10.8.15",
     "@pluralsight/ps-design-system-core": "^4.3.3",
@@ -33,6 +28,11 @@
     "@pluralsight/ps-design-system-text": "^10.7.14",
     "@pluralsight/ps-design-system-theme": "^1.3.2",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -2,39 +2,39 @@
   "name": "@pluralsight/ps-design-system-form",
   "version": "0.3.14",
   "description": "Design system components for form layout",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [
     "pluralsight",
     "design system",
     "form ui"
   ],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-theme": "^1.3.2",
     "@pluralsight/ps-design-system-util": "^1.2.2",
     "polished": "^1.9.2",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-actionmenu": "^3.1.10",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -2,34 +2,34 @@
   "name": "@pluralsight/ps-design-system-icon",
   "version": "8.13.0",
   "description": "Design System component for icon ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "svg:clean": "node build/svg-clean",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "glamorous": "^4.1.0",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -2,31 +2,31 @@
   "name": "@pluralsight/ps-design-system-layout",
   "version": "3.0.2",
   "description": "Design system components for ui layouts",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "babel src --out-dir dist --ignore spec.js --copy-files",
+    "build-storybook": "build-storybook",
     "build:watch": "npm run build -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-text": "^10.7.14",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-button": "^10.8.15",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -2,33 +2,33 @@
   "name": "@pluralsight/ps-design-system-link",
   "version": "5.7.12",
   "description": "Design System component for link/anchor ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
-  "typings": "./react.d.ts",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
+  "typings": "./react.d.ts",
+  "dependencies": {
+    "@pluralsight/ps-design-system-core": "^4.3.3",
+    "prop-types": "^15.6.0"
+  },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
     "react": ">=0.15.0 < 17.0.0"
-  },
-  "dependencies": {
-    "@pluralsight/ps-design-system-core": "^4.3.3",
-    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/normalize/package.json
+++ b/packages/normalize/package.json
@@ -2,17 +2,17 @@
   "name": "@pluralsight/ps-design-system-normalize",
   "version": "3.0.45",
   "description": "Normalize stylesheet.  Should be present on-page to help guarantee ps-* design system components appear properly.",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "dist/index.css",
-  "style": "dist/index.css",
   "scripts": {
     "build": "node ./build",
     "prepublish": "npm run build",
     "test": "echo \"Error: tests run in as a single design system suite\" && exit 1"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
+  "style": "dist/index.css",
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "normalize.css": "^7.0.0"

--- a/packages/packages-api/package.json
+++ b/packages/packages-api/package.json
@@ -1,19 +1,19 @@
 {
   "name": "packages-api",
   "version": "1.3.2",
-  "private": true,
   "description": "API for tracking the published packages in the design system",
-  "main": "dist/index.js",
-  "scripts": {
-    "flow": "flow",
-    "start": "concurrently \"npm run build -- --watch\" \"nodemon --watch ./dist\"",
-    "build": "babel src/ --out-dir dist/ --ignore spec.js"
-  },
+  "license": "Apache-2.0",
+  "private": true,
   "engines": {
     "node": "8.x"
   },
   "author": "jaketrent",
-  "license": "Apache-2.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "babel src/ --out-dir dist/ --ignore spec.js",
+    "flow": "flow",
+    "start": "concurrently \"npm run build -- --watch\" \"nodemon --watch ./dist\""
+  },
   "dependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -2,35 +2,35 @@
   "name": "@pluralsight/ps-design-system-radio",
   "version": "0.3.6",
   "description": "Design system components for radio buttons",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-theme": "^1.3.2",
     "@pluralsight/ps-design-system-util": "^1.2.2",
     "polished": "^1.9.2",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -2,35 +2,35 @@
   "name": "@pluralsight/ps-design-system-row",
   "version": "2.6.15",
   "description": "Design System component for row ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "glamorous": "^4.1.0",
     "polished": "^1.7.0",
     "prop-types": "^15.5.10",
     "void-elements": "^3.1.0"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,19 +1,26 @@
 {
   "name": "@pluralsight/ps-design-system-site",
-  "private": true,
   "version": "11.1.3",
   "description": "Reference site",
-  "main": "index.js",
+  "license": "Apache-2.0",
+  "private": true,
   "engines": {
     "node": ">= 7.9",
     "npm": ">= 4.2"
   },
+  "author": "jaketrent",
+  "main": "index.js",
   "scripts": {
     "build": "next build && next export -o dist",
     "start": "next -p 1337"
   },
-  "author": "jaketrent",
-  "license": "Apache-2.0",
+  "dependencies": {
+    "core-js": "^2.5.7",
+    "dotenv": "^5.0.1",
+    "http-server": "^0.11.1",
+    "isomorphic-fetch": "^2.2.1",
+    "polished": "^1.8.1"
+  },
   "devDependencies": {
     "@pluralsight/ps-design-system-actionmenu": "^3.1.10",
     "@pluralsight/ps-design-system-avatar": "^1.7.7",
@@ -64,12 +71,5 @@
     "react-codemirror": "^1.0.0",
     "react-dom": "^16.2.0",
     "react-markdown": "^2.5.0"
-  },
-  "dependencies": {
-    "core-js": "^2.5.7",
-    "dotenv": "^5.0.1",
-    "http-server": "^0.11.1",
-    "isomorphic-fetch": "^2.2.1",
-    "polished": "^1.8.1"
   }
 }

--- a/packages/storybook-addon-theme/package.json
+++ b/packages/storybook-addon-theme/package.json
@@ -2,26 +2,26 @@
   "name": "@pluralsight/ps-design-system-storybook-addon-theme",
   "version": "1.1.44",
   "description": "Storybook addon for Theme switching",
-  "main": "index.js",
-  "keywords": [
-    "react-storybook"
-  ],
-  "author": "jaketrent",
   "license": "Apache-2.0",
   "repository": "pluralsight/design-system",
+  "author": "jaketrent",
+  "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir dist --ignore spec.js",
     "build:watch": "npm run build -- --watch",
     "prepublish": "npm run build"
   },
-  "peerDependencies": {
-    "@storybook/addons": "v3.2.14",
-    "react": ">=0.15.0 < 17.0.0"
-  },
+  "keywords": [
+    "react-storybook"
+  ],
   "dependencies": {
     "@pluralsight/ps-design-system-button": "^10.8.15",
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-theme": "^1.3.2"
+  },
+  "peerDependencies": {
+    "@storybook/addons": "v3.2.14",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -2,34 +2,37 @@
   "name": "@pluralsight/ps-design-system-switch",
   "version": "1.5.9",
   "description": "Design System component for switch ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
-    "test": "jest",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test": "jest",
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
+  },
+  "jest": {
+    "setupTestFrameworkScriptFile": "<rootDir>/test/test-setup.js"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-theme": "^1.3.2",
     "polished": "^1.7.0",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",
@@ -46,8 +49,5 @@
     "jest": "^20.0.4",
     "npm-run-all": "^4.1.2",
     "react": "^16.2.0"
-  },
-  "jest": {
-    "setupTestFrameworkScriptFile": "<rootDir>/test/test-setup.js"
   }
 }

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -2,34 +2,34 @@
   "name": "@pluralsight/ps-design-system-tab",
   "version": "7.6.14",
   "description": "Design system component for tab list ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-theme": "^1.3.2",
     "glamorous": "^4.1.0",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -2,35 +2,35 @@
   "name": "@pluralsight/ps-design-system-table",
   "version": "1.1.15",
   "description": "Design System component for table ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-drawer": "^1.5.2",
     "@pluralsight/ps-design-system-icon": "^8.13.0",
     "@pluralsight/ps-design-system-theme": "^1.3.2",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -2,35 +2,35 @@
   "name": "@pluralsight/ps-design-system-tag",
   "version": "1.7.3",
   "description": "Design System component for tag ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-icon": "^8.13.0",
     "@pluralsight/ps-design-system-theme": "^1.3.2",
     "@pluralsight/ps-design-system-util": "^1.2.2",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -2,35 +2,35 @@
   "name": "@pluralsight/ps-design-system-text",
   "version": "10.7.14",
   "description": "Design system component for text-related ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-theme": "^1.3.2",
     "glamorous": "^4.1.0",
     "polished": "^1.9.2",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -2,29 +2,24 @@
   "name": "@pluralsight/ps-design-system-textarea",
   "version": "0.4.6",
   "description": "Design system components for text area",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-icon": "^8.13.0",
@@ -32,6 +27,11 @@
     "@pluralsight/ps-design-system-util": "^1.2.2",
     "polished": "^1.9.2",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/textinput/package.json
+++ b/packages/textinput/package.json
@@ -2,29 +2,24 @@
   "name": "@pluralsight/ps-design-system-textinput",
   "version": "0.5.6",
   "description": "Design system components for text input",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-icon": "^8.13.0",
@@ -32,6 +27,11 @@
     "@pluralsight/ps-design-system-util": "^1.2.2",
     "polished": "^1.9.2",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -2,6 +2,9 @@
   "name": "@pluralsight/ps-design-system-theme",
   "version": "1.3.2",
   "description": "Design System component for theming",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
@@ -9,20 +12,17 @@
     "build:watch": "npm run build -- --watch",
     "prepublish": "npm run build",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
     "react": ">=0.15.0 < 17.0.0"
-  },
-  "dependencies": {
-    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -2,33 +2,33 @@
   "name": "@pluralsight/ps-design-system-tooltip",
   "version": "1.3.12",
   "description": "Design System component for tooltip ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "node build/css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
-    "test": "jest",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test": "jest",
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "polished": "^1.7.0",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -2,6 +2,9 @@
   "name": "@pluralsight/ps-design-system-util",
   "version": "1.2.2",
   "description": "Runtime dependencies for utilitarian tasks.  Analogous to a lodash.",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir dist --ignore spec.js --copy-files",
@@ -10,14 +13,11 @@
     "test:watch": "npm run test -- --watch"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/viewtoggle/package.json
+++ b/packages/viewtoggle/package.json
@@ -2,34 +2,34 @@
   "name": "@pluralsight/ps-design-system-viewtoggle",
   "version": "1.3.12",
   "description": "Design System component for view toggle ui",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "author": "jaketrent",
   "main": "index.js",
   "module": "index.js",
   "scripts": {
     "build": "run-s build:js build:css",
+    "build-storybook": "build-storybook",
     "build:css": "build-css",
     "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
     "build:watch": "npm run build:js -- --watch",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
     "test": "jest",
-    "test:watch": "npm run test -- --watchAll",
-    "test:updateSnapshot": "npm run test -- --updateSnapshot"
+    "test:updateSnapshot": "npm run test -- --updateSnapshot",
+    "test:watch": "npm run test -- --watchAll"
   },
   "keywords": [],
-  "author": "jaketrent",
-  "license": "Apache-2.0",
-  "repository": "pluralsight/design-system",
-  "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
-  },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^4.3.3",
     "@pluralsight/ps-design-system-icon": "^8.13.0",
     "glamorous": "^4.1.0",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "^3.0.24",
+    "glamor": "^2.20.0",
+    "react": ">=0.15.0 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.8.3",


### PR DESCRIPTION
### What You're Solving

Adds a precommit hook to lint and format `.js` files. Also adds a hook to format `package.json` files. This is to ensure consistent style and automate the process. This also will make vscode/prettier play nicer with the project and give helpful hints in editors with eslint integrations.

As usual the precommit can be bypassed with the `-n` flag but my hope that in the future this is unnecessary - more of just an escape hatch while we're in transition.

### Design Decisions

- I chose to adopt the standardjs style - this is so we don't have to spend time defining our own rules
- I just integrated the tooling but did not fix all the linting errors. my reasoning is that we can fix them as we work on or refactor code. This allows a more incremental(but longer) transition.
- I added a hook to format package.json files and made the appropriate changes. This is more a style design I make but it is very low impact and i've liked having it automated in the past.
- i added a `.editorconfig` file for editors that support this.


