### PR TITLE
[WIP] feat(project): add script to scaffold new components

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean",
     "commitmsg": "commitlint -e",
+    "component:create": "./scripts/create-component/index.js",
     "lint": "eslint --ignore-path .gitignore .",
     "octopus:deploy": "octopus-deploy-create-release-and-deploy",
     "octopus:publish": "gulp octopus-publish",
@@ -26,18 +27,23 @@
     "test:watch": "npm run test -- --watchAll"
   },
   "lint-staged": {
-    "**/*.js": [
-      "prettier-eslint --write",
-      "git add"
+    "ignore": [
+      "scripts"
     ],
-    "package.json": [
-      "format-package -w",
-      "git add"
-    ],
-    "packages/**/*.css": [
-      "node_modules/.bin/prettier --single-quote --no-semi --write",
-      "git add"
-    ]
+    "linters": {
+      "**/*.js": [
+        "prettier-eslint --write",
+        "git add"
+      ],
+      "package.json": [
+        "format-package -w",
+        "git add"
+      ],
+      "packages/**/*.css": [
+        "node_modules/.bin/prettier --single-quote --no-semi --write",
+        "git add"
+      ]
+    }
   },
   "browserslist": "last 4 versions",
   "husky": {
@@ -77,6 +83,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "camelize": "^1.0.0",
+    "copy-template-dir": "^1.4.0",
     "eslint": "^5.7.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-config-standard-react": "^7.0.2",
@@ -91,9 +98,10 @@
     "gulp-bump": "^3.1.0",
     "husky": "^0.15.0-rc.13",
     "identity-obj-proxy": "^3.0.0",
+    "inquirer": "^6.2.0",
     "jest": "^20.0.0",
     "lerna": "^2.0.0-rc.4",
-    "lint-staged": "^4.0.2",
+    "lint-staged": "^7.3.0",
     "octopus-deploy": "^4.0.0",
     "prettier": "^1.7.4",
     "prettier-eslint-cli": "^4.7.1",

--- a/scripts/create-component/index.js
+++ b/scripts/create-component/index.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+const inquirer = require('inquirer')
+const copyTemplateDir = require('copy-template-dir')
+
+const { getPackages, toPackageName } = require('../utils/packages')
+const { smush, pascalize } = require('../utils/string')
+
+const MINIMUM_REACT_VERSION = '^16.2.0'
+
+const packagesDir = path.resolve(__dirname, '..', '..', 'packages')
+const templateDir = path.resolve(__dirname, 'package-template')
+
+const copyPackageFromTemplateDir = (source, dest, vars) => {
+  return new Promise((resolve, reject) => {
+    copyTemplateDir(source, dest, vars, (err, createdFiles) => {
+      if (err) reject(err)
+      else resolve(createdFiles)
+    })
+  })
+}
+
+const allPackages = getPackages()
+
+const suggestedDependencies = [
+  'button',
+  'core',
+  'icon',
+  'normalize',
+  'theme',
+  'util'
+].map(toPackageName)
+
+const questions = [
+  {
+    type: 'input',
+    name: 'name',
+    message: 'Component Name',
+    validate: name => (name.length > 0 ? true : 'invalid name')
+  },
+  {
+    type: 'checkbox',
+    name: 'dependencies',
+    message: 'Dependencies',
+    choices: suggestedDependencies.map(name => ({ name })),
+    filter: keys => {
+      const depMap = keys.reduce((acc, key) => {
+        const version = `^${allPackages[key]}`
+        return { ...acc, [key]: version }
+      }, {})
+
+      return JSON.stringify(depMap)
+    }
+  }
+]
+
+async function main () {
+  const answers = await inquirer.prompt(questions)
+
+  const componentName = pascalize(answers.name)
+  const folderName = smush(answers.name)
+  const packageName = toPackageName(answers.name)
+
+  const folderPath = path.resolve(packagesDir, folderName)
+
+  const vars = {
+    ...answers,
+    componentName,
+    folderName,
+    folderPath,
+    packageName,
+    reactVersion: MINIMUM_REACT_VERSION
+  }
+
+  if (fs.existsSync(folderPath)) {
+    throw new Error(`folder ${folderName} already exists`)
+  }
+
+  await copyPackageFromTemplateDir(templateDir, folderPath, vars)
+
+  return vars
+}
+
+main()
+  .then(vars => {
+    console.info(`\n${vars.componentName} created at: ${vars.folderPath}\n`)
+    console.info('Next run: npm run bootstrap\n')
+  })
+  .catch(console.error)

--- a/scripts/create-component/package-template/.babelrc
+++ b/scripts/create-component/package-template/.babelrc
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    "react",
+    "stage-2",
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": ["last 2 versions", "ie >= 10"]
+        }
+      }
+    ]
+  ]
+}

--- a/scripts/create-component/package-template/.npmignore
+++ b/scripts/create-component/package-template/.npmignore
@@ -1,0 +1,3 @@
+__specs__
+src
+.babelrc

--- a/scripts/create-component/package-template/.npmrc
+++ b/scripts/create-component/package-template/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/scripts/create-component/package-template/.storybook/addons.js
+++ b/scripts/create-component/package-template/.storybook/addons.js
@@ -1,0 +1,6 @@
+import '@storybook/addon-actions/register'
+
+import addons from '@storybook/addons'
+import register from '@pluralsight/ps-design-system-storybook-addon-theme/register'
+
+register(addons)

--- a/scripts/create-component/package-template/.storybook/config.js
+++ b/scripts/create-component/package-template/.storybook/config.js
@@ -1,0 +1,16 @@
+import addons from '@storybook/addons'
+import { addDecorator, configure } from '@storybook/react'
+
+import centerDecorator from '@pluralsight/ps-design-system-storybook-addon-center'
+import themeDecorator from '@pluralsight/ps-design-system-storybook-addon-theme'
+
+addDecorator(centerDecorator)
+addDecorator(themeDecorator(addons))
+
+const req = require.context('../stories', true, /\.story\.js$/)
+
+function loadStories() {
+  req.keys().forEach(filename => req(filename))
+}
+
+configure(loadStories, module)

--- a/scripts/create-component/package-template/.storybook/preview-head.html
+++ b/scripts/create-component/package-template/.storybook/preview-head.html
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="https://cloud.typography.com/6966154/691568/css/fonts.css" />
+<link rel="stylesheet" href="https://unpkg.com/@pluralsight/ps-design-system-normalize" />

--- a/scripts/create-component/package-template/css.js
+++ b/scripts/create-component/package-template/css.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/css')

--- a/scripts/create-component/package-template/index.js
+++ b/scripts/create-component/package-template/index.js
@@ -1,0 +1,5 @@
+const css = require('./css')
+const react = require('./react')
+const vars = require('./vars')
+
+module.exports = { css: css, react: react, vars: vars }

--- a/scripts/create-component/package-template/package.json
+++ b/scripts/create-component/package-template/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "{{packageName}}",
+  "version": "1.0.0",
+  "description": "{{componentName}} UI Component for the Pluralsight Design System",
+  "license": "Apache-2.0",
+  "repository": "pluralsight/design-system",
+  "main": "index.js",
+  "module": "index.js",
+  "scripts": {
+    "build": "run-s build:js build:css",
+    "build:css": "build-css",
+    "build:js": "babel src --out-dir dist --ignore spec.js --copy-files",
+    "build:watch": "npm run build:js -- --watch",
+    "prepublish": "npm run build",
+    "storybook": "start-storybook -p 6006"
+  },
+  "dependencies": {{dependencies}},
+  "peerDependencies": {
+    "@pluralsight/ps-design-system-normalize": "*",
+    "glamor": "^2.x.x",
+    "react": ">=0.15.0 < 17.0.0"
+  },
+  "devDependencies": {
+    "@pluralsight/ps-design-system-build": "*",
+    "@pluralsight/ps-design-system-storybook-addon-center": "*",
+    "@pluralsight/ps-design-system-storybook-addon-theme": "*",
+    "@storybook/addon-actions": "^3.x.x",
+    "@storybook/addon-storyshots": "^3.x.x",
+    "@storybook/addons": "^3.x.x",
+    "@storybook/react": "^3.x.x",
+    "babel-cli": "^6.x.x",
+    "babel-preset-env": "^1.x.x",
+    "babel-preset-react": "^6.x.x",
+    "babel-preset-stage-2": "^6.x.x",
+    "npm-run-all": "^4.x.x",
+    "react-dom": "{{reactVersion}}",
+    "react": "{{reactVersion}}"
+  }
+}

--- a/scripts/create-component/package-template/react.js
+++ b/scripts/create-component/package-template/react.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/react')

--- a/scripts/create-component/package-template/src/css/index.js
+++ b/scripts/create-component/package-template/src/css/index.js
@@ -1,0 +1,3 @@
+import * as vars from '../vars'
+
+export default {}

--- a/scripts/create-component/package-template/src/react/index.js
+++ b/scripts/create-component/package-template/src/react/index.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+import css from '../css'
+import * as vars from '../vars'
+
+const {{componentName}} = props => <div>{{componentName}}</div>
+
+{{componentName}}.propTypes = {}
+
+export default {{componentName}}

--- a/scripts/create-component/package-template/src/vars/index.js
+++ b/scripts/create-component/package-template/src/vars/index.js
@@ -1,0 +1,1 @@
+export default {}

--- a/scripts/create-component/package-template/stories/index.story.js
+++ b/scripts/create-component/package-template/stories/index.story.js
@@ -1,0 +1,7 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+
+import {{componentName}} from '../react'
+
+storiesOf('{{componentName}}', module)
+  .add('TODO', _ => <{{componentName}} />)

--- a/scripts/create-component/package-template/vars.js
+++ b/scripts/create-component/package-template/vars.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/vars')

--- a/scripts/utils/packages.js
+++ b/scripts/utils/packages.js
@@ -1,0 +1,30 @@
+const path = require('path')
+
+const Repository = require('lerna/lib/Repository')
+const PackageUtilities = require('lerna/lib/PackageUtilities')
+
+const { smush, validateIsString } = require('./string')
+
+const rootPath = path.resolve(__dirname, '..', '..')
+
+const npmScope = '@pluralsight'
+const packagePrefix = 'ps-design-system-'
+
+const toPackageName = str => {
+  validateIsString(str)
+  return `${npmScope}/${packagePrefix}${smush(str)}`
+}
+
+const getPackages = () => {
+  const repo = new Repository(rootPath)
+
+  return PackageUtilities.getPackages({
+    packageConfigs: repo.packageConfigs,
+    rootPath
+  }).reduce((acc, pkg) => ({ ...acc, [pkg.name]: pkg.version }), {})
+}
+
+module.exports = {
+  toPackageName,
+  getPackages
+}

--- a/scripts/utils/string.js
+++ b/scripts/utils/string.js
@@ -1,0 +1,32 @@
+const validateIsString = str => {
+  if (typeof str !== 'string') throw new TypeError('Expected a string')
+  return true
+}
+
+const stripWhitespace = str => {
+  validateIsString(str)
+  return str.replace(/\s/g, '')
+}
+
+const smush = str => {
+  validateIsString(str)
+  return stripWhitespace(str.toLowerCase())
+}
+
+const pascalize = str => {
+  validateIsString(str)
+  return stripWhitespace(titleize(str))
+}
+
+const titleize = str => {
+  validateIsString(str)
+  return str.toLowerCase().replace(/(?:^|\s|-)\S/g, x => x.toUpperCase())
+}
+
+module.exports = {
+  stripWhitespace,
+  smush,
+  pascalize,
+  titleize,
+  validateIsString
+}


### PR DESCRIPTION
### What You're Solving

I found there were many steps to setup a new component. I wanted an automated way to save myself time and errors - as well and to make it easier for outside contributors to get started.

### How to Verify

- `npm run component:create`

### Outstanding tasks

- [ ] glamor integration
- [ ] setup jest/enzyme
- [ ] update contributor docs


