### PR TITLE
storybook-addon-theme: remove Button circular dependency

### DIFF
--- a/packages/storybook-addon-theme/package.json
+++ b/packages/storybook-addon-theme/package.json
@@ -15,9 +15,10 @@
     "react-storybook"
   ],
   "dependencies": {
-    "@pluralsight/ps-design-system-button": "^10.8.15",
     "@pluralsight/ps-design-system-core": "^4.3.3",
-    "@pluralsight/ps-design-system-theme": "^1.3.2"
+    "@pluralsight/ps-design-system-theme": "^1.3.2",
+    "glamor": "^2.20.40",
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
     "@storybook/addons": "v3.2.14",

--- a/packages/storybook-addon-theme/src/index.js
+++ b/packages/storybook-addon-theme/src/index.js
@@ -1,58 +1,83 @@
-import core from '@pluralsight/ps-design-system-core'
+import * as glamor from 'glamor'
 import React from 'react'
+import PropTypes from 'prop-types'
+
+import core from '@pluralsight/ps-design-system-core'
 import Theme from '@pluralsight/ps-design-system-theme/react'
 
-const getStyle = themeName => ({
-  overflow: 'scroll',
-  position: 'fixed',
-  top: 0,
-  right: 0,
-  bottom: 0,
-  left: 0,
-  transition: `background ${core.motion.speedNormal}`,
-  backgroundSize: 'cover',
-  background: 'transparent',
-  ...{
-    [Theme.names.dark]: { background: core.colors.gray06 },
-    [Theme.names.light]: { background: core.colors.bone }
-  }[themeName]
-})
+const styles = {
+  decorator: ({ themeName }) => {
+    const base = glamor.css({
+      overflow: 'scroll',
+      position: 'fixed',
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      transition: `background ${core.motion.speedNormal}`,
+      backgroundSize: 'cover',
+      background: 'transparent'
+    })
+
+    const theme = glamor.css(
+      themeName === 'dark' && { background: core.colors.gray06 },
+      themeName === 'light' && { background: core.colors.bone }
+    )
+
+    return glamor.compose(
+      base,
+      theme
+    )
+  }
+}
 
 export class ThemeDecorator extends React.Component {
-  constructor(props) {
+  constructor (props) {
     super(props)
-    this.state = { themeName: Theme.defaultName }
+
     this.channel = this.props.addons.getChannel()
     this.story = this.props.story()
 
     this.setTheme = this.setTheme.bind(this)
+
+    this.state = { themeName: Theme.defaultName }
   }
-  componentWillMount() {
+
+  componentWillMount () {
     this.channel.on('theme', this.setTheme)
   }
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.story !== this.props.story) {
-      this.story = nextProps.story()
-    }
+
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.story !== this.props.story) this.story = nextProps.story()
   }
-  componentWillUnmount() {
+
+  componentWillUnmount () {
     this.channel.removeListener('theme', this.setTheme)
   }
-  setTheme(themeName) {
+
+  setTheme (themeName) {
     this.setState({ themeName })
   }
-  handleClick(themeName) {
-    this.setState({ themeName })
 
+  handleClick (themeName) {
+    this.setState({ themeName })
     this.channel.emit('ps-design-system-theme/names/select', themeName)
   }
-  render() {
+
+  render () {
     return (
-      <div style={getStyle(this.state.themeName)}>
+      <div {...styles.decorator({ themeName: this.state.themeName })}>
         <Theme name={this.state.themeName}>{this.story}</Theme>
       </div>
     )
   }
+}
+
+ThemeDecorator.propTypes = {
+  addons: PropTypes.shape({
+    getChannel: PropTypes.func.isRequired
+  }).isRequired,
+  story: PropTypes.func.isRequired
 }
 
 // NOTE: unconventional need to pass addons here.  dealt with this for a day

--- a/packages/storybook-addon-theme/src/swatch.js
+++ b/packages/storybook-addon-theme/src/swatch.js
@@ -1,0 +1,93 @@
+import * as glamor from 'glamor'
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import core from '@pluralsight/ps-design-system-core'
+import Theme from '@pluralsight/ps-design-system-theme/react'
+
+const styles = {
+  container: props =>
+    glamor.css({
+      border: `1px solid ${core.colors.gray01}`,
+      borderRadius: 4,
+      color: 'inherit',
+      cursor: 'pointer',
+      display: 'inline-block',
+      overflow: 'hidden',
+      padding: 0,
+      textAlign: 'left',
+      width: 150,
+      wordWrap: 'break-word',
+
+      '& + &': { marginLeft: 10 },
+      '&:first-child': { marginLeft: 0 }
+    }),
+  preview: props => {
+    const base = glamor.css({
+      height: 60
+    })
+    const theme = glamor.css(
+      props.name === 'dark' && { background: core.colors.gray06 },
+      props.name === 'light' && { background: core.colors.bone }
+    )
+
+    return glamor.compose(
+      base,
+      theme
+    )
+  },
+  info: props =>
+    glamor.css({
+      borderTop: `1px solid ${core.colors.gray01}`,
+      color: core.colors.gray03,
+      padding: '0 10px'
+    }),
+  title: props =>
+    glamor.css({
+      color: 'inherit',
+      fontWeight: 'bold',
+      fontSize: 12,
+      textTransform: 'uppercase'
+    })
+}
+
+const Container = props => <button {...styles.container()} {...props} />
+
+const Preview = props => <div {...styles.preview(props)} {...props} />
+
+const Info = props => <div {...styles.info()} {...props} />
+
+const Title = props => <h2 {...styles.title()} {...props} />
+
+Title.propTypes = {
+  children: PropTypes.string.isRequired
+}
+
+class Swatch extends React.Component {
+  constructor (props) {
+    super(props)
+    this.handleClick = this.handleClick.bind(this)
+  }
+
+  handleClick (event) {
+    this.props.onSelect(event, this.props.name)
+  }
+
+  render () {
+    return (
+      <Container onClick={this.handleClick}>
+        <Preview name={this.props.name} />
+        <Info>
+          <Title>{this.props.name}</Title>
+        </Info>
+      </Container>
+    )
+  }
+}
+
+Swatch.propTypes = {
+  name: PropTypes.oneOf(Object.values(Theme.names)).isRequired,
+  onSelect: PropTypes.func.isRequired
+}
+
+module.exports = Swatch

--- a/packages/storybook-addon-theme/src/theme-panel.js
+++ b/packages/storybook-addon-theme/src/theme-panel.js
@@ -4,35 +4,10 @@ import PropTypes from 'prop-types'
 
 import Theme from '@pluralsight/ps-design-system-theme/react'
 
-const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1)
+import Swatch from './swatch'
 
 const styles = {
-  panel: props => glamor.css({ padding: 15 }),
-  button: props => glamor.css({ marginRight: 10 })
-}
-
-class ThemeButton extends React.Component {
-  constructor (props) {
-    super(props)
-    this.handleClick = this.handleClick.bind(this)
-  }
-
-  handleClick (event) {
-    this.props.onSelect(event, this.props.name)
-  }
-
-  render () {
-    return (
-      <button {...styles.button(this.props)} onClick={this.handleClick}>
-        {capitalize(this.props.name)}
-      </button>
-    )
-  }
-}
-
-ThemeButton.propTypes = {
-  name: PropTypes.oneOf(Object.values(Theme.names)).isRequired,
-  onSelect: PropTypes.func.isRequired
+  panel: props => glamor.css({ padding: '10px 15px' })
 }
 
 class ThemePanel extends React.Component {
@@ -50,11 +25,7 @@ class ThemePanel extends React.Component {
     return (
       <div {...styles.panel(this.props)} {...this.props}>
         {Object.values(Theme.names).map(name => (
-          <ThemeButton
-            key={name}
-            name={name}
-            onSelect={this.handleThemeSelect}
-          />
+          <Swatch key={name} name={name} onSelect={this.handleThemeSelect} />
         ))}
       </div>
     )

--- a/packages/storybook-addon-theme/src/theme-panel.js
+++ b/packages/storybook-addon-theme/src/theme-panel.js
@@ -1,28 +1,73 @@
-import Button from '@pluralsight/ps-design-system-button/react'
-import core from '@pluralsight/ps-design-system-core'
+import * as glamor from 'glamor'
 import React from 'react'
+import PropTypes from 'prop-types'
+
 import Theme from '@pluralsight/ps-design-system-theme/react'
 
 const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1)
 
-export default class ThemePanel extends React.Component {
-  handleThemeClick(themeName) {
+const styles = {
+  panel: props => glamor.css({ padding: 15 }),
+  button: props => glamor.css({ marginRight: 10 })
+}
+
+class ThemeButton extends React.Component {
+  constructor (props) {
+    super(props)
+    this.handleClick = this.handleClick.bind(this)
+  }
+
+  handleClick (event) {
+    this.props.onSelect(event, this.props.name)
+  }
+
+  render () {
+    return (
+      <button {...styles.button(this.props)} onClick={this.handleClick}>
+        {capitalize(this.props.name)}
+      </button>
+    )
+  }
+}
+
+ThemeButton.propTypes = {
+  name: PropTypes.oneOf(Object.values(Theme.names)).isRequired,
+  onSelect: PropTypes.func.isRequired
+}
+
+class ThemePanel extends React.Component {
+  constructor (props) {
+    super(props)
+    this.handleThemeSelect = this.handleThemeSelect.bind(this)
+  }
+
+  handleThemeSelect (event, themeName) {
     this.props.channel.emit('theme', themeName)
     this.props.api.setQueryParams({ themeName })
   }
-  render() {
+
+  render () {
     return (
-      <div>
-        {Object.keys(Theme.names).map(name => (
-          <Button
-            style={{ margin: core.layout.spacingSmall }}
-            onClick={this.handleThemeClick.bind(this, name)}
+      <div {...styles.panel(this.props)} {...this.props}>
+        {Object.values(Theme.names).map(name => (
+          <ThemeButton
             key={name}
-          >
-            {capitalize(name)}
-          </Button>
+            name={name}
+            onSelect={this.handleThemeSelect}
+          />
         ))}
       </div>
     )
   }
 }
+
+ThemePanel.propTypes = {
+  api: PropTypes.shape({
+    setQueryParams: PropTypes.func.isRequired
+  }).isRequired,
+  channel: PropTypes.shape({
+    emit: PropTypes.func.isRequired
+  }).isRequired
+}
+
+export default ThemePanel


### PR DESCRIPTION
### What You're Solving

`storybook-addon-theme` depended on the `<Button />` and the `<Button />` depended on `storybook-addon-theme`. This caused a circular dependency

### Design Decisions

- I removed the `<Button />` dependency
- I added a new ui in the theme panel to switch themes - just for fun

<img width="354" alt="screen shot 2018-10-29 at 3 06 02 pm" src="https://user-images.githubusercontent.com/226356/47680452-70d96580-db8c-11e8-8ada-2c07858392b5.png">

