### PR TITLE
Patch/theme refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   "dependencies": {
     "babel-eslint": "^10.0.1",
     "glamor": "^2.20.0",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.2.1",

--- a/packages/actionmenu/package.json
+++ b/packages/actionmenu/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/circularprogress/package.json
+++ b/packages/circularprogress/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "*",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/emptystate/package.json
+++ b/packages/emptystate/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "*",
     "glamor": "^2.x.x",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "*",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/focusmanager/package.json
+++ b/packages/focusmanager/package.json
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "*",
     "glamor": "^2.x.x",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-actionmenu": "^3.2.2",

--- a/packages/halo/package.json
+++ b/packages/halo/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-button": "^10.11.7",

--- a/packages/linearprogress/package.json
+++ b/packages/linearprogress/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "*",
     "glamor": "^2.x.x",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/prop-types/package.json
+++ b/packages/prop-types/package.json
@@ -19,7 +19,7 @@
   },
   "keywords": [],
   "peerDependencies": {
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/row/src/react/index.js
+++ b/packages/row/src/react/index.js
@@ -96,22 +96,19 @@ const ActionBar = props => (
 )
 
 const ActionBarAction = withTheme(
-  class extends React.PureComponent {
-    render() {
-      // eslint-disable-next-line react/prop-types
-      const { icon, ...props } = this.props
-      const filteredProps = filterReactProps(props, {
-        tagName: 'button'
-      })
+  React.forwardRef((props, ref) => {
+    // eslint-disable-next-line react/prop-types
+    const { icon, ...rest } = props
+    const filteredProps = filterReactProps(rest, { tagName: 'button' })
 
-      return (
-        <button {...styles.actionBarAction(props)} {...filteredProps}>
-          {icon}
-        </button>
-      )
-    }
-  }
+    return (
+      <button {...styles.actionBarAction(props)} ref={ref} {...filteredProps}>
+        {icon}
+      </button>
+    )
+  })
 )
+
 ActionBarAction.displayName = 'Row.Action'
 ActionBarAction.propTypes = { icon: PropTypes.element.isRequired }
 

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -69,9 +69,9 @@
     "glamor": "^2.20.0",
     "next": "^4.2.3",
     "prop-types": "^15.5.9",
-    "react": "^16.2.0",
+    "react": "^16.3.0",
     "react-codemirror": "^1.0.0",
-    "react-dom": "^16.2.0",
+    "react-dom": "^16.3.0",
     "react-markdown": "^4.0.0",
     "webpack": "^3.6.0"
   }

--- a/packages/starrating/package.json
+++ b/packages/starrating/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/storybook-addon-center/package.json
+++ b/packages/storybook-addon-center/package.json
@@ -15,7 +15,7 @@
   ],
   "peerDependencies": {
     "@storybook/addons": "^4.0.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/storybook-addon-theme/package.json
+++ b/packages/storybook-addon-theme/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "@storybook/addons": "^4.0.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/textinput/package.json
+++ b/packages/textinput/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/theme/src/react/with-theme.js
+++ b/packages/theme/src/react/with-theme.js
@@ -12,8 +12,7 @@ const getDisplayName = Component => {
   return Component.displayName || Component.name || 'Component'
 }
 
-export default function withTheme(BaseComponent, options = {}) {
-  const { forwardRef = true } = options
+export default function withTheme(BaseComponent) {
   const name = getDisplayName(BaseComponent)
 
   const EnhancedComponent = ({ forwardedRef, ...props }, context) => {
@@ -24,17 +23,11 @@ export default function withTheme(BaseComponent, options = {}) {
   EnhancedComponent.contextTypes = { themeName: PropTypes.string }
   EnhancedComponent.propTypes = { forwardedRef: PropTypes.any }
 
-  if (forwardRef) {
-    const Forwarded = React.forwardRef(function forwardThemeRef(props, ref) {
-      return <EnhancedComponent {...props} forwardedRef={ref} />
-    })
-    Forwarded.BaseComponent = BaseComponent
-    Forwarded.displayName = `withTheme(${name})`
+  const Forwarded = React.forwardRef(function forwardThemeRef(props, ref) {
+    return <EnhancedComponent {...props} forwardedRef={ref} />
+  })
+  Forwarded.BaseComponent = BaseComponent
+  Forwarded.displayName = `withTheme(${name})`
 
-    return hoistNonReactStatics(Forwarded, BaseComponent)
-  }
-
-  EnhancedComponent.BaseComponent = BaseComponent
-  EnhancedComponent.displayName = `withTheme(${name})`
-  return hoistNonReactStatics(EnhancedComponent, BaseComponent)
+  return hoistNonReactStatics(Forwarded, BaseComponent)
 }

--- a/packages/theme/src/react/with-theme.js
+++ b/packages/theme/src/react/with-theme.js
@@ -12,17 +12,29 @@ const getDisplayName = Component => {
   return Component.displayName || Component.name || 'Component'
 }
 
-export default function withTheme(BaseComponent) {
+export default function withTheme(BaseComponent, options = {}) {
+  const { forwardRef = true } = options
   const name = getDisplayName(BaseComponent)
 
-  const EnhancedComponent = (props, context = {}) => {
+  const EnhancedComponent = ({ forwardedRef, ...props }, context) => {
     const themeName = context.themeName || themeDefaultName
-    return <BaseComponent {...props} themeName={themeName} />
+    return <BaseComponent {...props} ref={forwardedRef} themeName={themeName} />
+  }
+
+  EnhancedComponent.contextTypes = { themeName: PropTypes.string }
+  EnhancedComponent.propTypes = { forwardedRef: PropTypes.any }
+
+  if (forwardRef) {
+    const Forwarded = React.forwardRef(function forwardThemeRef(props, ref) {
+      return <EnhancedComponent {...props} forwardedRef={ref} />
+    })
+    Forwarded.BaseComponent = BaseComponent
+    Forwarded.displayName = `withTheme(${name})`
+
+    return hoistNonReactStatics(Forwarded, BaseComponent)
   }
 
   EnhancedComponent.BaseComponent = BaseComponent
-  EnhancedComponent.contextTypes = { themeName: PropTypes.string }
   EnhancedComponent.displayName = `withTheme(${name})`
-
   return hoistNonReactStatics(EnhancedComponent, BaseComponent)
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -18,7 +18,7 @@
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/viewtoggle/package.json
+++ b/packages/viewtoggle/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.0.24",
     "glamor": "^2.20.0",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.9.2",

--- a/scripts/create-component/package-template/package.json
+++ b/scripts/create-component/package-template/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "*",
     "glamor": "^2.x.x",
-    "react": ">=0.15.0 < 17.0.0"
+    "react": ">=0.16.3 < 17.0.0"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "*",


### PR DESCRIPTION
- updates the `withTheme` hoc to properly forward refs
- bumps react version to 16.3 to gain access to `React.forwardRef`

cc @willsoto