### PR TITLE
fix(dialog): remove underlay animation to remove blink

### DIFF
--- a/packages/dialog/src/css/index.js
+++ b/packages/dialog/src/css/index.js
@@ -93,7 +93,7 @@ export default {
     fill: core.colors.gray03
   },
   // __overlay
-  [`.psds-dialog__overlay`]: ({ fade }) => ({
+  [`.psds-dialog__overlay`]: {
     position: 'fixed',
     top: 0,
     left: 0,
@@ -102,10 +102,6 @@ export default {
     backgroundColor: transparentize(0.5, core.colors.black),
     display: 'flex',
     justifyContent: 'center',
-    alignItems: 'center',
-    opacity: 0,
-    animation: `${fade || 'psds-dialog__keyframes__fade'} ${
-      core.motion.speedFast
-    } ease-out forwards`
-  })
+    alignItems: 'center'
+  }
 }

--- a/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -53,7 +53,7 @@ exports[`Storyshots modal no click overlay 1`] = `
       </p>
       <div
         aria-label="Storybook Modal"
-        data-css-17ouz8q=""
+        data-css-1v49ac=""
         id="psds-dialog__overlay"
         onClick={[Function]}
         role="region"
@@ -213,7 +213,7 @@ exports[`Storyshots modal no close button 1`] = `
       </p>
       <div
         aria-label="Storybook Modal"
-        data-css-17ouz8q=""
+        data-css-1v49ac=""
         id="psds-dialog__overlay"
         onClick={[Function]}
         role="region"
@@ -357,7 +357,7 @@ exports[`Storyshots modal no escape key 1`] = `
       </p>
       <div
         aria-label="Storybook Modal"
-        data-css-17ouz8q=""
+        data-css-1v49ac=""
         id="psds-dialog__overlay"
         onClick={[Function]}
         role="region"
@@ -516,7 +516,7 @@ exports[`Storyshots modal no focus on mount 1`] = `
       </p>
       <div
         aria-label="Storybook Modal"
-        data-css-17ouz8q=""
+        data-css-1v49ac=""
         id="psds-dialog__overlay"
         onClick={[Function]}
         role="region"
@@ -732,7 +732,7 @@ exports[`Storyshots modal with close button 1`] = `
       </p>
       <div
         aria-label="Storybook Modal"
-        data-css-17ouz8q=""
+        data-css-1v49ac=""
         id="psds-dialog__overlay"
         onClick={[Function]}
         role="region"

--- a/packages/dialog/src/react/index.js
+++ b/packages/dialog/src/react/index.js
@@ -32,7 +32,7 @@ const styles = {
       ...css[`.psds-dialog__close`],
       '> svg': css[`.psds-dialog__close > svg`]
     }),
-  overlay: _ => glamor.css(css[`.psds-dialog__overlay`]({ fade }))
+  overlay: _ => glamor.css(css[`.psds-dialog__overlay`])
 }
 
 const CloseButton = props => (


### PR DESCRIPTION
Inner elements with transition, such as Switch would cause the entire
Dialog to repaint, but only:

- In Mac (Retina laptop screen only, OK in external monitor on same
computer)
- In Chrome/Brave (Chromium)

Fixes #473