### PR TITLE
fix(row): issues with safari and matchmedia

### DIFF
--- a/packages/row/src/react/index.js
+++ b/packages/row/src/react/index.js
@@ -376,7 +376,7 @@ renderProgress.propTypes = {
 // NOTE: the `title` prop clashes with a native html attr so we're exclude it
 //       from being mistakenly used in any child component
 const Row = ({ title, titleTruncated, ...props }) => {
-  const isDesktop = useMatchMedia('(min-width: 769px)')
+  const isDesktop = useMatchMedia('screen and (min-width: 769px)')
   if (!props.size) props.size = isDesktop ? vars.sizes.medium : vars.sizes.small
 
   return (

--- a/packages/row/src/react/use-match-media.js
+++ b/packages/row/src/react/use-match-media.js
@@ -11,10 +11,10 @@ export default function useMatchMedia(query) {
 
     update()
 
-    window.matchMedia(query).addEventListener('change', update)
+    window.matchMedia(query).addListener(update)
 
     return () => {
-      window.matchMedia(query).removeEventListener('change', update)
+      window.matchMedia(query).removeListener(update)
     }
   }, [query])
 


### PR DESCRIPTION
safari needs the `screen` keyword in the media query. it also doesn't support `addEventListener` on the `MediaQueryList` so i fell back to the more widely supported `addListener`