### PR TITLE
prop-types: workaround circular json error

### DIFF
--- a/packages/prop-types/src/__specs__/element-of-type.spec.js
+++ b/packages/prop-types/src/__specs__/element-of-type.spec.js
@@ -22,6 +22,19 @@ describe('elementOfType', () => {
     )
   })
 
+  it('should not throw error when expected element is a circular json', () => {
+    const fn = elementOfType(Uno)
+
+    const circularJSON = { outter: { inner: null } }
+    circularJSON.outter.inner = circularJSON.outter
+
+    const props = { [PROP_NAME]: circularJSON }
+
+    expect(() => {
+      fn(props, PROP_NAME, COMPONENT_NAME, PROP_LOCATION)
+    }).not.toThrow()
+  })
+
   it('should warn when expected element is of the wrong type', () => {
     const fn = elementOfType(Uno)
 

--- a/packages/prop-types/src/element-of-type.js
+++ b/packages/prop-types/src/element-of-type.js
@@ -3,7 +3,11 @@
 //       https://github.com/wzrdzl/react-element-proptypes
 
 import PropTypeError from './prop-type-error'
-import { createChainableTypeChecker, getDisplayName } from './utils'
+import {
+  createChainableTypeChecker,
+  getDisplayName,
+  getCircularReplacer
+} from './utils'
 
 export default function elementOfType(ExpectedElementType) {
   function validate(props, propName, componentName, location, propFullName) {
@@ -17,7 +21,7 @@ export default function elementOfType(ExpectedElementType) {
 
       if (!hasComponentType) {
         // prettier-ignore
-        const msg = `Invalid ${location} \`${propFullName}\` with value \`${JSON.stringify(prop)}\` supplied to ${componentName}, expected element of type \`${expectedTypeName}\``
+        const msg = `Invalid ${location} \`${propFullName}\` with value \`${JSON.stringify(prop, getCircularReplacer())}\` supplied to ${componentName}, expected element of type \`${expectedTypeName}\``
         return new PropTypeError(msg)
       }
 

--- a/packages/prop-types/src/utils/index.js
+++ b/packages/prop-types/src/utils/index.js
@@ -39,3 +39,18 @@ export const getDisplayName = Component => {
 }
 
 export const isNil = value => value == null
+
+// NOTE: example from MDN docs
+//       https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#Examples
+export const getCircularReplacer = () => {
+  const seen = new WeakSet()
+  return (key, value) => {
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) {
+        return
+      }
+      seen.add(value)
+    }
+    return value
+  }
+}


### PR DESCRIPTION
### What You're Solving

When the validator receives a prop that happens to be a circular json, JSON.stringify will throw an error, and as stated on prop-types docs you can't throw inside a PropTypes.oneOf validator.

It happened to me while using `ActionMenu` with multiple `ActionMenu.Item`, the children was an array of elements and failed on stringify due to a circular json.
In my specific case, the `PropTypes.oneOf` will validate as ok if the stringify don't throw.

### Design Decisions

Probably the message `with value ${JSON.stringify(...)}` is not that pretty for this circular json situation (you can test it by passing multiple ActionMenu.Item and a non ActionMenu.Item to an ActionMenu).

Another approach is to try-catch the `JSON.stringify` but I don't know how the `with value xxx` message should look like in this case.

### How to Verify

Render an `ActionMenu` with more than one `ActionMenu.Item` on a page.





