### PR TITLE
fix(textinput): [ie11] vert center icon

### DIFF
--- a/packages/breadcrumb/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/breadcrumb/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -8,7 +8,7 @@ exports[`Storyshots as link hrefs 1`] = `
     data-css-nipl9k=""
   >
     <a
-      data-css-1zmsb0=""
+      data-css-rrt0ya=""
       disabled={false}
       href="https://duckduckgo.com"
       style={Object {}}
@@ -49,7 +49,7 @@ exports[`Storyshots disabled disabled 1`] = `
     data-css-nipl9k=""
   >
     <button
-      data-css-o6hii6=""
+      data-css-stgcyf=""
       disabled={true}
       onClick={[Function]}
       style={Object {}}
@@ -90,7 +90,7 @@ exports[`Storyshots normal looks great 1`] = `
     data-css-nipl9k=""
   >
     <button
-      data-css-1zmsb0=""
+      data-css-rrt0ya=""
       disabled={false}
       style={Object {}}
     >
@@ -130,7 +130,7 @@ exports[`Storyshots with onClick clicks once 1`] = `
     data-css-nipl9k=""
   >
     <button
-      data-css-1zmsb0=""
+      data-css-rrt0ya=""
       disabled={false}
       onClick={[Function]}
       style={Object {}}

--- a/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -29,7 +29,7 @@ exports[`Storyshots modal no click overlay 1`] = `
         Sesame snaps cake pudding I love chupa chups I love. Cotton candy biscuit oat cake dessert donut I love lemon drops. Cookie croissant dragée tootsie roll marzipan I love. Apple pie cheesecake jelly-o cheesecake I love cheesecake.
       </p>
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         onClick={[Function]}
         style={Object {}}
@@ -123,7 +123,7 @@ exports[`Storyshots modal no click overlay 1`] = `
               }
             >
               <button
-                data-css-r0o8hq=""
+                data-css-1q6fyq5=""
                 disabled={false}
                 style={Object {}}
               >
@@ -141,7 +141,7 @@ exports[`Storyshots modal no click overlay 1`] = `
                 }
               />
               <button
-                data-css-k922kt=""
+                data-css-1srt63x=""
                 disabled={false}
                 style={Object {}}
               >
@@ -189,7 +189,7 @@ exports[`Storyshots modal no close button 1`] = `
         Sesame snaps cake pudding I love chupa chups I love. Cotton candy biscuit oat cake dessert donut I love lemon drops. Cookie croissant dragée tootsie roll marzipan I love. Apple pie cheesecake jelly-o cheesecake I love cheesecake.
       </p>
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         onClick={[Function]}
         style={Object {}}
@@ -267,7 +267,7 @@ exports[`Storyshots modal no close button 1`] = `
               }
             >
               <button
-                data-css-r0o8hq=""
+                data-css-1q6fyq5=""
                 disabled={false}
                 style={Object {}}
               >
@@ -285,7 +285,7 @@ exports[`Storyshots modal no close button 1`] = `
                 }
               />
               <button
-                data-css-k922kt=""
+                data-css-1srt63x=""
                 disabled={false}
                 style={Object {}}
               >
@@ -333,7 +333,7 @@ exports[`Storyshots modal no escape key 1`] = `
         Sesame snaps cake pudding I love chupa chups I love. Cotton candy biscuit oat cake dessert donut I love lemon drops. Cookie croissant dragée tootsie roll marzipan I love. Apple pie cheesecake jelly-o cheesecake I love cheesecake.
       </p>
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         onClick={[Function]}
         style={Object {}}
@@ -426,7 +426,7 @@ exports[`Storyshots modal no escape key 1`] = `
               }
             >
               <button
-                data-css-r0o8hq=""
+                data-css-1q6fyq5=""
                 disabled={false}
                 style={Object {}}
               >
@@ -444,7 +444,7 @@ exports[`Storyshots modal no escape key 1`] = `
                 }
               />
               <button
-                data-css-k922kt=""
+                data-css-1srt63x=""
                 disabled={false}
                 style={Object {}}
               >
@@ -492,7 +492,7 @@ exports[`Storyshots modal no focus on mount 1`] = `
         Sesame snaps cake pudding I love chupa chups I love. Cotton candy biscuit oat cake dessert donut I love lemon drops. Cookie croissant dragée tootsie roll marzipan I love. Apple pie cheesecake jelly-o cheesecake I love cheesecake.
       </p>
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         onClick={[Function]}
         style={Object {}}
@@ -586,7 +586,7 @@ exports[`Storyshots modal no focus on mount 1`] = `
               }
             >
               <button
-                data-css-r0o8hq=""
+                data-css-1q6fyq5=""
                 disabled={false}
                 style={Object {}}
               >
@@ -604,7 +604,7 @@ exports[`Storyshots modal no focus on mount 1`] = `
                 }
               />
               <button
-                data-css-k922kt=""
+                data-css-1srt63x=""
                 disabled={false}
                 style={Object {}}
               >
@@ -652,7 +652,7 @@ exports[`Storyshots modal no focusable child element, no lock 1`] = `
         Sesame snaps cake pudding I love chupa chups I love. Cotton candy biscuit oat cake dessert donut I love lemon drops. Cookie croissant dragée tootsie roll marzipan I love. Apple pie cheesecake jelly-o cheesecake I love cheesecake.
       </p>
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         onClick={[Function]}
         style={Object {}}
@@ -708,7 +708,7 @@ exports[`Storyshots modal with close button 1`] = `
         Sesame snaps cake pudding I love chupa chups I love. Cotton candy biscuit oat cake dessert donut I love lemon drops. Cookie croissant dragée tootsie roll marzipan I love. Apple pie cheesecake jelly-o cheesecake I love cheesecake.
       </p>
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         onClick={[Function]}
         style={Object {}}
@@ -802,7 +802,7 @@ exports[`Storyshots modal with close button 1`] = `
               }
             >
               <button
-                data-css-r0o8hq=""
+                data-css-1q6fyq5=""
                 disabled={false}
                 style={Object {}}
               >
@@ -820,7 +820,7 @@ exports[`Storyshots modal with close button 1`] = `
                 }
               />
               <button
-                data-css-k922kt=""
+                data-css-1srt63x=""
                 disabled={false}
                 style={Object {}}
               >
@@ -915,7 +915,7 @@ exports[`Storyshots onClose with onClose 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -933,7 +933,7 @@ exports[`Storyshots onClose with onClose 1`] = `
             }
           />
           <button
-            data-css-k922kt=""
+            data-css-1srt63x=""
             disabled={false}
             style={Object {}}
           >
@@ -1009,7 +1009,7 @@ exports[`Storyshots tailPosition bottomCenter 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -1027,7 +1027,7 @@ exports[`Storyshots tailPosition bottomCenter 1`] = `
             }
           />
           <button
-            data-css-k922kt=""
+            data-css-1srt63x=""
             disabled={false}
             style={Object {}}
           >
@@ -1103,7 +1103,7 @@ exports[`Storyshots tailPosition bottomLeft 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -1121,7 +1121,7 @@ exports[`Storyshots tailPosition bottomLeft 1`] = `
             }
           />
           <button
-            data-css-k922kt=""
+            data-css-1srt63x=""
             disabled={false}
             style={Object {}}
           >
@@ -1197,7 +1197,7 @@ exports[`Storyshots tailPosition bottomRight 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -1215,7 +1215,7 @@ exports[`Storyshots tailPosition bottomRight 1`] = `
             }
           />
           <button
-            data-css-k922kt=""
+            data-css-1srt63x=""
             disabled={false}
             style={Object {}}
           >
@@ -1291,7 +1291,7 @@ exports[`Storyshots tailPosition none 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -1309,7 +1309,7 @@ exports[`Storyshots tailPosition none 1`] = `
             }
           />
           <button
-            data-css-k922kt=""
+            data-css-1srt63x=""
             disabled={false}
             style={Object {}}
           >
@@ -1385,7 +1385,7 @@ exports[`Storyshots tailPosition topCenter 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -1403,7 +1403,7 @@ exports[`Storyshots tailPosition topCenter 1`] = `
             }
           />
           <button
-            data-css-k922kt=""
+            data-css-1srt63x=""
             disabled={false}
             style={Object {}}
           >
@@ -1479,7 +1479,7 @@ exports[`Storyshots tailPosition topLeft 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -1497,7 +1497,7 @@ exports[`Storyshots tailPosition topLeft 1`] = `
             }
           />
           <button
-            data-css-k922kt=""
+            data-css-1srt63x=""
             disabled={false}
             style={Object {}}
           >
@@ -1573,7 +1573,7 @@ exports[`Storyshots tailPosition topRight 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -1591,7 +1591,7 @@ exports[`Storyshots tailPosition topRight 1`] = `
             }
           />
           <button
-            data-css-k922kt=""
+            data-css-1srt63x=""
             disabled={false}
             style={Object {}}
           >

--- a/packages/drawer/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/drawer/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -10,7 +10,7 @@ exports[`Storyshots drawer controlled 1`] = `
 >
   <div>
     <button
-      data-css-k922kt=""
+      data-css-1srt63x=""
       disabled={false}
       onClick={[Function]}
       style={Object {}}

--- a/packages/emptystate/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/emptystate/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -78,7 +78,7 @@ exports[`Storyshots EmptyState combo 1`] = `
       data-css-aelvpu=""
     >
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         style={Object {}}
       >
@@ -178,7 +178,7 @@ exports[`Storyshots EmptyState in a small fixed size container 1`] = `
         data-css-aelvpu=""
       >
         <button
-          data-css-k922kt=""
+          data-css-1srt63x=""
           disabled={false}
           style={Object {}}
         >
@@ -287,7 +287,7 @@ exports[`Storyshots EmptyState/actions with an input 1`] = `
             />
           </div>
           <div
-            data-css-hgugth=""
+            data-css-1x5ndtu=""
           >
             <div
               data-css-otejxm=""
@@ -406,7 +406,7 @@ exports[`Storyshots EmptyState/actions with buttons 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -426,7 +426,7 @@ exports[`Storyshots EmptyState/actions with buttons 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -446,7 +446,7 @@ exports[`Storyshots EmptyState/actions with buttons 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -466,7 +466,7 @@ exports[`Storyshots EmptyState/actions with buttons 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -486,7 +486,7 @@ exports[`Storyshots EmptyState/actions with buttons 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -506,7 +506,7 @@ exports[`Storyshots EmptyState/actions with buttons 1`] = `
           }
         >
           <button
-            data-css-r0o8hq=""
+            data-css-1q6fyq5=""
             disabled={false}
             style={Object {}}
           >
@@ -1980,7 +1980,7 @@ exports[`Storyshots EmptyState/sizes large 1`] = `
     data-css-aelvpu=""
   >
     <button
-      data-css-k922kt=""
+      data-css-1srt63x=""
       disabled={false}
       style={Object {}}
     >
@@ -2063,7 +2063,7 @@ exports[`Storyshots EmptyState/sizes small 1`] = `
     data-css-aelvpu=""
   >
     <button
-      data-css-k922kt=""
+      data-css-1srt63x=""
       disabled={false}
       style={Object {}}
     >

--- a/packages/emptystate/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/emptystate/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -287,7 +287,7 @@ exports[`Storyshots EmptyState/actions with an input 1`] = `
             />
           </div>
           <div
-            data-css-1x5ndtu=""
+            data-css-hgugth=""
           >
             <div
               data-css-otejxm=""

--- a/packages/emptystate/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/emptystate/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -287,7 +287,7 @@ exports[`Storyshots EmptyState/actions with an input 1`] = `
             />
           </div>
           <div
-            data-css-hgugth=""
+            data-css-1x5ndtu=""
           >
             <div
               data-css-otejxm=""

--- a/packages/errors/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/errors/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -49,7 +49,7 @@ exports[`Storyshots pages 403 1`] = `
       </h2>
     </div>
     <a
-      data-css-k922kt=""
+      data-css-1srt63x=""
       disabled={false}
       href="https://help.pluralsight.com/help/contact-us"
       style={Object {}}
@@ -191,7 +191,7 @@ exports[`Storyshots pages 500 1`] = `
       </h2>
     </div>
     <a
-      data-css-k922kt=""
+      data-css-1srt63x=""
       disabled={false}
       href="https://help.pluralsight.com/help/contact-us"
       style={Object {}}

--- a/packages/form/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/form/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -641,7 +641,7 @@ exports[`Storyshots Sample Form sample 1`] = `
               data-css-7d5932=""
             >
               <button
-                data-css-k922kt=""
+                data-css-1srt63x=""
                 disabled={false}
                 style={Object {}}
               >
@@ -656,7 +656,7 @@ exports[`Storyshots Sample Form sample 1`] = `
               data-css-7d5932=""
             >
               <button
-                data-css-1aqsr4g=""
+                data-css-mtq3v8=""
                 disabled={false}
                 style={Object {}}
               >

--- a/packages/layout/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/layout/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -578,7 +578,7 @@ exports[`Storyshots Layout / PageHeadingLayout long title w/ actions 1`] = `
       data-css-1cnar9w=""
     >
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         style={Object {}}
       >
@@ -617,7 +617,7 @@ exports[`Storyshots Layout / PageHeadingLayout long titlew/ lots of actions 1`] 
       data-css-1cnar9w=""
     >
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         style={Object {}}
       >
@@ -634,7 +634,7 @@ exports[`Storyshots Layout / PageHeadingLayout long titlew/ lots of actions 1`] 
         A link
       </a>
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         style={Object {}}
       >
@@ -651,7 +651,7 @@ exports[`Storyshots Layout / PageHeadingLayout long titlew/ lots of actions 1`] 
         A link
       </a>
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         style={Object {}}
       >
@@ -668,7 +668,7 @@ exports[`Storyshots Layout / PageHeadingLayout long titlew/ lots of actions 1`] 
         A link
       </a>
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         style={Object {}}
       >
@@ -707,7 +707,7 @@ exports[`Storyshots Layout / PageHeadingLayout w/ actions 1`] = `
       data-css-1cnar9w=""
     >
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         style={Object {}}
       >
@@ -746,7 +746,7 @@ exports[`Storyshots Layout / PageHeadingLayout w/ lots of actions 1`] = `
       data-css-1cnar9w=""
     >
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         style={Object {}}
       >
@@ -763,7 +763,7 @@ exports[`Storyshots Layout / PageHeadingLayout w/ lots of actions 1`] = `
         A link
       </a>
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         style={Object {}}
       >
@@ -780,7 +780,7 @@ exports[`Storyshots Layout / PageHeadingLayout w/ lots of actions 1`] = `
         A link
       </a>
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         style={Object {}}
       >
@@ -797,7 +797,7 @@ exports[`Storyshots Layout / PageHeadingLayout w/ lots of actions 1`] = `
         A link
       </a>
       <button
-        data-css-k922kt=""
+        data-css-1srt63x=""
         disabled={false}
         style={Object {}}
       >

--- a/packages/textinput/src/css/index.js
+++ b/packages/textinput/src/css/index.js
@@ -68,6 +68,8 @@ export default {
   '.psds-text-input__icon': {
     position: 'absolute',
     left: core.layout.spacingXSmall,
+    top: '50%',
+    transform: 'translateY(-50%)',
     display: 'flex',
     alignItems: 'center',
     color: core.colors.gray03

--- a/packages/textinput/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/textinput/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -81,7 +81,7 @@ exports[`Storyshots appearance default w/ iconAlign left 1`] = `
           />
         </div>
         <div
-          data-css-1w67sw9=""
+          data-css-yntvgr=""
         >
           <div
             data-css-otejxm=""
@@ -131,7 +131,7 @@ exports[`Storyshots appearance default w/ iconAlign right 1`] = `
           />
         </div>
         <div
-          data-css-121dxw3=""
+          data-css-3rd0lv=""
         >
           <div
             data-css-otejxm=""
@@ -235,7 +235,7 @@ exports[`Storyshots appearance subtle w/ iconAlign left 1`] = `
           />
         </div>
         <div
-          data-css-1x5ndtu=""
+          data-css-hgugth=""
         >
           <div
             data-css-otejxm=""
@@ -285,7 +285,7 @@ exports[`Storyshots appearance subtle w/ iconAlign right 1`] = `
           />
         </div>
         <div
-          data-css-13qmv6x=""
+          data-css-y2nw0k=""
         >
           <div
             data-css-otejxm=""
@@ -912,7 +912,7 @@ exports[`Storyshots layouts right-aligned 1`] = `
               />
             </div>
             <div
-              data-css-1x5ndtu=""
+              data-css-hgugth=""
             >
               <div
                 data-css-otejxm=""

--- a/packages/textinput/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/textinput/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -81,7 +81,7 @@ exports[`Storyshots appearance default w/ iconAlign left 1`] = `
           />
         </div>
         <div
-          data-css-yntvgr=""
+          data-css-1w67sw9=""
         >
           <div
             data-css-otejxm=""
@@ -131,7 +131,7 @@ exports[`Storyshots appearance default w/ iconAlign right 1`] = `
           />
         </div>
         <div
-          data-css-3rd0lv=""
+          data-css-121dxw3=""
         >
           <div
             data-css-otejxm=""
@@ -235,7 +235,7 @@ exports[`Storyshots appearance subtle w/ iconAlign left 1`] = `
           />
         </div>
         <div
-          data-css-hgugth=""
+          data-css-1x5ndtu=""
         >
           <div
             data-css-otejxm=""
@@ -285,7 +285,7 @@ exports[`Storyshots appearance subtle w/ iconAlign right 1`] = `
           />
         </div>
         <div
-          data-css-y2nw0k=""
+          data-css-13qmv6x=""
         >
           <div
             data-css-otejxm=""
@@ -912,7 +912,7 @@ exports[`Storyshots layouts right-aligned 1`] = `
               />
             </div>
             <div
-              data-css-hgugth=""
+              data-css-1x5ndtu=""
             >
               <div
                 data-css-otejxm=""


### PR DESCRIPTION
Fixes: #457

Apparently IE needs to know the vert positioning for position: absolute
element.  The other browsers seemed to do fine with just align-items:
center on the flex container