### PR TITLE
fix(radio): [ie11] dont collapse margin on label

### DIFF
--- a/packages/form/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/form/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -478,15 +478,20 @@ exports[`Storyshots Sample Form sample 1`] = `
                 onClick={[Function]}
               >
                 <div
-                  data-css-480533=""
+                  data-css-1gbdc34=""
                 >
                   <div
-                    aria-checked={false}
-                    data-css-dbvyuf=""
-                    onFocus={[Function]}
-                    role="radio"
-                    tabIndex="-1"
-                  />
+                    data-css-480533=""
+                    data-css-iwspcj=""
+                  >
+                    <div
+                      aria-checked={false}
+                      data-css-dbvyuf=""
+                      onFocus={[Function]}
+                      role="radio"
+                      tabIndex="-1"
+                    />
+                  </div>
                 </div>
                 <input
                   checked={false}
@@ -497,7 +502,7 @@ exports[`Storyshots Sample Form sample 1`] = `
                   value="full"
                 />
                 <div
-                  data-css-pgc406=""
+                  data-css-cgsoeo=""
                 >
                   Full-time employement
                 </div>
@@ -511,15 +516,20 @@ exports[`Storyshots Sample Form sample 1`] = `
                 onClick={[Function]}
               >
                 <div
-                  data-css-480533=""
+                  data-css-1gbdc34=""
                 >
                   <div
-                    aria-checked={false}
-                    data-css-dbvyuf=""
-                    onFocus={[Function]}
-                    role="radio"
-                    tabIndex="-1"
-                  />
+                    data-css-480533=""
+                    data-css-iwspcj=""
+                  >
+                    <div
+                      aria-checked={false}
+                      data-css-dbvyuf=""
+                      onFocus={[Function]}
+                      role="radio"
+                      tabIndex="-1"
+                    />
+                  </div>
                 </div>
                 <input
                   checked={false}
@@ -530,7 +540,7 @@ exports[`Storyshots Sample Form sample 1`] = `
                   value="part"
                 />
                 <div
-                  data-css-pgc406=""
+                  data-css-cgsoeo=""
                 >
                   Part-time employement
                 </div>

--- a/packages/radio/src/css/index.js
+++ b/packages/radio/src/css/index.js
@@ -14,12 +14,19 @@ export default {
   },
 
   '.psds-radio-button': {
+    display: 'flex',
+    alignItems: 'center',
     padding: `${core.layout.spacingXXSmall} 0`,
     cursor: 'pointer'
   },
 
   '.psds-radio-button__halo': {
     transform: 'translateY(3px)'
+  },
+
+  '.psds-radio-button__circle-outer': {
+    width: '16px',
+    marginRight: core.layout.spacingSmall
   },
 
   '.psds-radio-button__circle': {
@@ -56,8 +63,6 @@ export default {
   },
 
   '.psds-radio-button__label': {
-    display: 'inline-block',
-    marginLeft: core.layout.spacingSmall,
     color: core.colors.bone,
     fontSize: core.type.fontSizeSmall,
     lineHeight: core.type.lineHeightStandard,

--- a/packages/radio/src/css/index.js
+++ b/packages/radio/src/css/index.js
@@ -2,8 +2,6 @@ import core from '@pluralsight/ps-design-system-core'
 import { names as themeNames } from '@pluralsight/ps-design-system-theme/vars'
 
 export default {
-  // group
-
   '.psds-radio-group:focus': {
     outline: 'none'
   },
@@ -11,20 +9,19 @@ export default {
     opacity: '0.5'
   },
 
-  // __button-container
   '.psds-radio-group__button-container': {
     padding: `${core.layout.spacingXXSmall} 0`
   },
 
-  // button
   '.psds-radio-button': {
-    display: 'flex',
-    alignItems: 'center',
     padding: `${core.layout.spacingXXSmall} 0`,
     cursor: 'pointer'
   },
 
-  // __circle
+  '.psds-radio-button__halo': {
+    transform: 'translateY(3px)'
+  },
+
   '.psds-radio-button__circle': {
     position: 'relative',
     display: 'inline-block',
@@ -45,7 +42,6 @@ export default {
     borderColor: core.colors.blue
   },
 
-  // __circle-inner
   '.psds-radio-button__circle-inner': {
     display: 'block',
     height: 'calc(100% - 4px)',
@@ -55,13 +51,12 @@ export default {
     background: core.colors.blue
   },
 
-  // __input
   '.psds-radio-button__input': {
     display: 'none'
   },
 
-  // __label
   '.psds-radio-button__label': {
+    display: 'inline-block',
     marginLeft: core.layout.spacingSmall,
     color: core.colors.bone,
     fontSize: core.type.fontSizeSmall,

--- a/packages/radio/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/radio/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -22,20 +22,24 @@ exports[`Storyshots Radio default 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={[Function]}
         >
           <div
-            data-css-480533=""
-            data-css-iwspcj=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={false}
-              data-css-dbvyuf=""
-              onFocus={[Function]}
-              role="radio"
-              tabIndex="-1"
-            />
+              data-css-480533=""
+              data-css-iwspcj=""
+            >
+              <div
+                aria-checked={false}
+                data-css-dbvyuf=""
+                onFocus={[Function]}
+                role="radio"
+                tabIndex="-1"
+              />
+            </div>
           </div>
           <input
             checked={false}
@@ -46,7 +50,7 @@ exports[`Storyshots Radio default 1`] = `
             value="red"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Red
           </div>
@@ -56,20 +60,24 @@ exports[`Storyshots Radio default 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={[Function]}
         >
           <div
-            data-css-480533=""
-            data-css-iwspcj=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={false}
-              data-css-dbvyuf=""
-              onFocus={[Function]}
-              role="radio"
-              tabIndex="-1"
-            />
+              data-css-480533=""
+              data-css-iwspcj=""
+            >
+              <div
+                aria-checked={false}
+                data-css-dbvyuf=""
+                onFocus={[Function]}
+                role="radio"
+                tabIndex="-1"
+              />
+            </div>
           </div>
           <input
             checked={false}
@@ -80,7 +88,7 @@ exports[`Storyshots Radio default 1`] = `
             value="green"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Green
           </div>
@@ -90,20 +98,24 @@ exports[`Storyshots Radio default 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={[Function]}
         >
           <div
-            data-css-480533=""
-            data-css-iwspcj=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={false}
-              data-css-dbvyuf=""
-              onFocus={[Function]}
-              role="radio"
-              tabIndex="-1"
-            />
+              data-css-480533=""
+              data-css-iwspcj=""
+            >
+              <div
+                aria-checked={false}
+                data-css-dbvyuf=""
+                onFocus={[Function]}
+                role="radio"
+                tabIndex="-1"
+              />
+            </div>
           </div>
           <input
             checked={false}
@@ -114,7 +126,7 @@ exports[`Storyshots Radio default 1`] = `
             value="blue"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Blue
           </div>
@@ -147,20 +159,24 @@ exports[`Storyshots Radio disabled & error 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={null}
         >
           <div
-            data-css-8x851q=""
-            data-css-iwspcj=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={false}
-              data-css-dbvyuf=""
-              onFocus={null}
-              role="radio"
-              tabIndex="-1"
-            />
+              data-css-8x851q=""
+              data-css-iwspcj=""
+            >
+              <div
+                aria-checked={false}
+                data-css-dbvyuf=""
+                onFocus={null}
+                role="radio"
+                tabIndex="-1"
+              />
+            </div>
           </div>
           <input
             checked={false}
@@ -171,7 +187,7 @@ exports[`Storyshots Radio disabled & error 1`] = `
             value="red"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Red
           </div>
@@ -181,23 +197,27 @@ exports[`Storyshots Radio disabled & error 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={null}
         >
           <div
-            data-css-8x851q=""
-            data-css-iwspcj=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={true}
-              data-css-4a14oy=""
-              onFocus={null}
-              role="radio"
-              tabIndex="-1"
+              data-css-8x851q=""
+              data-css-iwspcj=""
             >
               <div
-                data-css-16yi4o9=""
-              />
+                aria-checked={true}
+                data-css-4a14oy=""
+                onFocus={null}
+                role="radio"
+                tabIndex="-1"
+              >
+                <div
+                  data-css-16yi4o9=""
+                />
+              </div>
             </div>
           </div>
           <input
@@ -209,7 +229,7 @@ exports[`Storyshots Radio disabled & error 1`] = `
             value="green"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Green
           </div>
@@ -219,20 +239,24 @@ exports[`Storyshots Radio disabled & error 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={null}
         >
           <div
-            data-css-8x851q=""
-            data-css-iwspcj=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={false}
-              data-css-dbvyuf=""
-              onFocus={null}
-              role="radio"
-              tabIndex="-1"
-            />
+              data-css-8x851q=""
+              data-css-iwspcj=""
+            >
+              <div
+                aria-checked={false}
+                data-css-dbvyuf=""
+                onFocus={null}
+                role="radio"
+                tabIndex="-1"
+              />
+            </div>
           </div>
           <input
             checked={false}
@@ -243,7 +267,7 @@ exports[`Storyshots Radio disabled & error 1`] = `
             value="blue"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Blue
           </div>
@@ -276,20 +300,24 @@ exports[`Storyshots Radio disabled 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={null}
         >
           <div
-            data-css-iwspcj=""
-            data-css-jg1k2y=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={false}
-              data-css-dbvyuf=""
-              onFocus={null}
-              role="radio"
-              tabIndex="-1"
-            />
+              data-css-iwspcj=""
+              data-css-jg1k2y=""
+            >
+              <div
+                aria-checked={false}
+                data-css-dbvyuf=""
+                onFocus={null}
+                role="radio"
+                tabIndex="-1"
+              />
+            </div>
           </div>
           <input
             checked={false}
@@ -300,7 +328,7 @@ exports[`Storyshots Radio disabled 1`] = `
             value="red"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Red
           </div>
@@ -310,23 +338,27 @@ exports[`Storyshots Radio disabled 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={null}
         >
           <div
-            data-css-iwspcj=""
-            data-css-jg1k2y=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={true}
-              data-css-4a14oy=""
-              onFocus={null}
-              role="radio"
-              tabIndex="-1"
+              data-css-iwspcj=""
+              data-css-jg1k2y=""
             >
               <div
-                data-css-16yi4o9=""
-              />
+                aria-checked={true}
+                data-css-4a14oy=""
+                onFocus={null}
+                role="radio"
+                tabIndex="-1"
+              >
+                <div
+                  data-css-16yi4o9=""
+                />
+              </div>
             </div>
           </div>
           <input
@@ -338,7 +370,7 @@ exports[`Storyshots Radio disabled 1`] = `
             value="green"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Green
           </div>
@@ -348,20 +380,24 @@ exports[`Storyshots Radio disabled 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={null}
         >
           <div
-            data-css-iwspcj=""
-            data-css-jg1k2y=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={false}
-              data-css-dbvyuf=""
-              onFocus={null}
-              role="radio"
-              tabIndex="-1"
-            />
+              data-css-iwspcj=""
+              data-css-jg1k2y=""
+            >
+              <div
+                aria-checked={false}
+                data-css-dbvyuf=""
+                onFocus={null}
+                role="radio"
+                tabIndex="-1"
+              />
+            </div>
           </div>
           <input
             checked={false}
@@ -372,7 +408,7 @@ exports[`Storyshots Radio disabled 1`] = `
             value="blue"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Blue
           </div>
@@ -405,20 +441,24 @@ exports[`Storyshots Radio error 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={[Function]}
         >
           <div
-            data-css-11lyqbs=""
-            data-css-iwspcj=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={false}
-              data-css-dbvyuf=""
-              onFocus={[Function]}
-              role="radio"
-              tabIndex="-1"
-            />
+              data-css-11lyqbs=""
+              data-css-iwspcj=""
+            >
+              <div
+                aria-checked={false}
+                data-css-dbvyuf=""
+                onFocus={[Function]}
+                role="radio"
+                tabIndex="-1"
+              />
+            </div>
           </div>
           <input
             checked={false}
@@ -429,7 +469,7 @@ exports[`Storyshots Radio error 1`] = `
             value="red"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Red
           </div>
@@ -439,23 +479,27 @@ exports[`Storyshots Radio error 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={[Function]}
         >
           <div
-            data-css-11lyqbs=""
-            data-css-iwspcj=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={true}
-              data-css-4a14oy=""
-              onFocus={[Function]}
-              role="radio"
-              tabIndex="-1"
+              data-css-11lyqbs=""
+              data-css-iwspcj=""
             >
               <div
-                data-css-16yi4o9=""
-              />
+                aria-checked={true}
+                data-css-4a14oy=""
+                onFocus={[Function]}
+                role="radio"
+                tabIndex="-1"
+              >
+                <div
+                  data-css-16yi4o9=""
+                />
+              </div>
             </div>
           </div>
           <input
@@ -467,7 +511,7 @@ exports[`Storyshots Radio error 1`] = `
             value="green"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Green
           </div>
@@ -477,20 +521,24 @@ exports[`Storyshots Radio error 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={[Function]}
         >
           <div
-            data-css-11lyqbs=""
-            data-css-iwspcj=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={false}
-              data-css-dbvyuf=""
-              onFocus={[Function]}
-              role="radio"
-              tabIndex="-1"
-            />
+              data-css-11lyqbs=""
+              data-css-iwspcj=""
+            >
+              <div
+                aria-checked={false}
+                data-css-dbvyuf=""
+                onFocus={[Function]}
+                role="radio"
+                tabIndex="-1"
+              />
+            </div>
           </div>
           <input
             checked={false}
@@ -501,7 +549,7 @@ exports[`Storyshots Radio error 1`] = `
             value="blue"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Blue
           </div>
@@ -534,20 +582,24 @@ exports[`Storyshots Radio one selected 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={[Function]}
         >
           <div
-            data-css-480533=""
-            data-css-iwspcj=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={false}
-              data-css-dbvyuf=""
-              onFocus={[Function]}
-              role="radio"
-              tabIndex="-1"
-            />
+              data-css-480533=""
+              data-css-iwspcj=""
+            >
+              <div
+                aria-checked={false}
+                data-css-dbvyuf=""
+                onFocus={[Function]}
+                role="radio"
+                tabIndex="-1"
+              />
+            </div>
           </div>
           <input
             checked={false}
@@ -558,7 +610,7 @@ exports[`Storyshots Radio one selected 1`] = `
             value="red"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Red
           </div>
@@ -568,23 +620,27 @@ exports[`Storyshots Radio one selected 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={[Function]}
         >
           <div
-            data-css-480533=""
-            data-css-iwspcj=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={true}
-              data-css-4a14oy=""
-              onFocus={[Function]}
-              role="radio"
-              tabIndex="-1"
+              data-css-480533=""
+              data-css-iwspcj=""
             >
               <div
-                data-css-16yi4o9=""
-              />
+                aria-checked={true}
+                data-css-4a14oy=""
+                onFocus={[Function]}
+                role="radio"
+                tabIndex="-1"
+              >
+                <div
+                  data-css-16yi4o9=""
+                />
+              </div>
             </div>
           </div>
           <input
@@ -596,7 +652,7 @@ exports[`Storyshots Radio one selected 1`] = `
             value="green"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Green
           </div>
@@ -606,20 +662,24 @@ exports[`Storyshots Radio one selected 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-130mzdl=""
+          data-css-kn3wr0=""
           onClick={[Function]}
         >
           <div
-            data-css-480533=""
-            data-css-iwspcj=""
+            data-css-1gbdc34=""
           >
             <div
-              aria-checked={false}
-              data-css-dbvyuf=""
-              onFocus={[Function]}
-              role="radio"
-              tabIndex="-1"
-            />
+              data-css-480533=""
+              data-css-iwspcj=""
+            >
+              <div
+                aria-checked={false}
+                data-css-dbvyuf=""
+                onFocus={[Function]}
+                role="radio"
+                tabIndex="-1"
+              />
+            </div>
           </div>
           <input
             checked={false}
@@ -630,7 +690,7 @@ exports[`Storyshots Radio one selected 1`] = `
             value="blue"
           />
           <div
-            data-css-13elow3=""
+            data-css-cgsoeo=""
           >
             Blue
           </div>
@@ -674,23 +734,27 @@ exports[`Storyshots Radio state demo 1`] = `
           data-css-xp79s5=""
         >
           <label
-            data-css-130mzdl=""
+            data-css-kn3wr0=""
             onClick={[Function]}
           >
             <div
-              data-css-480533=""
-              data-css-iwspcj=""
+              data-css-1gbdc34=""
             >
               <div
-                aria-checked={true}
-                data-css-4a14oy=""
-                onFocus={[Function]}
-                role="radio"
-                tabIndex="-1"
+                data-css-480533=""
+                data-css-iwspcj=""
               >
                 <div
-                  data-css-16yi4o9=""
-                />
+                  aria-checked={true}
+                  data-css-4a14oy=""
+                  onFocus={[Function]}
+                  role="radio"
+                  tabIndex="-1"
+                >
+                  <div
+                    data-css-16yi4o9=""
+                  />
+                </div>
               </div>
             </div>
             <input
@@ -702,7 +766,7 @@ exports[`Storyshots Radio state demo 1`] = `
               value="red"
             />
             <div
-              data-css-13elow3=""
+              data-css-cgsoeo=""
             >
               Red
             </div>
@@ -712,20 +776,24 @@ exports[`Storyshots Radio state demo 1`] = `
           data-css-xp79s5=""
         >
           <label
-            data-css-130mzdl=""
+            data-css-kn3wr0=""
             onClick={[Function]}
           >
             <div
-              data-css-480533=""
-              data-css-iwspcj=""
+              data-css-1gbdc34=""
             >
               <div
-                aria-checked={false}
-                data-css-dbvyuf=""
-                onFocus={[Function]}
-                role="radio"
-                tabIndex="-1"
-              />
+                data-css-480533=""
+                data-css-iwspcj=""
+              >
+                <div
+                  aria-checked={false}
+                  data-css-dbvyuf=""
+                  onFocus={[Function]}
+                  role="radio"
+                  tabIndex="-1"
+                />
+              </div>
             </div>
             <input
               checked={false}
@@ -736,7 +804,7 @@ exports[`Storyshots Radio state demo 1`] = `
               value="green"
             />
             <div
-              data-css-13elow3=""
+              data-css-cgsoeo=""
             >
               Green
             </div>
@@ -746,20 +814,24 @@ exports[`Storyshots Radio state demo 1`] = `
           data-css-xp79s5=""
         >
           <label
-            data-css-130mzdl=""
+            data-css-kn3wr0=""
             onClick={[Function]}
           >
             <div
-              data-css-480533=""
-              data-css-iwspcj=""
+              data-css-1gbdc34=""
             >
               <div
-                aria-checked={false}
-                data-css-dbvyuf=""
-                onFocus={[Function]}
-                role="radio"
-                tabIndex="-1"
-              />
+                data-css-480533=""
+                data-css-iwspcj=""
+              >
+                <div
+                  aria-checked={false}
+                  data-css-dbvyuf=""
+                  onFocus={[Function]}
+                  role="radio"
+                  tabIndex="-1"
+                />
+              </div>
             </div>
             <input
               checked={false}
@@ -770,7 +842,7 @@ exports[`Storyshots Radio state demo 1`] = `
               value="blue"
             />
             <div
-              data-css-13elow3=""
+              data-css-cgsoeo=""
             >
               Blue
             </div>

--- a/packages/radio/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/radio/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -22,11 +22,12 @@ exports[`Storyshots Radio default 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={[Function]}
         >
           <div
             data-css-480533=""
+            data-css-iwspcj=""
           >
             <div
               aria-checked={false}
@@ -45,7 +46,7 @@ exports[`Storyshots Radio default 1`] = `
             value="red"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Red
           </div>
@@ -55,11 +56,12 @@ exports[`Storyshots Radio default 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={[Function]}
         >
           <div
             data-css-480533=""
+            data-css-iwspcj=""
           >
             <div
               aria-checked={false}
@@ -78,7 +80,7 @@ exports[`Storyshots Radio default 1`] = `
             value="green"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Green
           </div>
@@ -88,11 +90,12 @@ exports[`Storyshots Radio default 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={[Function]}
         >
           <div
             data-css-480533=""
+            data-css-iwspcj=""
           >
             <div
               aria-checked={false}
@@ -111,7 +114,7 @@ exports[`Storyshots Radio default 1`] = `
             value="blue"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Blue
           </div>
@@ -144,11 +147,12 @@ exports[`Storyshots Radio disabled & error 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={null}
         >
           <div
             data-css-8x851q=""
+            data-css-iwspcj=""
           >
             <div
               aria-checked={false}
@@ -167,7 +171,7 @@ exports[`Storyshots Radio disabled & error 1`] = `
             value="red"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Red
           </div>
@@ -177,11 +181,12 @@ exports[`Storyshots Radio disabled & error 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={null}
         >
           <div
             data-css-8x851q=""
+            data-css-iwspcj=""
           >
             <div
               aria-checked={true}
@@ -204,7 +209,7 @@ exports[`Storyshots Radio disabled & error 1`] = `
             value="green"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Green
           </div>
@@ -214,11 +219,12 @@ exports[`Storyshots Radio disabled & error 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={null}
         >
           <div
             data-css-8x851q=""
+            data-css-iwspcj=""
           >
             <div
               aria-checked={false}
@@ -237,7 +243,7 @@ exports[`Storyshots Radio disabled & error 1`] = `
             value="blue"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Blue
           </div>
@@ -270,10 +276,11 @@ exports[`Storyshots Radio disabled 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={null}
         >
           <div
+            data-css-iwspcj=""
             data-css-jg1k2y=""
           >
             <div
@@ -293,7 +300,7 @@ exports[`Storyshots Radio disabled 1`] = `
             value="red"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Red
           </div>
@@ -303,10 +310,11 @@ exports[`Storyshots Radio disabled 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={null}
         >
           <div
+            data-css-iwspcj=""
             data-css-jg1k2y=""
           >
             <div
@@ -330,7 +338,7 @@ exports[`Storyshots Radio disabled 1`] = `
             value="green"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Green
           </div>
@@ -340,10 +348,11 @@ exports[`Storyshots Radio disabled 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={null}
         >
           <div
+            data-css-iwspcj=""
             data-css-jg1k2y=""
           >
             <div
@@ -363,7 +372,7 @@ exports[`Storyshots Radio disabled 1`] = `
             value="blue"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Blue
           </div>
@@ -396,11 +405,12 @@ exports[`Storyshots Radio error 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={[Function]}
         >
           <div
             data-css-11lyqbs=""
+            data-css-iwspcj=""
           >
             <div
               aria-checked={false}
@@ -419,7 +429,7 @@ exports[`Storyshots Radio error 1`] = `
             value="red"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Red
           </div>
@@ -429,11 +439,12 @@ exports[`Storyshots Radio error 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={[Function]}
         >
           <div
             data-css-11lyqbs=""
+            data-css-iwspcj=""
           >
             <div
               aria-checked={true}
@@ -456,7 +467,7 @@ exports[`Storyshots Radio error 1`] = `
             value="green"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Green
           </div>
@@ -466,11 +477,12 @@ exports[`Storyshots Radio error 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={[Function]}
         >
           <div
             data-css-11lyqbs=""
+            data-css-iwspcj=""
           >
             <div
               aria-checked={false}
@@ -489,7 +501,7 @@ exports[`Storyshots Radio error 1`] = `
             value="blue"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Blue
           </div>
@@ -522,11 +534,12 @@ exports[`Storyshots Radio one selected 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={[Function]}
         >
           <div
             data-css-480533=""
+            data-css-iwspcj=""
           >
             <div
               aria-checked={false}
@@ -545,7 +558,7 @@ exports[`Storyshots Radio one selected 1`] = `
             value="red"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Red
           </div>
@@ -555,11 +568,12 @@ exports[`Storyshots Radio one selected 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={[Function]}
         >
           <div
             data-css-480533=""
+            data-css-iwspcj=""
           >
             <div
               aria-checked={true}
@@ -582,7 +596,7 @@ exports[`Storyshots Radio one selected 1`] = `
             value="green"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Green
           </div>
@@ -592,11 +606,12 @@ exports[`Storyshots Radio one selected 1`] = `
         data-css-xp79s5=""
       >
         <label
-          data-css-kn3wr0=""
+          data-css-130mzdl=""
           onClick={[Function]}
         >
           <div
             data-css-480533=""
+            data-css-iwspcj=""
           >
             <div
               aria-checked={false}
@@ -615,7 +630,7 @@ exports[`Storyshots Radio one selected 1`] = `
             value="blue"
           />
           <div
-            data-css-pgc406=""
+            data-css-13elow3=""
           >
             Blue
           </div>
@@ -659,11 +674,12 @@ exports[`Storyshots Radio state demo 1`] = `
           data-css-xp79s5=""
         >
           <label
-            data-css-kn3wr0=""
+            data-css-130mzdl=""
             onClick={[Function]}
           >
             <div
               data-css-480533=""
+              data-css-iwspcj=""
             >
               <div
                 aria-checked={true}
@@ -686,7 +702,7 @@ exports[`Storyshots Radio state demo 1`] = `
               value="red"
             />
             <div
-              data-css-pgc406=""
+              data-css-13elow3=""
             >
               Red
             </div>
@@ -696,11 +712,12 @@ exports[`Storyshots Radio state demo 1`] = `
           data-css-xp79s5=""
         >
           <label
-            data-css-kn3wr0=""
+            data-css-130mzdl=""
             onClick={[Function]}
           >
             <div
               data-css-480533=""
+              data-css-iwspcj=""
             >
               <div
                 aria-checked={false}
@@ -719,7 +736,7 @@ exports[`Storyshots Radio state demo 1`] = `
               value="green"
             />
             <div
-              data-css-pgc406=""
+              data-css-13elow3=""
             >
               Green
             </div>
@@ -729,11 +746,12 @@ exports[`Storyshots Radio state demo 1`] = `
           data-css-xp79s5=""
         >
           <label
-            data-css-kn3wr0=""
+            data-css-130mzdl=""
             onClick={[Function]}
           >
             <div
               data-css-480533=""
+              data-css-iwspcj=""
             >
               <div
                 aria-checked={false}
@@ -752,7 +770,7 @@ exports[`Storyshots Radio state demo 1`] = `
               value="blue"
             />
             <div
-              data-css-pgc406=""
+              data-css-13elow3=""
             >
               Blue
             </div>

--- a/packages/radio/src/react/button.js
+++ b/packages/radio/src/react/button.js
@@ -5,7 +5,7 @@ import React from 'react'
 import { defaultName as themeDefaultName } from '@pluralsight/ps-design-system-theme/react'
 import * as propsUtil from '@pluralsight/ps-design-system-util/props'
 
-import css from '../css'
+import css from '../css/index.js'
 
 const radioButtonHtmlPropsWhitelist = [
   'type',
@@ -33,6 +33,7 @@ const styles = {
     ),
   circleInner: ({ checked }) =>
     glamor.css(css['.psds-radio-button__circle-inner']),
+  halo: () => glamor.css(css['.psds-radio-button__halo']),
   input: () => glamor.css(css['.psds-radio-button__input']),
   label: ({ themeName }) =>
     glamor.css(
@@ -74,6 +75,7 @@ class Button extends React.Component {
           shape={Halo.shapes.pill}
           visibleOnFocus={!allProps._disabled}
           visible={allProps._isFocused}
+          {...styles.halo()}
         >
           <div
             role="radio"
@@ -107,6 +109,7 @@ Button.propTypes = {
   checked: PropTypes.bool,
   innerRef: PropTypes.func,
   label: PropTypes.node.isRequired,
+  onClick: PropTypes.func,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   _disabled: PropTypes.bool,
   _error: PropTypes.bool,

--- a/packages/radio/src/react/button.js
+++ b/packages/radio/src/react/button.js
@@ -31,6 +31,7 @@ const styles = {
       checked && css['.psds-radio-button__circle--checked'],
       { ':focus': css['.psds-radio-button__circle:focus'] }
     ),
+  circleOuter: () => glamor.css(css['.psds-radio-button__circle-outer']),
   circleInner: ({ checked }) =>
     glamor.css(css['.psds-radio-button__circle-inner']),
   halo: () => glamor.css(css['.psds-radio-button__halo']),
@@ -69,25 +70,29 @@ class Button extends React.Component {
         onClick={props._disabled ? null : this.handleClick}
         {...styles.button(allProps)}
       >
-        <Halo
-          error={allProps._error}
-          inline
-          shape={Halo.shapes.pill}
-          visibleOnFocus={!allProps._disabled}
-          visible={allProps._isFocused}
-          {...styles.halo()}
-        >
-          <div
-            role="radio"
-            aria-checked={allProps.checked}
-            tabIndex="-1"
-            onFocus={props._disabled ? null : _ => props._onFocus(props.value)}
-            ref={el => (this.circle = el)}
-            {...styles.circle(allProps)}
+        <div {...styles.circleOuter()}>
+          <Halo
+            error={allProps._error}
+            inline
+            shape={Halo.shapes.pill}
+            visibleOnFocus={!allProps._disabled}
+            visible={allProps._isFocused}
+            {...styles.halo()}
           >
-            {allProps.checked && <div {...styles.circleInner(allProps)} />}
-          </div>
-        </Halo>
+            <div
+              role="radio"
+              aria-checked={allProps.checked}
+              tabIndex="-1"
+              onFocus={
+                props._disabled ? null : _ => props._onFocus(props.value)
+              }
+              ref={el => (this.circle = el)}
+              {...styles.circle(allProps)}
+            >
+              {allProps.checked && <div {...styles.circleInner(allProps)} />}
+            </div>
+          </Halo>
+        </div>
         <input
           {...propsUtil.whitelistProps(allProps, radioButtonHtmlPropsWhitelist)}
           tabIndex="-1"

--- a/packages/radio/src/react/index.js
+++ b/packages/radio/src/react/index.js
@@ -1,5 +1,5 @@
-import Button from './button'
-import Group from './group'
+import Button from './button.js'
+import Group from './group.js'
 
 export default {
   Button,


### PR DESCRIPTION
Fixes: #458

Could not get to the bottom of why only IE did this.  It has something
to do with the Halo positioning.  Think it's related to IE's treatment
of splitting up the flex space.  Instead of flexing, just
display-inlined the circle and label.