### PR TITLE
fix(table): align column headers with rows that are tables

### DIFF
--- a/packages/table/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/table/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -1089,7 +1089,7 @@ exports[`Storyshots columnHeader w/ drawers 1`] = `
   role="table"
 >
   <div
-    data-css-prsp0g=""
+    data-css-1gk8y86=""
     role="row"
   >
     <div

--- a/packages/table/src/react/index.js
+++ b/packages/table/src/react/index.js
@@ -9,6 +9,8 @@ import { defaultName as themeDefaultName } from '@pluralsight/ps-design-system-t
 import css from '../css'
 import * as vars from '../vars'
 
+const drawerDisplayNameRegex = new RegExp(drawerVars.drawerDisplayName)
+
 const styles = {
   cell: ({ align, emphasis, themeName }) =>
     glamor.css(
@@ -210,7 +212,7 @@ class Table extends React.Component {
       child =>
         child &&
         child.type &&
-        child.type.displayName === drawerVars.drawerDisplayName
+        drawerDisplayNameRegex.test(child.type.displayName)
     ).some(bool => bool)
 
     return (


### PR DESCRIPTION
Fixes: #467

Problem was introduced when we created the Theme HoC.  Classic coupling to implicit APIs.