### PR TITLE
Refactor/color tokens

### DIFF
--- a/packages/button/src/css/index.js
+++ b/packages/button/src/css/index.js
@@ -24,15 +24,15 @@ export default {
     fontSize: core.type.fontSizeSmall,
     fontWeight: core.type.fontWeightMedium,
     textAlign: 'center',
-    color: core.colors.white,
-    background: core.colors.orange,
+    color: core.colors.text.onInteractive,
+    background: core.colors.interactive.default,
     whiteSpace: 'nowrap',
     textDecoration: 'none',
     transition: `all ${core.motion.speedNormal}`,
     verticalAlign: 'middle'
   },
   '.psds-button:hover': {
-    background: core.colors.orangeLight,
+    background: core.colors.interactive.hover,
     cursor: 'pointer'
   },
   '.psds-button:focus': {
@@ -84,15 +84,11 @@ export default {
     color: core.colors.white,
     background: transparentize(0.65, core.colors.gray02)
   },
-  [`.psds-button--appearance-${vars.appearances.secondary}.psds-theme--${
-    themeNames.light
-  }`]: {
+  [`.psds-button--appearance-${vars.appearances.secondary}.psds-theme--${themeNames.light}`]: {
     color: core.colors.gray03,
     background: transparentize(0.65, core.colors.gray01)
   },
-  [`.psds-button--appearance-${vars.appearances.secondary}.psds-theme--${
-    themeNames.light
-  }:hover`]: {
+  [`.psds-button--appearance-${vars.appearances.secondary}.psds-theme--${themeNames.light}:hover`]: {
     color: core.colors.gray06,
     background: transparentize(0.35, core.colors.gray01)
   },
@@ -110,50 +106,36 @@ export default {
     border: 'none',
     background: 'none'
   },
-  [`.psds-button--appearance-${vars.appearances.flat}.psds-theme--${
-    themeNames.light
-  }`]: {
+  [`.psds-button--appearance-${vars.appearances.flat}.psds-theme--${themeNames.light}`]: {
     color: core.colors.gray03
   },
-  [`.psds-button--appearance-${
-    vars.appearances.flat
-  }.psds-theme--${themeDefaultName}`]: {
+  [`.psds-button--appearance-${vars.appearances.flat}.psds-theme--${themeDefaultName}`]: {
     color: core.colors.gray02
   },
-  [`.psds-button--appearance-${vars.appearances.flat}.psds-theme--${
-    themeNames.light
-  }:hover`]: {
+  [`.psds-button--appearance-${vars.appearances.flat}.psds-theme--${themeNames.light}:hover`]: {
     background: transparentize(0.85, core.colors.gray03)
   },
-  [`.psds-button--appearance-${
-    vars.appearances.flat
-  }.psds-theme--${themeDefaultName}:hover`]: {
+  [`.psds-button--appearance-${vars.appearances.flat}.psds-theme--${themeDefaultName}:hover`]: {
     color: core.colors.white,
     background: transparentize(0.85, core.colors.white)
   },
   // --disabled
   [`.psds-button--disabled`]: {
-    color: core.colors.gray02,
-    background: core.colors.gray03,
+    color: core.colors.text.onDisabled,
+    background: core.colors.interactive.disabled,
     cursor: 'default'
   },
   [`.psds-button--disabled.psds-theme--${themeNames.light}`]: {
     color: core.colors.gray03,
     background: core.colors.gray01
   },
-  [`.psds-button--disabled.psds-button--appearance-${
-    vars.appearances.primary
-  }`]: {
+  [`.psds-button--disabled.psds-button--appearance-${vars.appearances.primary}`]: {
     opacity: 0.5
   },
-  [`.psds-button--disabled.psds-button--appearance-${
-    vars.appearances.secondary
-  }`]: {
+  [`.psds-button--disabled.psds-button--appearance-${vars.appearances.secondary}`]: {
     opacity: 0.5
   },
-  [`.psds-button--disabled.psds-button--appearance-${
-    vars.appearances.stroke
-  }`]: {
+  [`.psds-button--disabled.psds-button--appearance-${vars.appearances.stroke}`]: {
     border: 'none',
     opacity: 0.5
   },
@@ -165,24 +147,16 @@ export default {
   [`.psds-button--iconAlign-${vars.iconAligns.right}`]: {
     flexDirection: 'row-reverse'
   },
-  [`.psds-button--iconAlign-${
-    vars.iconAligns.right
-  }.psds-button--not-iconOnly`]: {
+  [`.psds-button--iconAlign-${vars.iconAligns.right}.psds-button--not-iconOnly`]: {
     paddingRight: core.layout.spacingXSmall
   },
-  [`.psds-button--iconAlign-${
-    vars.iconAligns.left
-  }.psds-button--not-iconOnly`]: {
+  [`.psds-button--iconAlign-${vars.iconAligns.left}.psds-button--not-iconOnly`]: {
     paddingLeft: core.layout.spacingXSmall
   },
-  [`.psds-button--iconAlign-${
-    vars.iconAligns.right
-  }.psds-button--not-iconOnly.psds-button--size-${vars.sizes.large}`]: {
+  [`.psds-button--iconAlign-${vars.iconAligns.right}.psds-button--not-iconOnly.psds-button--size-${vars.sizes.large}`]: {
     paddingRight: core.layout.spacingSmall
   },
-  [`.psds-button--iconAlign-${
-    vars.iconAligns.left
-  }.psds-button--not-iconOnly.psds-button--size-${vars.sizes.large}`]: {
+  [`.psds-button--iconAlign-${vars.iconAligns.left}.psds-button--not-iconOnly.psds-button--size-${vars.sizes.large}`]: {
     paddingLeft: core.layout.spacingSmall
   },
   [`.psds-button--iconOnly`]: {
@@ -238,9 +212,7 @@ export default {
     borderColor: transparentize(0.8, core.colors.gray01),
     borderTopColor: core.colors.gray01
   },
-  [`.psds-button__loading--appearance-${
-    vars.appearances.secondary
-  }.psds-button__loading--theme-${themeNames.light}`]: {
+  [`.psds-button__loading--appearance-${vars.appearances.secondary}.psds-button__loading--theme-${themeNames.light}`]: {
     borderColor: transparentize(0.8, core.colors.gray04),
     borderTopColor: core.colors.gray04
   },
@@ -248,15 +220,11 @@ export default {
     borderColor: transparentize(0.8, core.colors.white),
     borderTopColor: core.colors.orange
   },
-  [`.psds-button__loading--appearance-${
-    vars.appearances.flat
-  }.psds-button__loading--theme-${themeNames.light}`]: {
+  [`.psds-button__loading--appearance-${vars.appearances.flat}.psds-button__loading--theme-${themeNames.light}`]: {
     borderColor: transparentize(0.8, core.colors.gray04),
     borderTopColor: core.colors.gray04
   },
-  [`.psds-button__loading--appearance-${
-    vars.appearances.flat
-  }.psds-button__loading--theme-${themeDefaultName}`]: {
+  [`.psds-button__loading--appearance-${vars.appearances.flat}.psds-button__loading--theme-${themeDefaultName}`]: {
     borderColor: transparentize(0.8, core.colors.white),
     borderTopColor: core.colors.white
   },

--- a/packages/core/css/colors.module.css
+++ b/packages/core/css/colors.module.css
@@ -1,4 +1,12 @@
 :root {
+  /* specific token names mapped to abstracts */
+  --psTextOnInteractive: #000000;
+  --psTextOnDisabled: #aaaaaa;
+
+  --psInteractiveDefault: #f96816;
+  --psInteractiveHover: #ff7b39;
+  --psInteractiveDisabled: #555555;
+
   /* ui colors */
   --psColorsWhite: #ffffff;
   --psColorsBone: #f2f2f2;

--- a/packages/core/css/colors.module.css
+++ b/packages/core/css/colors.module.css
@@ -1,11 +1,11 @@
 :root {
   /* specific token names mapped to abstracts */
-  --psTextOnInteractive: #000000;
-  --psTextOnDisabled: #aaaaaa;
+  --psColorsTextOnInteractive: #000000;
+  --psColorsTextOnDisabled: #aaaaaa;
 
-  --psInteractiveDefault: #f96816;
-  --psInteractiveHover: #ff7b39;
-  --psInteractiveDisabled: #555555;
+  --psColorsInteractiveDefault: #f96816;
+  --psColorsInteractiveHover: #ff7b39;
+  --psColorsInteractiveDisabled: #555555;
 
   /* ui colors */
   --psColorsWhite: #ffffff;

--- a/packages/core/js/colors.js
+++ b/packages/core/js/colors.js
@@ -48,7 +48,8 @@ const core = {
 }
 
 module.exports = {
-  // specific token names mapped to abstracts above
+  // meaningful design token names to bridge the gap between naming and use.
+  // specific token names mapped to abstracts above.
   text: {
     onInteractive: core.color.white,
     onDisabled: core.color.neutral[68]

--- a/packages/core/js/colors.js
+++ b/packages/core/js/colors.js
@@ -1,7 +1,7 @@
 const core = {
   // abstract token names
   color: {
-    white: '#ffffff',
+    white: '#FFFFFF',
     black: '#000000',
     // the numbers below represents the 'L' in the color's HSL value
     neutral: {
@@ -50,7 +50,7 @@ const core = {
 module.exports = {
   // specific token names mapped to abstracts above
   text: {
-    onInteractve: core.color.white,
+    onInteractive: core.color.white,
     onDisabled: core.color.neutral[68]
   },
 

--- a/packages/core/js/colors.js
+++ b/packages/core/js/colors.js
@@ -1,32 +1,98 @@
+const core = {
+  // abstract token names
+  color: {
+    white: '#ffffff',
+    black: '#000000',
+    // the numbers below represents the 'L' in the color's HSL value
+    neutral: {
+      9: '#181818',
+      13: '#222222',
+      21: '#363636',
+      33: '#555555',
+      68: '#AAAAAA',
+      80: '#CCCCCC',
+      95: '#F2F2F2'
+    },
+    pink: {
+      47: '#E80A89'
+    },
+    red: {
+      54: '#DE3636',
+      66: '#D99077',
+      69: '#F26D6D'
+    },
+    orange: {
+      53: '#F96816',
+      61: '#FF7B39',
+      55: '#F05A28',
+      70: '#FF9466'
+    },
+    yellow: {
+      50: '#FFC200',
+      75: '#FFCA80'
+    },
+    green: {
+      40: '#23AA5A',
+      47: '#86CE21',
+      64: '#B8CC7A',
+      76: '#ABD9C6'
+    },
+    blue: {
+      42: '#137BC2',
+      72: '#8AC7E6'
+    },
+    purple: {
+      74: '#E695BD'
+    }
+  }
+}
+
 module.exports = {
-  white: '#ffffff',
-  bone: '#f2f2f2',
-  gray01: '#cccccc',
-  gray02: '#aaaaaa',
-  gray03: '#555555',
-  gray04: '#363636',
-  gray05: '#222222',
-  gray06: '#181818',
-  black: '#000000',
+  // specific token names mapped to abstracts above
+  text: {
+    onInteractve: core.color.white,
+    onDisabled: core.color.neutral[68]
+  },
 
-  pink: '#e80a89',
-  red: '#de3636',
-  orange: '#f96816',
-  orangeLight: '#ff7b39',
-  yellow: '#ffc200',
-  greenLight: '#86ce21',
-  green: '#23aa5a',
-  blue: '#137bc2',
+  interactive: {
+    default: core.color.orange[53],
+    hover: core.color.orange[61],
+    disabled: core.color.neutral[33]
+  },
 
-  gradientHorz: 'linear-gradient(to right, #f05a28, #e80a89)',
-  gradientVert: 'linear-gradient(to bottom, #f05a28, #e80a89)',
+  // old literal token names
+  white: core.color.white,
+  bone: core.color.neutral[95],
+  gray01: core.color.neutral[80],
+  gray02: core.color.neutral[68],
+  gray03: core.color.neutral[33],
+  gray04: core.color.neutral[21],
+  gray05: core.color.neutral[13],
+  gray06: core.color.neutral[9],
+  black: core.color.black,
 
-  codeRed: '#f26d6d',
-  codeOrange: '#ff9466',
-  codeYellow: '#ffca80',
-  codeGreen: '#b8cc7a',
-  codeTurquoise: '#abd9c6',
-  codeBlue: '#8ac7e6',
-  codePurple: '#e695bd',
-  codeSand: '#d99077'
+  pink: core.color.pink[47],
+  red: core.color.red[54],
+  orange: core.color.orange[53],
+  orangeLight: core.color.orange[61],
+  yellow: core.color.yellow[50],
+  greenLight: core.color.green[47],
+  green: core.color.green[40],
+  blue: core.color.blue[42],
+
+  gradientHorz: `linear-gradient(to right, ${core.color.orange[55]}, ${
+    core.color.pink[47]
+  })`,
+  gradientVert: `linear-gradient(to bottom, ${core.color.orange[55]}, ${
+    core.color.pink[47]
+  })`,
+
+  codeRed: core.color.red[69],
+  codeOrange: core.color.orange[70],
+  codeYellow: core.color.yellow[75],
+  codeGreen: core.color.green[64],
+  codeTurquoise: core.color.green[76],
+  codeBlue: core.color.blue[72],
+  codePurple: core.color.purple[74],
+  codeSand: core.color.red[66]
 }

--- a/packages/site/pages/core/color.js
+++ b/packages/site/pages/core/color.js
@@ -162,7 +162,7 @@ const Swatch = props => (
         flex-direction: column;
         justify-content: center;
         height: 120px;
-        width: 150px;
+        width: calc(25% - ${core.layout.spacingLarge});
         padding: ${core.layout.spacingSmall};
         margin: calc(${core.layout.spacingLarge} / 2);
       }
@@ -227,8 +227,8 @@ export default withServerProps(_ => (
         <Palette>
           <DarkSwatch hex={core.colors.pink} var="Pink" />
           <DarkSwatch hex={core.colors.red} var="Red" />
-          <DarkSwatch hex={core.colors.orange} var="Orange" />
-          <DarkSwatch hex={core.colors.orangeLight} var="OrangeLight" />
+          <DarkSwatch hex={core.colors.interactive.default} var="InteractiveDefault" />
+          <DarkSwatch hex={core.colors.interactive.hover} var="InteractiveHover" />
           <DarkSwatch hex={core.colors.yellow} var="Yellow" />
           <DarkSwatch hex={core.colors.greenLight} var="GreenLight" />
           <DarkSwatch hex={core.colors.green} var="Green" />
@@ -238,7 +238,7 @@ export default withServerProps(_ => (
         <br />
         <Code language="css">{`@import "@pluralsight/ps-design-system-core";
 .mySelector {
-  color: var(--psColorsOrange);
+  color: var(--psInteractiveDefault);
 }`}</Code>
       </div>
 

--- a/packages/site/pages/core/color.js
+++ b/packages/site/pages/core/color.js
@@ -227,8 +227,14 @@ export default withServerProps(_ => (
         <Palette>
           <DarkSwatch hex={core.colors.pink} var="Pink" />
           <DarkSwatch hex={core.colors.red} var="Red" />
-          <DarkSwatch hex={core.colors.interactive.default} var="InteractiveDefault" />
-          <DarkSwatch hex={core.colors.interactive.hover} var="InteractiveHover" />
+          <DarkSwatch
+            hex={core.colors.interactive.default}
+            var="InteractiveDefault"
+          />
+          <DarkSwatch
+            hex={core.colors.interactive.hover}
+            var="InteractiveHover"
+          />
           <DarkSwatch hex={core.colors.yellow} var="Yellow" />
           <DarkSwatch hex={core.colors.greenLight} var="GreenLight" />
           <DarkSwatch hex={core.colors.green} var="Green" />

--- a/packages/site/pages/core/color.js
+++ b/packages/site/pages/core/color.js
@@ -152,7 +152,7 @@ const VertGradient = props => (
 const Swatch = props => (
   <div
     className={`swatch ${props.light ? 'swatchLight' : 'swatchDark'}`}
-    style={{ backgroundColor: '#' + props.hex }}
+    style={{ backgroundColor: props.hex }}
   >
     <div className="hex">{props.hex}</div>
     <div className="var">psColors{props.var}</div>
@@ -201,15 +201,15 @@ export default withServerProps(_ => (
       <P>Grayscale colors are used for containers, text, lines and borders.</P>
       <div>
         <Palette>
-          <LightSwatch hex="FFFFFF" var="White" />
-          <LightSwatch hex="F2F2F2" var="Bone" />
-          <DarkSwatch hex="CCCCCC" var="Gray01" />
-          <DarkSwatch hex="AAAAAA" var="Gray02" />
-          <DarkSwatch hex="555555" var="Gray03" />
-          <DarkSwatch hex="363636" var="Gray04" />
-          <DarkSwatch hex="222222" var="Gray05" />
-          <DarkSwatch hex="181818" var="Gray06" />
-          <DarkSwatch hex="000000" var="Black" />
+          <LightSwatch hex={core.colors.white} var="White" />
+          <LightSwatch hex={core.colors.bone} var="Bone" />
+          <DarkSwatch hex={core.colors.gray01} var="Gray01" />
+          <DarkSwatch hex={core.colors.gray02} var="Gray02" />
+          <DarkSwatch hex={core.colors.gray03} var="Gray03" />
+          <DarkSwatch hex={core.colors.gray04} var="Gray04" />
+          <DarkSwatch hex={core.colors.gray05} var="Gray05" />
+          <DarkSwatch hex={core.colors.gray06} var="Gray06" />
+          <DarkSwatch hex={core.colors.black} var="Black" />
         </Palette>
         <br />
         <Code language="css">{`@import "@pluralsight/ps-design-system-core";
@@ -225,14 +225,14 @@ export default withServerProps(_ => (
       </P>
       <div>
         <Palette>
-          <DarkSwatch hex="E80A89" var="Pink" />
-          <DarkSwatch hex="DE3636" var="Red" />
-          <DarkSwatch hex="F96816" var="Orange" />
-          <DarkSwatch hex="FF7B39" var="OrangeLight" />
-          <DarkSwatch hex="FFC200" var="Yellow" />
-          <DarkSwatch hex="86CE21" var="GreenLight" />
-          <DarkSwatch hex="23AA5A" var="Green" />
-          <DarkSwatch hex="137BC2" var="Blue" />
+          <DarkSwatch hex={core.colors.pink} var="Pink" />
+          <DarkSwatch hex={core.colors.red} var="Red" />
+          <DarkSwatch hex={core.colors.orange} var="Orange" />
+          <DarkSwatch hex={core.colors.orangeLight} var="OrangeLight" />
+          <DarkSwatch hex={core.colors.yellow} var="Yellow" />
+          <DarkSwatch hex={core.colors.greenLight} var="GreenLight" />
+          <DarkSwatch hex={core.colors.green} var="Green" />
+          <DarkSwatch hex={core.colors.blue} var="Blue" />
         </Palette>
 
         <br />
@@ -251,19 +251,19 @@ export default withServerProps(_ => (
         <Palette>
           <Gradient var={core.colors.gradientHorz}>
             <div>
-              <GradientStop>F05A28</GradientStop>
+              <GradientStop>#F05A28</GradientStop>
               <GradientVar>psColorsGradientHorz</GradientVar>
             </div>
             <div className="gradientHorzStop2">
-              <GradientStop>E80A89</GradientStop>
+              <GradientStop>#E80A89</GradientStop>
             </div>
           </Gradient>
           <Gradient var={core.colors.gradientVert}>
             <div className="gradientVert">
-              <GradientStop>F05A28</GradientStop>
+              <GradientStop>#F05A28</GradientStop>
               <GradientVar>psColorsGradientVert</GradientVar>
               <div className="gradientVertStop2">
-                <GradientStop>E80A89</GradientStop>
+                <GradientStop>#E80A89</GradientStop>
               </div>
             </div>
           </Gradient>

--- a/packages/site/pages/core/color.js
+++ b/packages/site/pages/core/color.js
@@ -244,7 +244,7 @@ export default withServerProps(_ => (
         <br />
         <Code language="css">{`@import "@pluralsight/ps-design-system-core";
 .mySelector {
-  color: var(--psInteractiveDefault);
+  color: var(--psColorsInteractiveDefault);
 }`}</Code>
       </div>
 


### PR DESCRIPTION
## Instructions

- core: convert color names to design token naming
- label: enhancement

### What You're Solving

- This PR is an exploration in converting variable names to meaningful design token names to bridge the gap between naming and use.

### Design Decisions

- Design Tokens help developers know when to use variables based on their name. 

The style property values for `button` would look like this:

```css
.psds-button {
    color: core.colors.text.onInteractive;
    background: core.colors.interactive.default;
}

.psds-button--disabled {
    color: core.colors.text.onDisabled;
    background: core.colors.interactive.disabled;
}
```

instead of this:

```css
.psds-button {
    color: core.colors.white;
    background: core.colors.orange;
}

.psds-button--disabled {
    color: core.colors.gray02;
    background: core.colors.gray03;
}
```

The `color.js` src file could map design token names to abstract names. Thus systematizing the variables which allows the values of the tokens to be changed in the future without having to update any component that references the literal name.

```js
  text: {
    onInteractive: core.color.white,
    onDisabled: core.color.neutral[68]
  },

  interactive: {
    default: core.color.orange[53],
    hover: core.color.orange[61],
    disabled: core.color.neutral[33]
  }
``` 

### How to Verify

- I've updated the `psColorsOrange` and `psColorsOrangeLight` variable references in the `packages/button` component and on the core doc page as an example demonstration.

http://localhost:1337/core/color

<img width="432" alt="Screen Shot 2019-06-17 at 6 01 22 AM" src="https://user-images.githubusercontent.com/3717760/59606627-7a392300-90c6-11e9-88eb-8b14ad57b0cf.png">


