### PR TITLE
[WIP] storybook: add storybook package to roll up all stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "publish:beta": "npm run publish -- --npm-tag=beta",
     "site": "cd packages/site && npm start",
     "start": "npm run site",
+    "storybook": "start-storybook -p 6006",
     "test": "jest"
   },
   "husky": {

--- a/packages/storybook/.storybook/.babelrc
+++ b/packages/storybook/.storybook/.babelrc
@@ -1,0 +1,19 @@
+{
+  "presets": [
+    "@babel/preset-react",
+    [
+      "@babel/preset-env",
+      { "targets": { "node": "current" }, "corejs": 2, "useBuiltIns": "usage" }
+    ]
+  ],
+  "plugins": [
+    ["@babel/plugin-proposal-class-properties", { "loose": true }],
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-json-strings",
+    "@babel/plugin-proposal-object-rest-spread",
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-syntax-import-meta",
+    "macros"
+  ]
+}

--- a/packages/storybook/.storybook/addons.js
+++ b/packages/storybook/.storybook/addons.js
@@ -1,0 +1,1 @@
+import '@pluralsight/ps-design-system-storybook-addon-theme/register'

--- a/packages/storybook/.storybook/config-utils.js
+++ b/packages/storybook/.storybook/config-utils.js
@@ -1,0 +1,55 @@
+const fs = require('fs')
+const path = require('path')
+
+const ROOT_PATH = path.resolve(__dirname, '../../../')
+const PKGS_DIR_PATH = path.resolve(ROOT_PATH, 'packages')
+
+const getPackageNameToPathMap = () => {
+  const pkgDirectories = fs
+    .readdirSync(PKGS_DIR_PATH)
+    .filter(name => fs.lstatSync(path.join(PKGS_DIR_PATH, name)).isDirectory())
+
+  return pkgDirectories.reduce((acc, dirName) => {
+    const dirPath = path.join(PKGS_DIR_PATH, dirName)
+    const pkgJsonPath = path.join(dirPath, 'package.json')
+
+    const pkgJson = require(pkgJsonPath)
+
+    return { ...acc, [pkgJson.name]: dirPath }
+  }, {})
+}
+
+const filterWebpackRules = (config, loaderName) =>
+  config.module.rules.filter(ruleIncludesLoader(loaderName))
+
+const ruleIncludesLoader = loaderName => rule => {
+  let isMatch = false
+
+  if (rule.loader && rule.loader.includes(loaderName)) {
+    isMatch = true
+  }
+
+  if (rule.use) {
+    rule.use.forEach(use => {
+      if (typeof use === 'string' && use.includes(loaderName)) {
+        isMatch = true
+      } else if (
+        typeof use === 'object' &&
+        use.loader &&
+        use.loader.includes(loaderName)
+      ) {
+        isMatch = true
+      }
+    })
+  }
+
+  return isMatch
+}
+
+module.exports = {
+  ROOT_PATH,
+  PKGS_DIR_PATH,
+
+  filterWebpackRules,
+  getPackageNameToPathMap
+}

--- a/packages/storybook/.storybook/config.js
+++ b/packages/storybook/.storybook/config.js
@@ -1,0 +1,17 @@
+import { addDecorator, configure } from '@storybook/react'
+
+import themeDecorator from '@pluralsight/ps-design-system-storybook-addon-theme'
+
+const requests = []
+
+requests.push(require.context('../../avatar/src', true, /\.story\.js$/))
+requests.push(require.context('../../button/src', true, /\.story\.js$/))
+
+function loadStories() {
+  requests.forEach(req => {
+    req.keys().forEach(fname => req(fname))
+  })
+}
+
+addDecorator(themeDecorator)
+configure(loadStories, module)

--- a/packages/storybook/.storybook/preview-head.html
+++ b/packages/storybook/.storybook/preview-head.html
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="https://cloud.typography.com/6966154/6397212/css/fonts.css" />
+<link rel="stylesheet" href="https://unpkg.com/@pluralsight/ps-design-system-normalize" />

--- a/packages/storybook/.storybook/webpack.config.js
+++ b/packages/storybook/.storybook/webpack.config.js
@@ -1,0 +1,22 @@
+const path = require('path')
+const { lstatSync, readdirSync, readFileSync } = require('fs')
+
+const {
+  PKGS_DIR_PATH,
+  filterWebpackRules,
+  getPackageNameToPathMap
+} = require('./config-utils.js')
+
+module.exports = ({ config }) => {
+  const babelRules = filterWebpackRules(config, 'babel-loader')
+
+  babelRules.forEach(rule => {
+    rule.include = PKGS_DIR_PATH
+    rule.exclude = /node_modules/
+  })
+
+  const nameToPathMap = getPackageNameToPathMap()
+  Object.assign(config.resolve.alias, nameToPathMap)
+
+  return config
+}

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@pluralsight/ps-design-system-storybook",
+  "private": true,
+  "scripts": {
+    "start": "start-storybook"
+  },
+  "dependencies": {
+    "@pluralsight/ps-design-system-storybook-addon-theme": "*"
+  },
+  "devDependencies": {
+    "@pluralsight/ps-design-system-avatar": "*",
+    "@pluralsight/ps-design-system-button": "*"
+  }
+}


### PR DESCRIPTION
> One Storybook to Rule Them All

### What You're Solving

- a new storybook package/build that can included all stories from all packages

### Design Decisions

- a separate package for the storybook for organization and dep management
- used webpack aliases to resolve paths to source code
- package stories need to be explicitly included
  - because of es6 static naming i couldn't find a good way to dynamically load the packages
  - i tried just using require.context to glob load everything in `./packages` but it was crazy slow

### outstanding tasks
- [ ] refactor the stories with better names and add hierarchy info for storybook navigation
  - [ ] waiting on new storybook [CSF](https://medium.com/storybookjs/component-story-format-66f4c32366df) to be released
  - [ ] waiting until after we upgrade all the component to use react 16

### How to Verify

- install and bootstrap
- npm run storybook from the root
