### PR TITLE
refactor(site): interleave voice and tone guidelines without columns

### DIFF
--- a/packages/site/pages/patterns/voice-tone.js
+++ b/packages/site/pages/patterns/voice-tone.js
@@ -270,87 +270,82 @@ export default _ => (
         through it. Follow these 3 guidelines when writing error messages:
       </P>
 
-      <EqualColumnLayout count={EqualColumnLayout.counts.two}>
-        <P>
-          <ExampleHeader>1. Explain what happened and why</ExampleHeader>
-          Be clear about what’s going on. Give the right amount of detail, but
-          don’t get too technical. Write in a way that anyone could easily
-          understand without using jargon.
-        </P>
+      <P
+        style={{
+          marginTop: core.layout.spacingXLarge
+        }}
+      >
+        <ExampleHeader>1. Explain what happened and why</ExampleHeader>
+        Be clear about what’s going on. Give the right amount of detail, but
+        don’t get too technical. Write in a way that anyone could easily
+        understand without using jargon.
+      </P>
 
-        <div>
-          <Guideline
-            // columnCount={1}
-            do={
-              <div style={{ textAlign: 'center' }}>
-                <strong>Your credit card has expired</strong> <br />
-                Update your payment method to restore your subscription.
-              </div>
-            }
-            dont={
-              <div style={{ textAlign: 'center' }}>
-                <strong>Billing error</strong>
-              </div>
-            }
-          />
-        </div>
-      </EqualColumnLayout>
+      <Guideline
+        do={
+          <div style={{ textAlign: 'center' }}>
+            <strong>Your credit card has expired</strong> <br />
+            Update your payment method to restore your subscription.
+          </div>
+        }
+        dont={
+          <div style={{ textAlign: 'center' }}>
+            <strong>Billing error</strong>
+          </div>
+        }
+      />
 
-      <EqualColumnLayout count={EqualColumnLayout.counts.two}>
-        <P>
-          <ExampleHeader>2. Suggest a next step</ExampleHeader>
-          After you explain what happened, tell the user what they can do to
-          resolve the issue. If possible include a button, a link, or another
-          call to action.
-        </P>
+      <P
+        style={{
+          marginTop: core.layout.spacingXLarge
+        }}
+      >
+        <ExampleHeader>2. Suggest a next step</ExampleHeader>
+        After you explain what happened, tell the user what they can do to
+        resolve the issue. If possible include a button, a link, or another call
+        to action.
+      </P>
 
-        <div>
-          <Guideline
-            // columnCount={1}
-            do={
-              <div style={{ textAlign: 'center' }}>
-                <strong>There was a problem loading the video</strong> <br />
-                <br />
-                <Button appearance={Button.appearances.primary}>
-                  Try again
-                </Button>
-              </div>
-            }
-            dont={
-              <div style={{ textAlign: 'center' }}>
-                <strong>Error 7007</strong>
-                <br />
-                Unable to play video
-              </div>
-            }
-          />
-        </div>
-      </EqualColumnLayout>
+      <Guideline
+        do={
+          <div style={{ textAlign: 'center' }}>
+            <strong>There was a problem loading the video</strong> <br />
+            <br />
+            <Button appearance={Button.appearances.primary}>Try again</Button>
+          </div>
+        }
+        dont={
+          <div style={{ textAlign: 'center' }}>
+            <strong>Error 7007</strong>
+            <br />
+            Unable to play video
+          </div>
+        }
+      />
 
-      <EqualColumnLayout count={EqualColumnLayout.counts.two}>
-        <P>
-          <ExampleHeader>3. Match the tone to the context</ExampleHeader>
-          Avoid being robotic or silly. Remember, something went wrong, now's
-          your time to help them through it in a friendly way.
-        </P>
+      <P
+        style={{
+          marginTop: core.layout.spacingXLarge
+        }}
+      >
+        <ExampleHeader>3. Match the tone to the context</ExampleHeader>
+        Avoid being robotic or silly. Remember, something went wrong, now's your
+        time to help them through it in a friendly way.
+      </P>
 
-        <div>
-          <Guideline
-            // columnCount={1}
-            do={
-              <div style={{ textAlign: 'center' }}>
-                That password doesn’t match. Try again?
-              </div>
-            }
-            dont={
-              <div style={{ textAlign: 'center' }}>
-                Yo, big problemo! The password you provided doesn’t match. Wanna
-                try that again?
-              </div>
-            }
-          />
-        </div>
-      </EqualColumnLayout>
+      <Guideline
+        do={
+          <div style={{ textAlign: 'center' }}>
+            That password doesn’t match. Try again?
+          </div>
+        }
+        dont={
+          <div style={{ textAlign: 'center' }}>
+            Yo, big problemo! The password you provided doesn’t match. Wanna try
+            that again?
+          </div>
+        }
+      />
 
       <Divider />
 


### PR DESCRIPTION
I adjusted the interleaving.  

It goes from this, which seems squeezed for space:

<img width="1083" alt="before" src="https://user-images.githubusercontent.com/552044/63702745-cb5f4480-c7e4-11e9-8a2c-2a0897ce1bc4.png">

To this:

<img width="1083" alt="after" src="https://user-images.githubusercontent.com/552044/63702769-d4e8ac80-c7e4-11e9-99be-a55560b3df36.png">

(Both look the same on mobile)

