### PR TITLE
fix(site): remove flash of unstyled content with custom document

### DIFF
--- a/packages/site/pages/_document.js
+++ b/packages/site/pages/_document.js
@@ -1,0 +1,35 @@
+import Document, { Head, Main, NextScript } from 'next/document'
+import flush from 'styled-jsx/server'
+import React from 'react'
+import { renderStatic } from 'glamor/server'
+
+export default class MyDocument extends Document {
+  static async getInitialProps({ renderPage }) {
+    const page = renderPage()
+    const jsxStyles = flush()
+    const styles = renderStatic(() => page.html || page.errorHtml)
+    return { ...page, ...styles, styles: jsxStyles }
+  }
+
+  constructor(props) {
+    super(props)
+    const { __NEXT_DATA__, ids } = props
+    if (ids) {
+      __NEXT_DATA__.ids = this.props.ids
+    }
+  }
+
+  render() {
+    return (
+      <html>
+        <Head>
+          <style dangerouslySetInnerHTML={{ __html: this.props.css }} />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    )
+  }
+}


### PR DESCRIPTION
Fixes #624 
Fixes #215 

I could actually repro #624 in Firefox.  I did see the "icon takeover" temporarily, but it adjusted after FOUC.  Instead of pursuing that specific problem, I thought that I'd address the thing that I've often wanted to do, hoping that now on a later version of nextjs, it'd actually stick.  It seems to.

To test, I ran:

1. Dev/local server (npm start)
2. Nextjs build (npm run build) and serve the static directory

This solution allows glamor and styled-jsx to ssr.