### PR TITLE
[WIP] carousel: re-add overflow hidden

### DIFF
--- a/packages/card/src/react/__specs__/index.spec.js
+++ b/packages/card/src/react/__specs__/index.spec.js
@@ -1,5 +1,7 @@
-import { shallow } from 'enzyme'
+import Icon from '@pluralsight/ps-design-system-icon/react.js'
 import React from 'react'
+import { render } from '@testing-library/react'
+import { shallow } from 'enzyme'
 
 import Card from '../index.js'
 
@@ -11,4 +13,22 @@ test('click on Card.Title triggered once', () => {
   const title = shallow(<Card.Title onClick={onClick}>Clicks once</Card.Title>)
   title.simulate('click')
   expect(callCount).toBe(1)
+})
+
+describe('#Card.Action', () => {
+  it('forwards ref', () => {
+    const refToForward = React.createRef()
+
+    const { getByTestId } = render(
+      <Card.Action
+        data-testid="under-test"
+        ref={refToForward}
+        title="Some title"
+        icon={<Icon id={Icon.ids.more} />}
+      ></Card.Action>
+    )
+
+    const el = getByTestId('under-test')
+    expect(el).toBe(refToForward.current)
+  })
 })

--- a/packages/card/src/react/index.js
+++ b/packages/card/src/react/index.js
@@ -86,17 +86,15 @@ const ActionBar = props => (
   <div {...styles.actionBar(props)} {...filterReactProps(props)} />
 )
 
-const ActionButton = props => (
+const ActionBarAction = React.forwardRef(({ icon, ...props }, ref) => (
   <button
     {...styles.actionButton(props)}
     {...filterReactProps(props, { tagName: 'button' })}
-  />
-)
-
-const ActionBarAction = ({ icon, ...props }) => (
-  <ActionButton {...filterReactProps(props)}>{icon}</ActionButton>
-)
-
+    ref={ref}
+  >
+    {icon}
+  </button>
+))
 ActionBarAction.displayName = 'Card.Action'
 ActionBarAction.propTypes = {
   icon: PropTypes.element.isRequired,

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -36,6 +36,7 @@
     "@pluralsight/ps-design-system-actionmenu": "^5.1.4",
     "@pluralsight/ps-design-system-build": "^1.10.1",
     "@pluralsight/ps-design-system-card": "^11.0.0",
+    "@pluralsight/ps-design-system-position": "*",
     "@pluralsight/ps-design-system-storybook-addon-center": "^2.0.5",
     "@pluralsight/ps-design-system-storybook-addon-theme": "^4.0.0",
     "@pluralsight/ps-design-system-theme": "^3.0.3"

--- a/packages/carousel/src/css/index.js
+++ b/packages/carousel/src/css/index.js
@@ -1,5 +1,5 @@
 import core from '@pluralsight/ps-design-system-core'
-import { names as themeNames } from '@pluralsight/ps-design-system-theme/vars'
+import { names as themeNames } from '@pluralsight/ps-design-system-theme/vars.js'
 
 import { controlDirections as directions } from '../vars/index.js'
 
@@ -93,10 +93,7 @@ export default {
     ...resetList,
     ...resetFocus,
     display: 'flex',
-    width: '100%'
-  },
-
-  '.psds-carousel__pages--transitioning': {
+    width: '100%',
     overflow: 'hidden'
   },
 

--- a/packages/carousel/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/carousel/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -11,7 +11,7 @@ exports[`Storyshots Carousel/Item with child nodes 1`] = `
     <ul
       aria-describedby="carousel-mock_unique_id__instructions"
       aria-label="carousel"
-      data-css-1f0n9j9=""
+      data-css-1d3rq9b=""
       id="carousel-mock_unique_id"
       onKeyDown={[Function]}
       role="region"
@@ -161,7 +161,7 @@ exports[`Storyshots Carousel/Item with render props 1`] = `
     <ul
       aria-describedby="carousel-mock_unique_id__instructions"
       aria-label="carousel"
-      data-css-1f0n9j9=""
+      data-css-1d3rq9b=""
       id="carousel-mock_unique_id"
       onKeyDown={[Function]}
       role="region"
@@ -321,7 +321,7 @@ exports[`Storyshots Carousel/controls custom alignment 1`] = `
     <ul
       aria-describedby="carousel-mock_unique_id__instructions"
       aria-label="carousel"
-      data-css-1f0n9j9=""
+      data-css-1d3rq9b=""
       id="carousel-mock_unique_id"
       onKeyDown={[Function]}
       role="region"
@@ -484,7 +484,7 @@ exports[`Storyshots Carousel/items dynamic items 1`] = `
     <ul
       aria-describedby="carousel-mock_unique_id__instructions"
       aria-label="carousel"
-      data-css-1f0n9j9=""
+      data-css-1d3rq9b=""
       id="carousel-mock_unique_id"
       onKeyDown={[Function]}
       role="region"
@@ -622,7 +622,7 @@ exports[`Storyshots Carousel/items many items 1`] = `
     <ul
       aria-describedby="carousel-mock_unique_id__instructions"
       aria-label="carousel"
-      data-css-1f0n9j9=""
+      data-css-1d3rq9b=""
       id="carousel-mock_unique_id"
       onKeyDown={[Function]}
       role="region"
@@ -847,7 +847,7 @@ exports[`Storyshots Carousel/items one item 1`] = `
     <ul
       aria-describedby="carousel-mock_unique_id__instructions"
       aria-label="carousel"
-      data-css-1f0n9j9=""
+      data-css-1d3rq9b=""
       id="carousel-mock_unique_id"
       onKeyDown={[Function]}
       role="region"
@@ -953,7 +953,7 @@ exports[`Storyshots Carousel/items two items 1`] = `
     <ul
       aria-describedby="carousel-mock_unique_id__instructions"
       aria-label="carousel"
-      data-css-1f0n9j9=""
+      data-css-1d3rq9b=""
       id="carousel-mock_unique_id"
       onKeyDown={[Function]}
       role="region"
@@ -1063,7 +1063,7 @@ exports[`Storyshots Carousel/size narrow 1`] = `
     <ul
       aria-describedby="carousel-mock_unique_id__instructions"
       aria-label="carousel"
-      data-css-1f0n9j9=""
+      data-css-1d3rq9b=""
       id="carousel-mock_unique_id"
       onKeyDown={[Function]}
       role="region"
@@ -1240,7 +1240,7 @@ exports[`Storyshots Carousel/size wide 1`] = `
     <ul
       aria-describedby="carousel-mock_unique_id__instructions"
       aria-label="carousel"
-      data-css-1f0n9j9=""
+      data-css-1d3rq9b=""
       id="carousel-mock_unique_id"
       onKeyDown={[Function]}
       role="region"
@@ -1406,6 +1406,289 @@ exports[`Storyshots Carousel/size wide 1`] = `
 </div>
 `;
 
+exports[`Storyshots Carousel/with ActionMenu in portal 1`] = `
+<div
+  data-css-x7zjce=""
+  data-testid="story-wrapper"
+>
+  <div
+    style={
+      Object {
+        "border": "1px solid red",
+        "maxWidth": 600,
+        "padding": 10,
+      }
+    }
+  >
+    <div
+      data-css-rumlay=""
+    >
+      <ul
+        aria-describedby="carousel-mock_unique_id__instructions"
+        aria-label="carousel"
+        data-css-1d3rq9b=""
+        id="carousel-mock_unique_id"
+        onKeyDown={[Function]}
+        role="region"
+        tabIndex="0"
+      >
+        <li
+          data-css-bxro55=""
+          data-css-fx3xhe=""
+        >
+          <div
+            data-css-a8uf5t=""
+          >
+            <div
+              data-css-1ybvkp1=""
+            >
+              <div
+                data-css-x1twjb=""
+              >
+                <div
+                  data-css-i7gti2=""
+                  style={
+                    Object {
+                      "backgroundImage": "url(//picsum.photos/680/320?image=42&gravity=north)",
+                    }
+                  }
+                />
+                <div
+                  data-css-1kb1o0e=""
+                >
+                  <button
+                    data-css-226xmr=""
+                    onClick={[Function]}
+                    title="asdf"
+                  >
+                    <div
+                      data-css-otejxm=""
+                    >
+                      <svg
+                        aria-label="more icon"
+                        role="img"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                data-css-piydn8=""
+              >
+                <span
+                  data-css-1202ll4=""
+                >
+                  <a
+                    href="#"
+                  >
+                    <div
+                      data-css-1tlmf72=""
+                    >
+                      <div
+                        className=""
+                      >
+                        <span
+                          style={
+                            Object {
+                              "display": "block",
+                              "maxHeight": "0px",
+                              "overflow": "hidden",
+                              "position": "relative",
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "display": "block",
+                                "width": "100%",
+                              }
+                            }
+                          >
+                            Yahoo
+                          </span>
+                          <span
+                            aria-hidden="true"
+                            style={
+                              Object {
+                                "display": "block",
+                                "height": "0px",
+                                "overflow": "hidden",
+                                "width": "100%",
+                              }
+                            }
+                          >
+                            Yahoo
+                          </span>
+                          <span
+                            aria-hidden="true"
+                            style={
+                              Object {
+                                "display": "block",
+                                "left": "-20000px",
+                                "position": "absolute",
+                                "width": "100%",
+                              }
+                            }
+                          >
+                            <span
+                              style={
+                                Object {
+                                  "display": "block",
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "display": "block",
+                                  }
+                                }
+                              >
+                                W
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "display": "block",
+                                  }
+                                }
+                              >
+                                W
+                              </span>
+                            </span>
+                            <span
+                              style={
+                                Object {
+                                  "display": "block",
+                                }
+                              }
+                            >
+                              Yahoo
+                            </span>
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  </a>
+                </span>
+              </div>
+              <div
+                data-css-sb1dn8=""
+              >
+                <span
+                  data-css-1tz10dh=""
+                >
+                  <span
+                    data-css-1202ll4=""
+                  >
+                    <a
+                      href="#"
+                    >
+                      meta
+                    </a>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li
+          data-css-17v35en=""
+          data-css-bxro55=""
+          hidden={true}
+          tabIndex={-1}
+        />
+        <li
+          data-css-17v35en=""
+          data-css-bxro55=""
+          hidden={true}
+          tabIndex={-1}
+        />
+        <li
+          data-css-17v35en=""
+          data-css-bxro55=""
+          hidden={true}
+          tabIndex={-1}
+        />
+      </ul>
+      <ul
+        aria-controls="carousel-mock_unique_id"
+        aria-label="carousel controls"
+        data-css-b3afd4=""
+      >
+        <li>
+          <button
+            aria-label="previous"
+            data-css-1wkjkcr=""
+            hidden={true}
+            onClick={[Function]}
+            tabIndex={-1}
+          >
+            <div
+              aria-hidden={true}
+              data-css-otejxm=""
+            >
+              <svg
+                aria-label="caret left icon"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8 12l5-5 1.41 1.41L10.83 12l3.58 3.59L13 17"
+                />
+              </svg>
+            </div>
+          </button>
+        </li>
+        <li>
+          <button
+            aria-label="next"
+            data-css-n705st=""
+            onClick={[Function]}
+          >
+            <div
+              aria-hidden={true}
+              data-css-otejxm=""
+            >
+              <svg
+                aria-label="caret right icon"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16 12l-5-5-1.41 1.41L13.17 12l-3.58 3.59L11 17"
+                />
+              </svg>
+            </div>
+          </button>
+        </li>
+      </ul>
+      <div
+        data-css-6wu9td=""
+        id="carousel-mock_unique_id__instructions"
+      >
+        <p>
+          Currently on page 
+          1
+           of 
+          4
+          .
+        </p>
+        <p>
+          Use left and right arrow keys for navigation.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Carousel/with ActionMenu positioned child 1`] = `
 <div
   data-css-x7zjce=""
@@ -1426,7 +1709,7 @@ exports[`Storyshots Carousel/with ActionMenu positioned child 1`] = `
       <ul
         aria-describedby="carousel-mock_unique_id__instructions"
         aria-label="carousel"
-        data-css-1f0n9j9=""
+        data-css-1d3rq9b=""
         id="carousel-mock_unique_id"
         onKeyDown={[Function]}
         role="region"
@@ -1756,7 +2039,7 @@ exports[`Storyshots Carousel/with Card narrow 1`] = `
     <ul
       aria-describedby="carousel-mock_unique_id__instructions"
       aria-label="carousel"
-      data-css-1f0n9j9=""
+      data-css-1d3rq9b=""
       id="carousel-mock_unique_id"
       onKeyDown={[Function]}
       role="region"
@@ -2080,7 +2363,7 @@ exports[`Storyshots Carousel/with Card wide 1`] = `
     <ul
       aria-describedby="carousel-mock_unique_id__instructions"
       aria-label="carousel"
-      data-css-1f0n9j9=""
+      data-css-1d3rq9b=""
       id="carousel-mock_unique_id"
       onKeyDown={[Function]}
       role="region"

--- a/packages/carousel/src/react/__stories__/index.story.js
+++ b/packages/carousel/src/react/__stories__/index.story.js
@@ -1,11 +1,13 @@
 import { storiesOf } from '@storybook/react'
 
-import * as glamor from 'glamor'
+import { css } from 'glamor'
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 
-import ActionMenu from '@pluralsight/ps-design-system-actionmenu/react'
-import Card from '@pluralsight/ps-design-system-card/react'
+import ActionMenu from '@pluralsight/ps-design-system-actionmenu/react.js'
+import Card from '@pluralsight/ps-design-system-card/react.js'
+import Icon from '@pluralsight/ps-design-system-icon/react.js'
+import { BelowRight } from '@pluralsight/ps-design-system-position/react.js'
 
 import Carousel from '../index.js'
 
@@ -41,7 +43,7 @@ const longStringsMetaData = [
 
 const MockItem = props => (
   <div
-    {...glamor.css({
+    {...css({
       alignItems: 'center',
       background: 'pink',
       display: 'flex',
@@ -89,7 +91,7 @@ storiesOf('Carousel/items', module)
           </Carousel>
 
           <div
-            {...glamor.css({
+            {...css({
               alignItems: 'center',
               display: 'flex',
               justifyContent: 'center',
@@ -181,20 +183,77 @@ Object.values(Carousel.sizes).forEach(size => {
   ))
 })
 
-storiesOf('Carousel/with ActionMenu', module).add('positioned child', () => (
-  <div style={{ border: '1px solid red', maxWidth: 400, padding: 10 }}>
-    <Carousel size={Carousel.sizes.wide}>
-      <MockItem>
-        <ActionMenu style={{ left: 20, top: 20 }}>
-          {new Array(8).fill(null).map((_, index) => (
-            <ActionMenu.Item key={index}>item: {index}</ActionMenu.Item>
-          ))}
-        </ActionMenu>
-      </MockItem>
+storiesOf('Carousel/with ActionMenu', module)
+  .add('positioned child', () => (
+    <div style={{ border: '1px solid red', maxWidth: 400, padding: 10 }}>
+      <Carousel size={Carousel.sizes.wide}>
+        <MockItem>
+          <ActionMenu style={{ left: 20, top: 20 }}>
+            {new Array(8).fill(null).map((_, index) => (
+              <ActionMenu.Item key={index}>item: {index}</ActionMenu.Item>
+            ))}
+          </ActionMenu>
+        </MockItem>
 
-      {new Array(13).fill(null).map((_, index) => (
-        <MockItem key={index} />
-      ))}
-    </Carousel>
-  </div>
-))
+        {new Array(13).fill(null).map((_, index) => (
+          <MockItem key={index} />
+        ))}
+      </Carousel>
+    </div>
+  ))
+  .add('in portal', () => {
+    function PortalStory() {
+      const [isOpen, setOpen] = React.useState(false)
+      return (
+        <div style={{ border: '1px solid red', maxWidth: 600, padding: 10 }}>
+          <Carousel
+            size={Carousel.sizes.wide}
+            controls={
+              <Carousel.Controls>
+                <Carousel.Control
+                  direction={Carousel.Control.directions.prev}
+                  onClick={_ => setOpen(false)}
+                />
+                <Carousel.Control
+                  direction={Carousel.Control.directions.next}
+                  onClick={_ => setOpen(false)}
+                />
+              </Carousel.Controls>
+            }
+          >
+            <MockCard
+              actionBarVisible
+              actionBar={[
+                <BelowRight
+                  inNode={document.body}
+                  when={isOpen}
+                  show={
+                    <ActionMenu>
+                      {new Array(8).fill(null).map((_, index) => (
+                        <ActionMenu.Item key={index}>
+                          item: {index}
+                        </ActionMenu.Item>
+                      ))}
+                    </ActionMenu>
+                  }
+                  key="a"
+                >
+                  <Card.Action
+                    title="asdf"
+                    icon={<Icon id={Icon.ids.more} />}
+                    key="asdf"
+                    onClick={_ => setOpen(!isOpen)}
+                  />
+                </BelowRight>
+              ]}
+              titleText="Yahoo"
+            />
+            {new Array(3).fill(null).map((_, index) => (
+              <MockItem key={index} />
+            ))}
+          </Carousel>
+        </div>
+      )
+    }
+    return <PortalStory />
+  })

--- a/packages/carousel/src/react/index.js
+++ b/packages/carousel/src/react/index.js
@@ -26,11 +26,7 @@ const styles = {
       css(stylesheet['.psds-carousel']),
       ready && css(stylesheet['.psds-carousel--ready'])
     ),
-  pages: (props, { transitioning }) =>
-    compose(
-      css(stylesheet['.psds-carousel__pages']),
-      transitioning && css(stylesheet['.psds-carousel__pages--transitioning'])
-    ),
+  pages: props => compose(css(stylesheet['.psds-carousel__pages'])),
   page: props =>
     compose(
       css(stylesheet['.psds-carousel__page']),
@@ -179,24 +175,6 @@ function Instructions(props) {
 
 const Pages = React.forwardRef((props, ref) => {
   const context = React.useContext(CarouselContext)
-  const prevActivePage = usePrevious(context.activePage)
-  const [transitioning, setTransitioning] = React.useState(false)
-
-  React.useEffect(() => {
-    let timer
-    const starting =
-      prevActivePage !== undefined && prevActivePage !== context.activePage
-
-    if (starting) {
-      setTransitioning(true)
-    } else {
-      timer = setTimeout(() => {
-        setTransitioning(false)
-      }, TRANSITION_DURATION_MS)
-    }
-
-    return () => clearTimeout(timer)
-  }, [context.activePage, prevActivePage])
 
   useSwipe(ref, {
     onSwipeLeft: props.onSwipeLeft,
@@ -211,7 +189,7 @@ const Pages = React.forwardRef((props, ref) => {
       ref={ref}
       role="region"
       tabIndex="0"
-      {...styles.pages(props, { transitioning })}
+      {...styles.pages(props)}
       {...filterReactProps(props)}
     />
   )
@@ -310,14 +288,4 @@ function usePager(pageCount, additionalSideEffectTriggers = []) {
     prev,
     ref
   }
-}
-
-function usePrevious(value) {
-  const ref = React.useRef()
-
-  React.useEffect(() => {
-    ref.current = value
-  }, [value])
-
-  return ref.current
 }

--- a/packages/site/pages/components/carousel.js
+++ b/packages/site/pages/components/carousel.js
@@ -1,9 +1,15 @@
 import React from 'react'
 
+import ActionMenu from '@pluralsight/ps-design-system-actionmenu/react.js'
 import Avatar from '@pluralsight/ps-design-system-avatar/react.js'
+import { BelowRight } from '@pluralsight/ps-design-system-position/react.js'
 import Card from '@pluralsight/ps-design-system-card/react.js'
 import Carousel from '@pluralsight/ps-design-system-carousel/react.js'
+import Icon from '@pluralsight/ps-design-system-icon/react.js'
+import core from '@pluralsight/ps-design-system-core'
 import Note from '@pluralsight/ps-design-system-note/react.js'
+import Text from '@pluralsight/ps-design-system-text/react.js'
+import Theme from '@pluralsight/ps-design-system-theme/react.js'
 
 import {
   Chrome,
@@ -12,6 +18,7 @@ import {
   Example,
   Guideline,
   Intro,
+  Link,
   P,
   PageHeading,
   PropTypes,
@@ -238,7 +245,7 @@ export default _ => (
         }}
       />
 
-      <SectionHeading>In-app example</SectionHeading>
+      <SectionHeading>Auto paging</SectionHeading>
       <P>The number and width of items are handled automatically.</P>
 
       <Example.React
@@ -265,6 +272,20 @@ export default _ => (
 `
         ]}
       />
+
+      <SectionHeading>Using portals</SectionHeading>
+      <P>
+        If there are any UI elements that need to appear in the same visual
+        space as the carousel container, they will need to be rendered outside
+        the <Text.Code>Carousel</Text.Code> DOM. This is because the Carousel
+        container solution requires being styled{' '}
+        <Text.Code>overflow: hidden</Text.Code>. A{' '}
+        <Link href="https://reactjs.org/docs/portals.html">React Portal</Link>{' '}
+        is a great solution. A common example could be an{' '}
+        <Text.Code>ActionMenu</Text.Code> rendered from a{' '}
+        <Text.Code>Card</Text.Code>. Here is some example code:
+      </P>
+      <PortalExample />
 
       <SectionHeading>Size</SectionHeading>
       <P>
@@ -410,3 +431,85 @@ export default _ => (
     </Content>
   </Chrome>
 )
+
+function PortalExample() {
+  const [courseIdForOpenMenu, openCourseMenu] = React.useState(-1)
+
+  function handleClickMore(evt, courseId) {
+    evt.preventDefault()
+    console.log('click more', { courseId })
+    if (courseId === courseIdForOpenMenu) {
+      openCourseMenu(-1)
+    } else {
+      openCourseMenu(courseId)
+    }
+  }
+
+  return (
+    <Theme>
+      <style jsx>{`
+        .example {
+          padding: ${core.layout.spacingLarge};
+          background: ${core.colors.gray06};
+          color: ${core.colors.white};
+          min-height: 200px;
+        }
+        .label {
+          padding: ${core.layout.spacingLarge} 0;
+          font-size: ${core.type.fontSizeMedium};
+        }
+      `}</style>
+
+      <div className="example">
+        <Carousel
+          size={Carousel.sizes.wide}
+          controls={
+            <Carousel.Controls>
+              <Carousel.Control
+                direction={Carousel.Control.directions.prev}
+                onClick={_ => openCourseMenu(-1)}
+              />
+              <Carousel.Control
+                direction={Carousel.Control.directions.next}
+                onClick={_ => openCourseMenu(-1)}
+              />
+            </Carousel.Controls>
+          }
+        >
+          {MOCK_DATA.courses.map(course => (
+            <Card
+              key={course.id}
+              image={<Card.Image src={course.image} />}
+              metadata1={[course.author, course.level]}
+              title={<Card.Title>{course.title}</Card.Title>}
+              actionBarVisible
+              actionBar={[
+                <BelowRight
+                  inNode={typeof document !== 'undefined' && document.body}
+                  when={course.id === courseIdForOpenMenu}
+                  show={
+                    <ActionMenu>
+                      {new Array(8).fill(null).map((_, index) => (
+                        <ActionMenu.Item key={index}>
+                          Useless menu item {index}
+                        </ActionMenu.Item>
+                      ))}
+                    </ActionMenu>
+                  }
+                  key="a"
+                >
+                  <Card.Action
+                    title="See more"
+                    icon={<Icon id={Icon.ids.more} />}
+                    key="more"
+                    onClick={evt => handleClickMore(evt, course.id)}
+                  />
+                </BelowRight>
+              ]}
+            />
+          ))}
+        </Carousel>
+      </div>
+    </Theme>
+  )
+}


### PR DESCRIPTION
Overflow hidden is back.  Added a story in Carousel to support it.  Added forwardRef to Card to support that.  

*Problem*: Now I'm in site, adding docs for how one might do this IRL.  But, it's slow!  I'd love your thoughts on this, @EdwardIrby and @danethurber .  A couple things to look at:

1. The carousel paging seems slower than the others.  I wonder why that would be.
2. The "more" context menu click takes a long! time.  It also scrolls me to the top of the page on first click.

I'll keep looking at this later, but I thought I might make this available in case you had ideas.  Thanks!