### PR TITLE
feat(banner): add button component

### DIFF
--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.10.1",
+    "@pluralsight/ps-design-system-button": "*",
     "@pluralsight/ps-design-system-storybook-addon-theme": "^4.0.1"
   }
 }

--- a/packages/banner/src/css/index.js
+++ b/packages/banner/src/css/index.js
@@ -31,6 +31,13 @@ export default {
     backgroundColor: core.colors.red
   },
 
+  '.psds-banner__button': {
+    '&:hover, &:active, &:focus': {
+      transition: `all ${core.motion.speedNormal}`,
+      opacity: '0.65'
+    }
+  },
+
   '.psds-banner__text': {
     flex: '1',
     textAlign: 'center',

--- a/packages/banner/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/banner/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -1,5 +1,137 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Button blue 1`] = `
+<div
+  data-css-claeju=""
+>
+  <div
+    data-css-13j4h8v=""
+  >
+    <div
+      data-css-s10s6t=""
+    >
+      this is the text with a 
+      <button
+        data-css-8e2uc6=""
+        data-css-mdmyt1=""
+        disabled={false}
+        style={
+          Object {
+            "borderColor": "currentColor",
+            "color": "currentColor",
+          }
+        }
+      >
+        <span
+          data-css-15b13by=""
+        >
+          button
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Button green 1`] = `
+<div
+  data-css-claeju=""
+>
+  <div
+    data-css-g8uz7t=""
+  >
+    <div
+      data-css-s10s6t=""
+    >
+      this is the text with a 
+      <button
+        data-css-8e2uc6=""
+        data-css-mdmyt1=""
+        disabled={false}
+        style={
+          Object {
+            "borderColor": "currentColor",
+            "color": "currentColor",
+          }
+        }
+      >
+        <span
+          data-css-15b13by=""
+        >
+          button
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Button red 1`] = `
+<div
+  data-css-claeju=""
+>
+  <div
+    data-css-1j58ngq=""
+  >
+    <div
+      data-css-s10s6t=""
+    >
+      this is the text with a 
+      <button
+        data-css-8e2uc6=""
+        data-css-mdmyt1=""
+        disabled={false}
+        style={
+          Object {
+            "borderColor": "currentColor",
+            "color": "currentColor",
+          }
+        }
+      >
+        <span
+          data-css-15b13by=""
+        >
+          button
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Button yellow 1`] = `
+<div
+  data-css-claeju=""
+>
+  <div
+    data-css-jrrxjl=""
+  >
+    <div
+      data-css-s10s6t=""
+    >
+      this is the text with a 
+      <button
+        data-css-8e2uc6=""
+        data-css-mdmyt1=""
+        disabled={false}
+        style={
+          Object {
+            "borderColor": "currentColor",
+            "color": "currentColor",
+          }
+        }
+      >
+        <span
+          data-css-15b13by=""
+        >
+          button
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots color blue 1`] = `
 <div
   data-css-claeju=""
@@ -316,7 +448,7 @@ exports[`Storyshots styling child anchor tag auto-styled in yellow 1`] = `
 </div>
 `;
 
-exports[`Storyshots styling className prop  1`] = `
+exports[`Storyshots styling className prop 1`] = `
 <div
   data-css-claeju=""
 >
@@ -351,7 +483,7 @@ exports[`Storyshots styling className prop  1`] = `
 </div>
 `;
 
-exports[`Storyshots styling style prop  1`] = `
+exports[`Storyshots styling style prop 1`] = `
 <div
   data-css-claeju=""
 >

--- a/packages/banner/src/react/__specs__/index.spec.js
+++ b/packages/banner/src/react/__specs__/index.spec.js
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import Banner from '../index.js'
+
+describe('Banner', () => {
+  it('renders', () => {
+    const { getByTestId } = render(
+      <Banner data-testid="undertest">text</Banner>
+    )
+
+    expect(getByTestId('undertest')).toBeInTheDocument()
+  })
+
+  it('forwards refs', () => {
+    const ref = React.createRef()
+    const buttonRef = React.createRef()
+
+    render(
+      <Banner ref={ref}>
+        text <Banner.Button ref={buttonRef}>button</Banner.Button>
+      </Banner>
+    )
+
+    expect(ref.current).not.toBeNull()
+    expect(buttonRef.current).not.toBeNull()
+  })
+})

--- a/packages/banner/src/react/__stories__/index.story.js
+++ b/packages/banner/src/react/__stories__/index.story.js
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 
 import Link from '@pluralsight/ps-design-system-link/react.js'
+
 import Banner from '../index.js'
 
 const colorStory = storiesOf('color', module)
@@ -31,13 +32,22 @@ storiesOf('onClick', module)
     ))
   )
 
+const buttonStory = storiesOf('Button', module)
+Object.keys(Banner.colors).forEach(color =>
+  buttonStory.add(color, _ => (
+    <Banner color={color}>
+      this is the text with a <Banner.Button>button</Banner.Button>
+    </Banner>
+  ))
+)
+
 storiesOf('styling', module)
-  .add('style prop ', () => (
+  .add('style prop', () => (
     <Banner style={{ outline: '3px solid red' }} onClick={action('click X')}>
       this is the text
     </Banner>
   ))
-  .add('className prop ', () => (
+  .add('className prop', () => (
     <Banner className="someClass" onClick={action('click X')}>
       this is the text
     </Banner>

--- a/packages/banner/src/react/index.js
+++ b/packages/banner/src/react/index.js
@@ -1,15 +1,21 @@
-import { css } from 'glamor'
-import filterReactProps from '@pluralsight/ps-design-system-filter-react-props'
-import Icon from '@pluralsight/ps-design-system-icon/react.js'
+import { compose, css } from 'glamor'
 import PropTypes from 'prop-types'
 import React from 'react'
+
+import BaseButton from '@pluralsight/ps-design-system-button/react.js'
+import filterReactProps from '@pluralsight/ps-design-system-filter-react-props'
+import Icon from '@pluralsight/ps-design-system-icon/react.js'
 
 import stylesheet from '../css/index.js'
 import * as vars from '../vars/index.js'
 
 const styles = {
   banner: ({ color }) =>
-    css(stylesheet['.psds-banner'], stylesheet[`.psds-banner--color-${color}`]),
+    compose(
+      css(stylesheet['.psds-banner']),
+      css(stylesheet[`.psds-banner--color-${color}`])
+    ),
+  button: () => css(stylesheet['.psds-banner__button']),
   dismiss: () => css(stylesheet['.psds-banner__dismiss']),
   text: () => css(stylesheet['.psds-banner__text'])
 }
@@ -29,6 +35,7 @@ const Banner = React.forwardRef((props, ref) => {
 })
 
 Banner.displayName = 'Banner'
+
 Banner.propTypes = {
   color: PropTypes.oneOf(Object.keys(vars.colors).map(key => vars.colors[key])),
   children: PropTypes.node.isRequired,
@@ -37,8 +44,21 @@ Banner.propTypes = {
 Banner.defaultProps = {
   color: vars.colors.blue
 }
-Banner.colors = vars.colors
 
+const Button = React.forwardRef((props, forwardRef) => (
+  <BaseButton
+    {...styles.button()}
+    {...props}
+    ref={forwardRef}
+    appearance={BaseButton.appearances.stroke}
+    size={BaseButton.sizes.small}
+    style={{ borderColor: 'currentColor', color: 'currentColor' }}
+  />
+))
+
+Banner.Button = Button
+
+Banner.colors = vars.colors
 export const colors = vars.colors
 
 export default Banner

--- a/packages/site/pages/components/banner.js
+++ b/packages/site/pages/components/banner.js
@@ -29,24 +29,31 @@ export default _ => (
       </Code>
 
       <PropTypes
-        props={[
-          PropTypes.row([
-            'color',
-            PropTypes.union(Banner.colors),
-            null,
-            <code>{Banner.colors.blue}</code>,
-            <span>
-              banner color (from <code>Banner.colors</code>)
-            </span>
-          ]),
-          PropTypes.row([
-            'onClick',
-            'Event => ()',
-            null,
-            null,
-            'displays dismiss button, triggered on click'
-          ])
-        ]}
+        props={{
+          Banner: [
+            PropTypes.row([
+              'color',
+              PropTypes.union(Banner.colors),
+              null,
+              <code>{Banner.colors.blue}</code>,
+              <span>
+                banner color (from <code>Banner.colors</code>)
+              </span>
+            ]),
+            PropTypes.row([
+              'onClick',
+              'Event => ()',
+              null,
+              null,
+              'displays dismiss button, triggered on click'
+            ])
+          ],
+          'Banner.Button': [
+            PropTypes.row(['children', 'string', true, null]),
+            PropTypes.row(['href', 'string', null, null]),
+            PropTypes.row(['onClick', 'Event => ()', null, null])
+          ]
+        }}
       />
 
       <SectionHeading>Color</SectionHeading>
@@ -74,6 +81,22 @@ export default _ => (
         includes={{ Banner }}
         codes={[
           `<Banner onClick={_ => alert('Clicked to dismiss!')}>User should be able to dismiss this.</Banner>`
+        ]}
+      />
+
+      <SectionHeading>Inline Buttons</SectionHeading>
+      <P>
+        For little added oomph to get your point across, you can inline a
+        button.
+      </P>
+      <Example.React
+        orient="vertical"
+        includes={{ Banner }}
+        codes={[
+          `
+<Banner>
+  Maybe you've got a message and then BAM...it's a <Banner.Button>button</Banner.Button>
+</Banner>`
         ]}
       />
     </Content>

--- a/packages/site/pages/components/button.js
+++ b/packages/site/pages/components/button.js
@@ -72,13 +72,6 @@ export default _ => (
             </span>
           ]),
           PropTypes.row([
-            'innerRef',
-            'DOM element => ()',
-            null,
-            null,
-            'react ref callback'
-          ]),
-          PropTypes.row([
             'loading',
             'boolean',
             null,


### PR DESCRIPTION
### What You're Solving

- resolves #665

### Design Decisions

`Banner` now includes `Banner.Button`

I tried out a couple different approach but was hitting issues with css specificity in regards to the button styles. Our glamor setup was making it really difficult to fix the css order and specificity. I opted to create a new subcomponent(`Banner.Button`) which I feel is the best way to ensure the correct styles are applied. I also prefer this approach to encapsulate and ensure the right type of button is used.