### PR TITLE
site: add imports to example

### DIFF
--- a/packages/site/pages/components/actionmenu.js
+++ b/packages/site/pages/components/actionmenu.js
@@ -106,7 +106,11 @@ function InAppExample() {
       </Theme>
 
       <Code collapsible language="javascript">
-        {`function InAppExample() {
+        {`import ActionMenu from '@pluralsight/ps-design-system-actionmenu/react.js'
+import { BelowLeft } from '@pluralsight/ps-design-system-position/react.js'
+import Button from '@pluralsight/ps-design-system-button/react.js'
+
+function InAppExample() {
   const categories = [
     {
       name: 'Channels',


### PR DESCRIPTION
To bring clarity to this question:

> Hey there — basic question perhaps, but does BelowLeft in the first in-app example here refer to something in the design system? https://design-system.pluralsight.com/components/actionmenu