### PR TITLE
feat(icon): alternate caret icons

### DIFF
--- a/packages/icon/src/react/__stories__/index.story.js
+++ b/packages/icon/src/react/__stories__/index.story.js
@@ -2,7 +2,7 @@ import { css } from 'glamor'
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import Icon from '..'
+import Icon from '../index.js'
 
 const styles = {
   grid: css({

--- a/packages/icon/src/svg/caret-alt-down.icon.svg
+++ b/packages/icon/src/svg/caret-alt-down.icon.svg
@@ -1,0 +1,3 @@
+<svg role="img" aria-label="caret down icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1661 13.8525C12.0714 13.9367 11.9286 13.9367 11.8339 13.8525L7.99145 10.437C7.81964 10.2843 7.92767 10.0001 8.15755 10.0001H15.8424C16.0723 10.0001 16.1804 10.2843 16.0085 10.437L12.1661 13.8525Z" />
+</svg>

--- a/packages/icon/src/svg/caret-alt-left.icon.svg
+++ b/packages/icon/src/svg/caret-alt-left.icon.svg
@@ -1,0 +1,3 @@
+<svg role="img" aria-label="caret left icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M9.14762 12.1663C9.06342 12.0715 9.06342 11.9288 9.14762 11.8341L12.5631 7.99164C12.7159 7.81982 13 7.92785 13 8.15773V15.8426C13 16.0725 12.7159 16.1805 12.5631 16.0087L9.14762 12.1663Z" />
+</svg>

--- a/packages/icon/src/svg/caret-alt-right.icon.svg
+++ b/packages/icon/src/svg/caret-alt-right.icon.svg
@@ -1,0 +1,3 @@
+<svg role="img" aria-label="caret right icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M14.8524 12.1663C14.9366 12.0715 14.9366 11.9288 14.8524 11.8341L11.4369 7.99164C11.2841 7.81982 11 7.92785 11 8.15773V15.8426C11 16.0725 11.2841 16.1805 11.4369 16.0087L14.8524 12.1663Z" />
+</svg>

--- a/packages/icon/src/svg/caret-alt-up.icon.svg
+++ b/packages/icon/src/svg/caret-alt-up.icon.svg
@@ -1,0 +1,3 @@
+<svg role="img" aria-label="caret up icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M12.1661 10.1477C12.0714 10.0635 11.9287 10.0635 11.834 10.1477L7.99152 13.5633C7.8197 13.716 7.92773 14.0001 8.15761 14.0001H15.8425C16.0724 14.0001 16.1804 13.716 16.0086 13.5633L12.1661 10.1477Z" />
+</svg>


### PR DESCRIPTION
this was a request from gitprime. we already use this icon in the Dropdown but there isn't a version that is exposed in the Icons package. Gitprime would like these icons as they built out some custom components