### PR TITLE
refactor(site): adjust examples to prevent theme toggle overlapping

### DIFF
--- a/packages/site/src/ui/example/react.js
+++ b/packages/site/src/ui/example/react.js
@@ -38,7 +38,7 @@ const OutputDecorationGlobalStyles = _ => (
       display: flex;
       flex-direction: column;
       justify-content: flex-start;
-      padding: ${core.layout.spacingLarge};
+      padding: ${core.layout.spacingXLarge} ${core.layout.spacingLarge};
       background: ${core.colors.gray06};
       overflow: hidden;
     }

--- a/packages/site/src/ui/theme-toggle.js
+++ b/packages/site/src/ui/theme-toggle.js
@@ -12,8 +12,8 @@ function ThemeToggle(props) {
       <style jsx>{`
         .toggle {
           position: absolute;
-          top: ${core.layout.spacingMedium};
-          right: ${core.layout.spacingMedium};
+          top: ${core.layout.spacingXSmall};
+          right: ${core.layout.spacingXSmall};
           z-index: 1;
         }
       `}</style>


### PR DESCRIPTION
I adjusted the position of the theme toggle to move it closer to the top-right edge of the example div, and added more padding to the top & bottom of the example div so there would be no overlapping of the theme toggle and the examples.

![Example Padding - Before - After](https://user-images.githubusercontent.com/48542/66689123-c0525d80-ec46-11e9-9b56-91e9ad8ee77c.png)
