### PR TITLE
fix(datepicker): fix onblur behavior for subfields in datepicker

### DIFF
--- a/packages/datepicker/src/react/__specs__/index.spec.js
+++ b/packages/datepicker/src/react/__specs__/index.spec.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 
 import * as vars from '../../vars/index.js'
 
@@ -22,6 +22,28 @@ describe('DatePicker', () => {
     render(<DatePicker ref={ref} />)
 
     expect(ref.current).not.toBeNull()
+  })
+
+  describe('onSelect prop', () => {
+    it('should call onSelect when onBlur is called for a valid date', () => {
+      const onSelectMock = jest.fn()
+      const { getByDisplayValue } = render(
+        <DatePicker value="8/14/2001" onSelect={onSelectMock} />
+      )
+      fireEvent.blur(getByDisplayValue('2001'))
+      expect(onSelectMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not call onSelect when onBlur is called for an invalid date', () => {
+      const onSelectMock = jest.fn()
+      const { getByDisplayValue } = render(
+        <DatePicker value="8/14/2001" onSelect={onSelectMock} />
+      )
+      const yearSubField = getByDisplayValue('2001')
+      fireEvent.change(yearSubField, { target: { value: '' } })
+      fireEvent.blur(yearSubField)
+      expect(onSelectMock).not.toHaveBeenCalled()
+    })
   })
 
   describe('with a controlled value', () => {

--- a/packages/datepicker/src/react/__specs__/index.spec.js
+++ b/packages/datepicker/src/react/__specs__/index.spec.js
@@ -34,7 +34,7 @@ describe('DatePicker', () => {
       expect(onSelectMock).toHaveBeenCalledTimes(1)
     })
 
-    it('should not call onSelect when onBlur is called for an invalid date', () => {
+    it('should call onSelect when onBlur is called for an invalid date', () => {
       const onSelectMock = jest.fn()
       const { getByDisplayValue } = render(
         <DatePicker value="8/14/2001" onSelect={onSelectMock} />
@@ -42,7 +42,8 @@ describe('DatePicker', () => {
       const yearSubField = getByDisplayValue('2001')
       fireEvent.change(yearSubField, { target: { value: '' } })
       fireEvent.blur(yearSubField)
-      expect(onSelectMock).not.toHaveBeenCalled()
+      expect(onSelectMock).toHaveBeenCalledTimes(1)
+      expect(onSelectMock).toHaveBeenCalledWith(null)
     })
   })
 

--- a/packages/datepicker/src/react/index.js
+++ b/packages/datepicker/src/react/index.js
@@ -154,6 +154,7 @@ const DatePicker = React.forwardRef((props, ref) => {
     )
 
     const nextDate = {
+      ...currentDateOverwrittenByEventValue,
       dd: alwaysReValidateDay,
       [name]: forceValidValueFor[name](currentDateOverwrittenByEventValue)
     }


### PR DESCRIPTION
- Fixes `nextDate` object key-values to include month and year values in the `handleSubFieldBlur` function
- Add `onSelect` unit tests for the DatePicker

### What You're Solving

Resolves issue #687 - Fixes `onBlur` not calling `onSelect` for valid dates

### How to Verify

1. Pass the DatePicker an `onSelect` prop
2. Trigger a blur event with a valid date by focusing and unfocusing out of a SubField in the DatePicker
3. Ensure that the function passed to `onSelect` was called
