### PR TITLE
fix(link): fix link typescript declaration file

### DIFF
--- a/packages/link/react.d.ts
+++ b/packages/link/react.d.ts
@@ -1,10 +1,13 @@
 /// <reference types="react" />
 
-type Appearance = 'default' | 'subtle'
+type AppearanceMap = { default: 'default'; subtle: 'subtle' }
 
+type Appearance = keyof AppearanceMap
 export interface LinkProps {
   appearance?: Appearance
 }
 
-export default function Link(props: LinkProps): React.Component<LinkProps>
-
+declare const Link: React.FunctionComponent<LinkProps> & {
+  appearances: AppearanceMap
+}
+export default Link


### PR DESCRIPTION
### What You're Solving

- Fixes the TypeScript declaration file for the `Link` component.
  - This fixes the `appearances` reference described in the docs, eg. `Link.appearances.subtle`

### Design Decisions

The current declaration file does not include a reference to appearances in the `Link` export and should have the `Component` updated to `FunctionComponent` to allow `children` props.

### How to Verify

Import `Link` into a `.tsx` file and use with a React component. TypeScript should no longer throw the following error:
```
Type '{ children: Element; appearance: any; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
  Property 'children' does not exist on type 'IntrinsicAttributes & LinkProps'.ts(2322)```
