### PR TITLE
collapsible: animation & height issues

### DIFF
--- a/packages/collapsible/src/__specs__/index.spec.js
+++ b/packages/collapsible/src/__specs__/index.spec.js
@@ -12,7 +12,7 @@ describe('Collapsible', () => {
     )
     const wrapper = container.querySelector('[aria-hidden]')
     expect(wrapper).toHaveAttribute('aria-hidden', 'false')
-    expect(wrapper).not.toHaveStyle(`height: 0`)
+    expect(wrapper).toHaveStyle(`height: auto`)
     rerender(
       <Collapsible isOpen={false}>
         <div>content</div>

--- a/packages/collapsible/src/index.js
+++ b/packages/collapsible/src/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback } from 'react'
 import filterReactProps from '@pluralsight/ps-design-system-filter-react-props'
 
 // NOTE: see https://stackoverflow.com/a/3485654
@@ -78,22 +78,19 @@ const close = element => {
 }
 
 const Collapsible = ({ isOpen, tagName, ...rest }) => {
-  const containerElement = useRef()
+  const containerRef = useCallback(
+    node => {
+      if (node) isOpen ? open(node) : close(node)
+    },
+    [isOpen]
+  )
 
-  useEffect(() => {
-    setTimeout(() => {
-      const element = containerElement.current
-      if (!element) return
-
-      isOpen ? open(element) : close(element)
-    }, 0)
-  }, [isOpen])
   const TagName = tagName
   return (
     <TagName
       aria-hidden={!isOpen}
       {...filterReactProps(rest)}
-      ref={containerElement}
+      ref={containerRef}
     />
   )
 }

--- a/packages/collapsible/src/index.js
+++ b/packages/collapsible/src/index.js
@@ -22,6 +22,10 @@ const setTransitionEnabled = (enabled, element) => {
 }
 
 const waitForHeightTransitionToEnd = element => {
+  const isAlreadyAtTargetHeight =
+    element.style.height === `${element.getBoundingClientRect().height}px`
+  if (isAlreadyAtTargetHeight) return Promise.resolve()
+
   return new Promise(resolve => {
     element.addEventListener(
       'transitionend',
@@ -42,12 +46,15 @@ const updateOverflowStyle = ({ element, isOpen, isTransitioning = false }) => {
   }
 }
 
-const open = (element, isOpen) => {
+const isClosed = element => element.getBoundingClientRect().height === 0
+
+const open = element => {
   setHeightToAuto(element)
   updateOverflowStyle({ element, isOpen: true, isTransitioning: true })
-  return waitForHeightTransitionToEnd(element).then(() => {
-    if (isOpen) {
-      updateOverflowStyle(true, false)
+
+  waitForHeightTransitionToEnd(element).then(() => {
+    if (!isClosed(element)) {
+      updateOverflowStyle({ element, isOpen: true, isTransitioning: false })
       setTransitionEnabled(false, element)
       element.style.height = 'auto'
       forceRepaint(element)
@@ -56,7 +63,7 @@ const open = (element, isOpen) => {
   })
 }
 
-const close = (element, isOpen) => {
+const close = element => {
   setTransitionEnabled(false, element)
   element.style.height = window.getComputedStyle(element).height
   forceRepaint(element)
@@ -64,10 +71,9 @@ const close = (element, isOpen) => {
   setTransitionEnabled(true, element)
   element.style.height = '0px'
 
-  return waitForHeightTransitionToEnd(element).then(() => {
-    if (!isOpen) {
-      updateOverflowStyle(false, false)
-    }
+  waitForHeightTransitionToEnd(element).then(() => {
+    if (isClosed(element))
+      updateOverflowStyle({ element, isOpen: false, isTransitioning: false })
   })
 }
 
@@ -75,16 +81,12 @@ const Collapsible = ({ isOpen, tagName, ...rest }) => {
   const containerElement = useRef()
 
   useEffect(() => {
-    if (isOpen)
-      setTimeout(
-        () =>
-          containerElement.current && open(containerElement.current, isOpen),
-        0
-      )
-    else {
-      containerElement.current.style.height = 0
-      containerElement.current && close(containerElement.current, isOpen)
-    }
+    setTimeout(() => {
+      const element = containerElement.current
+      if (!element) return
+
+      isOpen ? open(element) : close(element)
+    }, 0)
   }, [isOpen])
   const TagName = tagName
   return (


### PR DESCRIPTION
### What You're Solving

1. Fixes close animations not working. The bug was caused by the height
not being set to the calculated auto height before being set to zero. Fixed
by not setting height to 0 before calculating the height.

1. Fixes the container not resizing with its content when it starts open. The
bug was caused by the height not being set to "auto" when it starts opened.
Fixed by resolving waitForHeightTransitionToEnd() if container is already at
target height.

1. Fixes the drawer breaking if user opens while it's closing or vice versa.
The bug was caused by not checking if the collapse was in the expected
state after the animation finishes. Fixed by checking the measured height
of the element after the animation finished and only doing close/open cleanup
code if the container is closed/opened.

### How to Verify

1. When closing the collapsible it should animate smoothly instead of snapping shut.

1. Create a collapsible that starts open. Modify the content or the height of the content inside the container. The container should update its height accordingly instead of staying the same height.

1. This wasn't a bug before but we had to add some code to prevent it from happening with our other changes. When closing the collapsible, open it while it's animating closed. It should render correctly.
