### PR TITLE
Layout page width

### DIFF
--- a/packages/layout/src/css/aside-layout.js
+++ b/packages/layout/src/css/aside-layout.js
@@ -1,4 +1,4 @@
-import * as core from '@pluralsight/ps-design-system-core'
+import { layout } from '@pluralsight/ps-design-system-core'
 
 import { asideLayout as vars } from '../vars/index.js'
 
@@ -13,10 +13,10 @@ export default {
     flexDirection: 'column-reverse'
   },
   [`.psds-aside-layout__aside--aside-position-${vars.asidePositions.first}`]: {
-    marginBottom: core.layout.spacingLarge
+    marginBottom: layout.spacingLarge
   },
   [`.psds-aside-layout__aside--aside-position-${vars.asidePositions.last}`]: {
-    marginTop: core.layout.spacingLarge
+    marginTop: layout.spacingLarge
   },
   '@media (min-width: 769px)': {
     [`.psds-aside-layout--aside-position-${vars.asidePositions.first}`]: {
@@ -30,11 +30,11 @@ export default {
     },
     [`.psds-aside-layout__aside--aside-position-${vars.asidePositions.first}`]: {
       marginBottom: 0,
-      marginRight: core.layout.spacingLarge
+      marginRight: layout.spacingLarge
     },
     [`.psds-aside-layout__aside--aside-position-${vars.asidePositions.last}`]: {
       marginTop: 0,
-      marginLeft: core.layout.spacingLarge
+      marginLeft: layout.spacingLarge
     },
     '.psds-aside-layout__main': {
       width: 'calc(75%)'

--- a/packages/layout/src/css/equal-column-layout.js
+++ b/packages/layout/src/css/equal-column-layout.js
@@ -1,4 +1,4 @@
-import * as core from '@pluralsight/ps-design-system-core'
+import { layout } from '@pluralsight/ps-design-system-core'
 
 import { equalColumnLayout as vars } from '../vars/index.js'
 
@@ -6,10 +6,10 @@ export default {
   '.psds-equal-column-layout': {
     display: 'flex',
     flexWrap: 'wrap',
-    margin: `calc(${core.layout.spacingLarge} / -2)`
+    margin: `calc(${layout.spacingLarge} / -2)`
   },
   '.psds-equal-column-layout__column': {
-    margin: `calc(${core.layout.spacingLarge} / 2)`
+    margin: `calc(${layout.spacingLarge} / 2)`
   },
   [`.psds-equal-column-layout__column--count-${vars.counts.two}`]: {
     width: '100%'
@@ -18,23 +18,23 @@ export default {
     width: '100%'
   },
   [`.psds-equal-column-layout__column--count-${vars.counts.four}`]: {
-    width: `calc(50% - ${core.layout.spacingLarge})`
+    width: `calc(50% - ${layout.spacingLarge})`
   },
   [`.psds-equal-column-layout__column--count-${vars.counts.six}`]: {
-    width: `calc(50% - ${core.layout.spacingLarge})`
+    width: `calc(50% - ${layout.spacingLarge})`
   },
   '@media (min-width: 769px)': {
     [`.psds-equal-column-layout__column--count-${vars.counts.two}`]: {
-      width: `calc(50% - ${core.layout.spacingLarge})`
+      width: `calc(50% - ${layout.spacingLarge})`
     },
     [`.psds-equal-column-layout__column--count-${vars.counts.three}`]: {
-      width: `calc(33.33% - ${core.layout.spacingLarge})`
+      width: `calc(33.33% - ${layout.spacingLarge})`
     },
     [`.psds-equal-column-layout__column--count-${vars.counts.four}`]: {
-      width: `calc(25% - ${core.layout.spacingLarge})`
+      width: `calc(25% - ${layout.spacingLarge})`
     },
     [`.psds-equal-column-layout__column--count-${vars.counts.six}`]: {
-      width: `calc(16.66% - ${core.layout.spacingLarge})`
+      width: `calc(16.66% - ${layout.spacingLarge})`
     }
   }
 }

--- a/packages/layout/src/css/index.js
+++ b/packages/layout/src/css/index.js
@@ -1,11 +1,18 @@
 import asideLayoutCSS from './aside-layout.js'
 import equalColumnLayoutCSS from './equal-column-layout.js'
 import pageHeadingLayoutCSS from './page-heading-layout.js'
+import pageWidthLayoutCSS from './page-width-layout.js'
 
-export { asideLayoutCSS, equalColumnLayoutCSS, pageHeadingLayoutCSS }
+export {
+  asideLayoutCSS,
+  equalColumnLayoutCSS,
+  pageHeadingLayoutCSS,
+  pageWidthLayoutCSS
+}
 
 export default {
   ...asideLayoutCSS,
   ...equalColumnLayoutCSS,
-  ...pageHeadingLayoutCSS
+  ...pageHeadingLayoutCSS,
+  ...pageWidthLayoutCSS
 }

--- a/packages/layout/src/css/page-heading-layout.js
+++ b/packages/layout/src/css/page-heading-layout.js
@@ -1,8 +1,8 @@
-import * as core from '@pluralsight/ps-design-system-core'
+import { layout } from '@pluralsight/ps-design-system-core'
 
 export default {
   '.psds-page-heading-layout': {
-    padding: core.layout.spacingLarge
+    padding: layout.spacingLarge
   },
   '.psds-page-heading-layout__actions': {
     display: 'flex',
@@ -11,8 +11,8 @@ export default {
     flexWrap: 'wrap',
 
     '& > *': {
-      marginRight: core.layout.spacingSmall,
-      marginBottom: core.layout.spacingMedium
+      marginRight: layout.spacingSmall,
+      marginBottom: layout.spacingMedium
     }
   },
   '@media (min-width: 769px)': {
@@ -22,7 +22,7 @@ export default {
     },
     '.psds-page-heading-layout__actions': {
       marginLeft: 'auto',
-      paddingLeft: core.layout.spacingLarge,
+      paddingLeft: layout.spacingLarge,
       justifyContent: 'flex-end',
       alignItems: 'center',
       flexWrap: 'nowrap',
@@ -32,7 +32,7 @@ export default {
         marginBottom: 0
       },
       '& > * + *': {
-        marginLeft: core.layout.spacingSmall
+        marginLeft: layout.spacingSmall
       }
     }
   }

--- a/packages/layout/src/css/page-width-layout.js
+++ b/packages/layout/src/css/page-width-layout.js
@@ -1,17 +1,17 @@
-import * as core from '@pluralsight/ps-design-system-core'
+import { layout } from '@pluralsight/ps-design-system-core'
 
 export default {
   '.psds-page-width-layout': {
     marginLeft: 'auto',
     marginRight: 'auto',
     maxWidth: '1600px',
-    paddingLeft: core.layout.spacingLarge,
-    paddingRight: core.layout.spacingLarge
+    paddingLeft: layout.spacingLarge,
+    paddingRight: layout.spacingLarge
   },
   '@media (min-width: 769px)': {
     '.psds-page-width-layout': {
-      paddingLeft: core.layout.spacingXLarge,
-      paddingRight: core.layout.spacingXLarge
+      paddingLeft: layout.spacingXLarge,
+      paddingRight: layout.spacingXLarge
     }
   }
 }

--- a/packages/layout/src/css/page-width-layout.js
+++ b/packages/layout/src/css/page-width-layout.js
@@ -1,0 +1,17 @@
+import * as core from '@pluralsight/ps-design-system-core'
+
+export default {
+  '.psds-page-width-layout': {
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    maxWidth: '1600px',
+    paddingLeft: core.layout.spacingLarge,
+    paddingRight: core.layout.spacingLarge
+  },
+  '@media (min-width: 769px)': {
+    '.psds-page-width-layout': {
+      paddingLeft: core.layout.spacingXLarge,
+      paddingRight: core.layout.spacingXLarge
+    }
+  }
+}

--- a/packages/layout/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/layout/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -818,3 +818,38 @@ exports[`Storyshots Layout / PageHeadingLayout w/ lots of actions 1`] = `
   My content
 </div>
 `;
+
+exports[`Storyshots Layout / PageWidthLayout default 1`] = `
+<div
+  data-css-eg0ypq=""
+  style={
+    Object {
+      "color": "white",
+    }
+  }
+>
+  My content
+</div>
+`;
+
+exports[`Storyshots Layout / PageWidthLayout full-bleed 1`] = `
+<div
+  style={
+    Object {
+      "background": "rebeccapurple",
+    }
+  }
+>
+  <div
+    data-css-60rhmp=""
+    style={
+      Object {
+        "color": "white",
+        "outline": "1px solid red",
+      }
+    }
+  >
+    My content
+  </div>
+</div>
+`;

--- a/packages/layout/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/layout/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -821,10 +821,11 @@ exports[`Storyshots Layout / PageHeadingLayout w/ lots of actions 1`] = `
 
 exports[`Storyshots Layout / PageWidthLayout default 1`] = `
 <div
-  data-css-eg0ypq=""
+  data-css-60rhmp=""
   style={
     Object {
       "color": "white",
+      "outline": "1px solid red",
     }
   }
 >

--- a/packages/layout/src/react/__stories__/index.story.js
+++ b/packages/layout/src/react/__stories__/index.story.js
@@ -7,7 +7,12 @@ import Button from '@pluralsight/ps-design-system-button'
 import * as core from '@pluralsight/ps-design-system-core'
 import Link from '@pluralsight/ps-design-system-link'
 
-import { AsideLayout, EqualColumnLayout, PageHeadingLayout } from '../index.js'
+import {
+  AsideLayout,
+  EqualColumnLayout,
+  PageHeadingLayout,
+  PageWidthLayout
+} from '../index.js'
 
 const mockActions = [
   <Button key="action-1">Wow, an action</Button>,
@@ -34,6 +39,20 @@ const mockManyActions = [
     <a href="https://duckduckgo.com">A link</a>
   </Link>
 ]
+
+storiesOf('Layout / PageWidthLayout', module)
+  .add('default', _ => (
+    <PageWidthLayout style={{ color: 'white', outline: '1px solid red' }}>
+      My content
+    </PageWidthLayout>
+  ))
+  .add('full-bleed', _ => (
+    <div style={{ background: 'rebeccapurple' }}>
+      <PageWidthLayout style={{ color: 'white', outline: '1px solid red' }}>
+        My content
+      </PageWidthLayout>
+    </div>
+  ))
 
 storiesOf('Layout / PageHeadingLayout', module)
   .add('default', _ => (

--- a/packages/layout/src/react/index.js
+++ b/packages/layout/src/react/index.js
@@ -1,3 +1,4 @@
-export { default as PageHeadingLayout } from './page-heading-layout.js'
 export { default as AsideLayout } from './aside-layout.js'
 export { default as EqualColumnLayout } from './equal-column-layout.js'
+export { default as PageHeadingLayout } from './page-heading-layout.js'
+export { default as PageWidthLayout } from './page-width-layout.js'

--- a/packages/layout/src/react/page-width-layout.js
+++ b/packages/layout/src/react/page-width-layout.js
@@ -1,0 +1,30 @@
+import { compose, css, media } from 'glamor'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import { pageWidthLayoutCSS as stylesheet } from '../css/index.js'
+
+const styles = {
+  layout: () =>
+    compose(
+      css(stylesheet['.psds-page-width-layout']),
+      media(
+        '(min-width: 769px)',
+        stylesheet['@media (min-width: 769px)']['.psds-page-width-layout']
+      )
+    )
+}
+
+function PageWidthLayout(props) {
+  return (
+    <div {...styles.layout()} {...props}>
+      {props.children}
+    </div>
+  )
+}
+PageWidthLayout.displayName = 'PageWidthLayout'
+PageWidthLayout.propTypes = {
+  children: PropTypes.any
+}
+
+export default PageWidthLayout

--- a/packages/site/pages/components/layout.js
+++ b/packages/site/pages/components/layout.js
@@ -1,8 +1,9 @@
 import * as core from '@pluralsight/ps-design-system-core'
 import {
-  PageHeadingLayout,
   AsideLayout,
-  EqualColumnLayout
+  EqualColumnLayout,
+  PageHeadingLayout,
+  PageWidthLayout
 } from '@pluralsight/ps-design-system-layout'
 import Badge from '@pluralsight/ps-design-system-badge'
 import Button from '@pluralsight/ps-design-system-button'
@@ -114,6 +115,101 @@ const PageHeadingLayoutOutput = _ => (
         top: 0;
         left: 0;
         border-right-width: 1px;
+      }
+    `}</style>
+  </div>
+)
+
+const PageWidthLayoutOutput = _ => (
+  <div className="page">
+    <Theme>
+      <div className="fullBleed">
+        <div className="body">
+          <PageWidthLayout>
+            <div className="content">
+              Contents in front of full-bleed background
+              <div className="marginBg" />
+              <div className="margin marginVert marginRight" />
+              <div className="margin marginVert marginLeft" />
+            </div>
+          </PageWidthLayout>
+        </div>
+      </div>
+      <div className="divider" />
+      <div className="body">
+        <PageWidthLayout>
+          <div className="content">
+            Normal case contents layout
+            <div className="marginBg" />
+            <div className="margin marginVert marginRight" />
+            <div className="margin marginVert marginLeft" />
+          </div>
+        </PageWidthLayout>
+      </div>
+    </Theme>
+    <style jsx>{`
+      .page {
+        background: ${core.colors.gray06};
+        color: ${core.colors.white};
+      }
+      .fullBleed {
+        background: rebeccapurple;
+      }
+      .body {
+        position: relative;
+        margin: 0 ${core.layout.spacingXXLarge};
+        background: ${core.colors.gray06};
+      }
+      .divider {
+        border-top: 1px dashed #ff00ce;
+        margin: 0 ${core.layout.spacingXXLarge};
+        height: 0;
+      }
+      .content {
+        height: 134px;
+        background: #223a56;
+      }
+      .marginBg {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        border: ${core.layout.spacingLarge} solid rgba(232, 10, 137, 0.3);
+        border-top-width: 0;
+        border-bottom-width: 0;
+      }
+      .margin {
+        position: absolute;
+        border-style: dashed;
+        border-color: #ff00ce;
+        border-width: 0;
+      }
+      .marginVert {
+        height: 100%;
+        width: ${core.layout.spacingLarge};
+      }
+      .marginRight {
+        top: 0;
+        right: 0;
+        border-left-width: 1px;
+      }
+      .marginLeft {
+        top: 0;
+        left: 0;
+        border-right-width: 1px;
+      }
+      @media (min-width: 769px) {
+        .body:after {
+          width: calc(100% - 2 * ${core.layout.spacingXLarge});
+        }
+        .marginBg {
+          border-left-width: ${core.layout.spacingXLarge};
+          border-right-width: ${core.layout.spacingXLarge};
+        }
+        .marginVert {
+          width: ${core.layout.spacingXLarge};
+        }
       }
     `}</style>
   </div>
@@ -290,9 +386,10 @@ export default _ => (
       <P>Include a React component in your project:</P>
       <Code language="javascript">
         {`import {
-  PageHeadingLayout,
   AsideLayout,
-  EqualColumnLayout
+  EqualColumnLayout,
+  PageHeadingLayout,
+  PageWidthLayout
 } from '@pluralsight/ps-design-system-layout'`}
       </Code>
 
@@ -325,17 +422,38 @@ export default _ => (
             'React.element[]',
             null,
             null,
-            <span>Actionable elements to place in the top-right</span>
+            <span key="a">Actionable elements to place in the top-right</span>
           ]),
           PropTypes.row([
             'heading',
             'React.element',
             true,
             null,
-            <span>Heading element to display as page title</span>
+            <span key="a">Heading element to display as page title</span>
           ])
         ]}
       />
+
+      <SectionHeading>Page Width Layout</SectionHeading>
+      <P>
+        This layout will help you consistently match the max width of the site
+        and the standard margins.
+      </P>
+      <P>
+        We anticipate this will be used to support full-bleed background
+        layouts, where the background might run to the edge of the viewport, but
+        the content should still be constrained.
+      </P>
+      <PageWidthLayoutOutput />
+      <Code language="javascript">{`<div style={{ background: 'rebeccapurple' }}>
+  <PageWidthLayout>
+    Contents in front of full-bleed background
+  </PageHeadingLayout>
+</div>
+<PageWidthLayout>
+  Normal case contents layout
+</PageHeadingLayout>
+`}</Code>
 
       <SectionHeading>Aside Layout</SectionHeading>
       <P>Use this layout for any 1/4, 3/4-proportioned layouts.</P>
@@ -353,26 +471,26 @@ export default _ => (
         props={[
           PropTypes.row([
             'aside',
-            <code>AsideLayout.Aside</code>,
+            <code key="a">AsideLayout.Aside</code>,
             true,
             null,
-            <span>Content for aside</span>
+            <span key="b">Content for aside</span>
           ]),
           PropTypes.row([
             'asidePosition',
             PropTypes.union(AsideLayout.asidePositions),
             false,
-            <code>first</code>,
-            <span>
+            <code key="a">first</code>,
+            <span key="b">
               Aside position (from <code>AsideLayout.asidePositions</code>)
             </span>
           ]),
           PropTypes.row([
             'main',
-            <code>AsideLayout.Main</code>,
+            <code key="a">AsideLayout.Main</code>,
             true,
             null,
-            <span>Main content</span>
+            <span key="b">Main content</span>
           ])
         ]}
       />
@@ -417,15 +535,15 @@ export default _ => (
             'count',
             PropTypes.union(EqualColumnLayout.counts),
             false,
-            <code>four</code>,
-            <span>Number of columns in a row at full width</span>
+            <code key="a">four</code>,
+            <span key="b">Number of columns in a row at full width</span>
           ]),
           PropTypes.row([
             'children',
             'single parent element | children array',
             false,
-            <code>div</code>,
-            <span>
+            <code key="a">div</code>,
+            <span key="b">
               Where children must accept <code>data-css-*</code> props
             </span>
           ])


### PR DESCRIPTION
Adds new LayoutPageWidth component

Supports:
- Constrains max width when prism won't
- Standard page-level gutters = 24px; 48px above 768px
- Float in center space