### PR TITLE
[wont work, but review problem, plz] Theme prop to enable bleutrals

### DIFF
--- a/packages/site/pages/components/theme.js
+++ b/packages/site/pages/components/theme.js
@@ -76,6 +76,15 @@ export default _ => (
       <PropTypes
         props={[
           PropTypes.row([
+            'enableBleutrals',
+            'boolean',
+            null,
+            <code>false</code>,
+            <span>
+              assists in feature toggle for upcoming "bleutral" colors
+            </span>
+          ]),
+          PropTypes.row([
             'name',
             PropTypes.union(Theme.names),
             null,

--- a/packages/theme/src/react/__specs__/index.spec.js
+++ b/packages/theme/src/react/__specs__/index.spec.js
@@ -59,6 +59,22 @@ describe('Theme', () => {
     expect(container).toHaveTextContent(Theme.names.light)
   })
 
+  it('allows changing the enableBleutrals', () => {
+    const { container, rerender } = render(
+      <Theme name={Theme.names.dark}>
+        <MockComponent />
+      </Theme>
+    )
+
+    rerender(
+      <Theme name={Theme.names.light} enableBleutrals>
+        <MockComponent />
+      </Theme>
+    )
+
+    expect(container).toHaveTextContent(Theme.names.light + 'Bleutrals')
+  })
+
   it('should allow nesting', () => {
     const { getByTestId } = render(
       <Theme name={Theme.names.light}>
@@ -79,6 +95,11 @@ describe('useTheme', () => {
   it('should return the themeName', () => {
     const { result } = renderHook(() => useTheme())
     expect(result.current).toEqual(defaultName)
+  })
+
+  it('should return the themeName with enableBleutrals config', () => {
+    const { result } = renderHook(() => useTheme({ enableBleutrals: true }))
+    expect(result.current).toEqual(defaultName + 'Bleutrals')
   })
 })
 
@@ -116,6 +137,16 @@ describe('withTheme', () => {
 
       expect(container).toHaveTextContent(Theme.names.light)
     })
+
+    it('adjusts themeName based on enableBleutrals', () => {
+      const { container } = render(
+        <Theme name={Theme.names.light} enableBleutrals>
+          <EnhancedComponent />
+        </Theme>
+      )
+
+      expect(container).toHaveTextContent(Theme.names.light + 'Bleutrals')
+    })
   })
 
   describe('when NOT wrapped in a ThemeProvider', () => {
@@ -123,6 +154,12 @@ describe('withTheme', () => {
       const { container } = render(<EnhancedComponent />)
 
       expect(container).toHaveTextContent(defaultName)
+    })
+
+    it('allows HoC withTheme component to enableBleutrals', () => {
+      const { container } = render(<EnhancedComponent enableBleutrals />)
+
+      expect(container).toHaveTextContent(defaultName + 'Bleutrals')
     })
   })
 })

--- a/packages/theme/src/react/index.js
+++ b/packages/theme/src/react/index.js
@@ -19,34 +19,46 @@ export function withTheme(BaseComponent) {
   const name = getDisplayName(BaseComponent)
 
   const Forwarded = React.forwardRef((props, ref) => {
-    const themeName = useTheme()
-    return <BaseComponent {...props} ref={ref} themeName={themeName} />
+    const { enableBleutrals, ...rest } = props
+    const themeName = useTheme({ enableBleutrals })
+    return <BaseComponent {...rest} ref={ref} themeName={themeName} />
   })
   Forwarded.BaseComponent = BaseComponent
   Forwarded.displayName = `withTheme(${name})`
+  Forwarded.propTypes = {
+    enableBleutrals: PropTypes.bool
+  }
+  Forwarded.defaultProps = {
+    enableBleutrals: false
+  }
 
   return hoistNonReactStatics(Forwarded, BaseComponent)
 }
 
-export function useTheme() {
+export function useTheme(config) {
   const themeName = React.useContext(ThemeContext)
-  return themeName
+  const bleutralsAdjustedThemeName =
+    config && config.enableBleutrals ? themeName + 'Bleutrals' : themeName
+  return bleutralsAdjustedThemeName
 }
 
 // NOTE: anything that uses <Theme /> from context only (no withTheme), will be broken with this new impl
 // TODO: find this set of components ^ and update
 export default function Theme(props) {
+  const value = props.enableBleutrals ? props.name + 'Bleutrals' : props.name
   return (
-    <ThemeContext.Provider value={props.name}>
+    <ThemeContext.Provider value={value}>
       {props.children}
     </ThemeContext.Provider>
   )
 }
 Theme.propTypes = {
   children: PropTypes.any,
+  enableBleutrals: PropTypes.bool,
   name: PropTypes.oneOf(Object.keys(vars.names)).isRequired
 }
 Theme.defaultProps = {
+  enableBleutrals: false,
   name: vars.defaultName
 }
 


### PR DESCRIPTION
Resolves #745 

I think it'd be a little better to transmit *multiple* values from the theme provider.  But this would require changing the consumption.  Instead, what I did was modify the themeName value going down in context to consumers.

If enabled:
"dark" -> "darkBleutrals"
"light" -> "lightBleutrals"

This allows the api not to change.  

What it will require....

Blast, this won't work.  Because what about those components that need "light" to come through and are not updated to work with bleutrals?  We shouldn't need to update them.  Yet, their themeName is going to be modified so it won't match corresponding css in those components.

We need another idea... Something that doesn't modify themeName.  Probably means a separate value.  And that probably means breaking change on Theme.  Then, what's the upgrade process there?  Same problem, different impl detail in this scenario: what about those components that are not using the new Theme version (you can only have one in your project)?

Too bad we didn't return a more flexible data structure like an object from this context provider!

Anyone have an idea for a solution to this?