### PR TITLE
feat(icon): enables treeshaking when used by parcel or webpack

### DIFF
--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -26,6 +26,7 @@
     "test": "jest",
     "test:watch": "npm run test -- --watchAll"
   },
+  "sideEffects": false,
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^5.0.3",
     "@pluralsight/ps-design-system-filter-react-props": "^1.1.10",

--- a/packages/site/pages/components/icon.js
+++ b/packages/site/pages/components/icon.js
@@ -78,7 +78,11 @@ export default _ => (
       <Code language="bash">
         npm install @pluralsight/ps-design-system-icon
       </Code>
-
+      <P>
+        In your package webpack config in order to enable treeshaking add the
+        following config option:
+      </P>
+      <Code>{`optimization: {usedExports: true }`}</Code>
       <P>Include a React component in your project:</P>
       <Code language="javascript">
         {`import {CodeIcon, /* OtherNamedIcons */} from '@pluralsight/ps-design-system-icon'`}

--- a/packages/site/pages/components/icon.js
+++ b/packages/site/pages/components/icon.js
@@ -79,10 +79,11 @@ export default _ => (
         npm install @pluralsight/ps-design-system-icon
       </Code>
       <P>
-        In your package webpack config in order to enable treeshaking add the
-        following config option:
+        To enable treeshaking use Webpack 4's <b>production</b> mode or add the
+        following config option to your <b>dev/non-prod</b> mode config:
       </P>
       <Code>{`optimization: {usedExports: true }`}</Code>
+
       <P>Include a React component in your project:</P>
       <Code language="javascript">
         {`import {CodeIcon, /* OtherNamedIcons */} from '@pluralsight/ps-design-system-icon'`}


### PR DESCRIPTION
Treeshaking for Icons is not be working. After creating a test project I concluded it's two things adding `sideEffects: false` to our repo and `optimization: {usedExports: true,}` to a webpack config for webpack 4. As for Parcel I haven't tested yet but according to their docs just the sideEffects part is needed only.