### PR TITLE
refactor(viewtoggle): apply 2020 color palette

### DIFF
--- a/packages/viewtoggle/package.json
+++ b/packages/viewtoggle/package.json
@@ -28,12 +28,14 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.1.7",
+    "@pluralsight/ps-design-system-theme": "^4.0.0",
     "glamor": "^2.20.40",
     "react": "^16.8.6"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.11.4",
     "@pluralsight/ps-design-system-storybook-addon-center": "^2.1.3",
-    "@pluralsight/ps-design-system-storybook-addon-theme": "^5.0.7"
+    "@pluralsight/ps-design-system-storybook-addon-theme": "^5.0.7",
+    "@pluralsight/ps-design-system-theme": "^4.0.0"
   }
 }

--- a/packages/viewtoggle/package.json
+++ b/packages/viewtoggle/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^3.1.7",
-    "@pluralsight/ps-design-system-theme": "^4.0.0",
+    "@pluralsight/ps-design-system-theme": "4.x",
     "glamor": "^2.20.40",
     "react": "^16.8.6"
   },
@@ -36,6 +36,6 @@
     "@pluralsight/ps-design-system-build": "^1.11.4",
     "@pluralsight/ps-design-system-storybook-addon-center": "^2.1.3",
     "@pluralsight/ps-design-system-storybook-addon-theme": "^5.0.7",
-    "@pluralsight/ps-design-system-theme": "^4.0.0"
+    "@pluralsight/ps-design-system-theme": "^4.0.3"
   }
 }

--- a/packages/viewtoggle/src/css/index.js
+++ b/packages/viewtoggle/src/css/index.js
@@ -1,4 +1,5 @@
 import * as core from '@pluralsight/ps-design-system-core'
+import { names as themeNames } from '@pluralsight/ps-design-system-theme'
 
 import * as vars from '../vars/index.js'
 
@@ -26,9 +27,13 @@ export default {
     margin: 0,
     padding: '2px 3px',
     height: vars.style.outerHeight,
-    background: core.colors.gray03,
+    background: core.colorsBackgroundUtility[25],
+    border: `1px solid ${core.colorsBorder.lowOnDark}`,
     borderRadius: `calc(${vars.style.outerHeight} / 2)`,
     overflow: 'hidden'
+  },
+  [`.psds-viewtoggle.psds-theme--${themeNames.light}`]: {
+    borderColor: core.colorsBorder.lowOnLight
   },
 
   // __option
@@ -36,19 +41,24 @@ export default {
     ...option,
     position: 'relative',
     background: 'none',
-    color: core.colors.bone
+    color: core.colorsTextIcon.highOnDark
+  },
+  [`.psds-viewtoggle__option.psds-theme--${themeNames.light}`]: {
+    color: core.colorsTextIcon.highOnLight
   },
   '.psds-viewtoggle__option--active': {
-    color: core.colors.gray05
+    color: core.colorsTextIcon.highOnLight
   },
 
   // __option-bg
   '.psds-viewtoggle__option-bg': {
     ...option,
     position: 'absolute',
-    top: '2px',
-    background: core.colors.white,
-    boxShadow: '1px 1px 2px rgba(0, 0, 0, 0.6)'
+    top: '1px',
+    background: core.colors.white
+  },
+  [`.psds-viewtoggle__option-bg.psds-theme--${themeNames.light}`]: {
+    border: `1px solid ${core.colorsBorder.lowOnLight}`
   },
 
   // __option-bg__spacer

--- a/packages/viewtoggle/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/viewtoggle/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -2,13 +2,14 @@
 
 exports[`Storyshots active default first 1`] = `
 <div
-  data-css-1ifazk6=""
+  data-css-12bar4o=""
   role="radiogroup"
 >
   <div
     aria-hidden={true}
-    data-css-ztmayk=""
+    data-css-1282r6f=""
     style={Object {}}
+    themeName="dark"
   >
     <span
       data-css-1jyyyen=""
@@ -18,7 +19,7 @@ exports[`Storyshots active default first 1`] = `
   </div>
   <button
     aria-selected={true}
-    data-css-1p9dg7s=""
+    data-css-192bud=""
     onClick={[Function]}
     role="radio"
   >
@@ -26,7 +27,7 @@ exports[`Storyshots active default first 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -34,7 +35,7 @@ exports[`Storyshots active default first 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -45,13 +46,14 @@ exports[`Storyshots active default first 1`] = `
 
 exports[`Storyshots active explicit first 1`] = `
 <div
-  data-css-1ifazk6=""
+  data-css-12bar4o=""
   role="radiogroup"
 >
   <div
     aria-hidden={true}
-    data-css-ztmayk=""
+    data-css-1282r6f=""
     style={Object {}}
+    themeName="dark"
   >
     <span
       data-css-1jyyyen=""
@@ -61,7 +63,7 @@ exports[`Storyshots active explicit first 1`] = `
   </div>
   <button
     aria-selected={true}
-    data-css-1p9dg7s=""
+    data-css-192bud=""
     onClick={[Function]}
     role="radio"
   >
@@ -69,7 +71,7 @@ exports[`Storyshots active explicit first 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -77,7 +79,7 @@ exports[`Storyshots active explicit first 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -88,13 +90,14 @@ exports[`Storyshots active explicit first 1`] = `
 
 exports[`Storyshots active explicit second 1`] = `
 <div
-  data-css-1ifazk6=""
+  data-css-12bar4o=""
   role="radiogroup"
 >
   <div
     aria-hidden={true}
-    data-css-ztmayk=""
+    data-css-1282r6f=""
     style={Object {}}
+    themeName="dark"
   >
     <span
       data-css-1jyyyen=""
@@ -104,7 +107,7 @@ exports[`Storyshots active explicit second 1`] = `
   </div>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -112,7 +115,7 @@ exports[`Storyshots active explicit second 1`] = `
   </button>
   <button
     aria-selected={true}
-    data-css-1p9dg7s=""
+    data-css-192bud=""
     onClick={[Function]}
     role="radio"
   >
@@ -120,7 +123,7 @@ exports[`Storyshots active explicit second 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -131,13 +134,14 @@ exports[`Storyshots active explicit second 1`] = `
 
 exports[`Storyshots active explicit third 1`] = `
 <div
-  data-css-1ifazk6=""
+  data-css-12bar4o=""
   role="radiogroup"
 >
   <div
     aria-hidden={true}
-    data-css-ztmayk=""
+    data-css-1282r6f=""
     style={Object {}}
+    themeName="dark"
   >
     <span
       data-css-1jyyyen=""
@@ -147,7 +151,7 @@ exports[`Storyshots active explicit third 1`] = `
   </div>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -155,7 +159,7 @@ exports[`Storyshots active explicit third 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -163,7 +167,7 @@ exports[`Storyshots active explicit third 1`] = `
   </button>
   <button
     aria-selected={true}
-    data-css-1p9dg7s=""
+    data-css-192bud=""
     onClick={[Function]}
     role="radio"
   >
@@ -174,13 +178,14 @@ exports[`Storyshots active explicit third 1`] = `
 
 exports[`Storyshots dynamic options sizes correctly 1`] = `
 <div
-  data-css-1ifazk6=""
+  data-css-12bar4o=""
   role="radiogroup"
 >
   <div
     aria-hidden={true}
-    data-css-ztmayk=""
+    data-css-1282r6f=""
     style={Object {}}
+    themeName="dark"
   >
     <span
       data-css-1jyyyen=""
@@ -190,7 +195,7 @@ exports[`Storyshots dynamic options sizes correctly 1`] = `
   </div>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -198,7 +203,7 @@ exports[`Storyshots dynamic options sizes correctly 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -206,7 +211,7 @@ exports[`Storyshots dynamic options sizes correctly 1`] = `
   </button>
   <button
     aria-selected={true}
-    data-css-1p9dg7s=""
+    data-css-192bud=""
     onClick={[Function]}
     role="radio"
   >
@@ -217,13 +222,14 @@ exports[`Storyshots dynamic options sizes correctly 1`] = `
 
 exports[`Storyshots onSelect handles click 1`] = `
 <div
-  data-css-1ifazk6=""
+  data-css-12bar4o=""
   role="radiogroup"
 >
   <div
     aria-hidden={true}
-    data-css-ztmayk=""
+    data-css-1282r6f=""
     style={Object {}}
+    themeName="dark"
   >
     <span
       data-css-1jyyyen=""
@@ -233,7 +239,7 @@ exports[`Storyshots onSelect handles click 1`] = `
   </div>
   <button
     aria-selected={true}
-    data-css-1p9dg7s=""
+    data-css-192bud=""
     onClick={[Function]}
     role="radio"
   >
@@ -241,7 +247,7 @@ exports[`Storyshots onSelect handles click 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -249,7 +255,7 @@ exports[`Storyshots onSelect handles click 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -261,13 +267,14 @@ exports[`Storyshots onSelect handles click 1`] = `
 exports[`Storyshots options count dynamic 1`] = `
 Array [
   <div
-    data-css-1ifazk6=""
+    data-css-12bar4o=""
     role="radiogroup"
   >
     <div
       aria-hidden={true}
-      data-css-ztmayk=""
+      data-css-1282r6f=""
       style={Object {}}
+      themeName="dark"
     >
       <span
         data-css-1jyyyen=""
@@ -278,7 +285,7 @@ Array [
     </div>
     <button
       aria-selected={true}
-      data-css-1p9dg7s=""
+      data-css-192bud=""
       onClick={[Function]}
       role="radio"
     >
@@ -287,7 +294,7 @@ Array [
     </button>
     <button
       aria-selected={false}
-      data-css-1eee2k7=""
+      data-css-118ipcw=""
       onClick={[Function]}
       role="radio"
     >
@@ -316,13 +323,14 @@ Array [
 
 exports[`Storyshots options count more than max 1`] = `
 <div
-  data-css-1ifazk6=""
+  data-css-12bar4o=""
   role="radiogroup"
 >
   <div
     aria-hidden={true}
-    data-css-ztmayk=""
+    data-css-1282r6f=""
     style={Object {}}
+    themeName="dark"
   >
     <span
       data-css-1jyyyen=""
@@ -332,7 +340,7 @@ exports[`Storyshots options count more than max 1`] = `
   </div>
   <button
     aria-selected={true}
-    data-css-1p9dg7s=""
+    data-css-192bud=""
     onClick={[Function]}
     role="radio"
   >
@@ -340,7 +348,7 @@ exports[`Storyshots options count more than max 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -348,7 +356,7 @@ exports[`Storyshots options count more than max 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -359,13 +367,14 @@ exports[`Storyshots options count more than max 1`] = `
 
 exports[`Storyshots options count one 1`] = `
 <div
-  data-css-1ifazk6=""
+  data-css-12bar4o=""
   role="radiogroup"
 >
   <div
     aria-hidden={true}
-    data-css-ztmayk=""
+    data-css-1282r6f=""
     style={Object {}}
+    themeName="dark"
   >
     <span
       data-css-1jyyyen=""
@@ -375,7 +384,7 @@ exports[`Storyshots options count one 1`] = `
   </div>
   <button
     aria-selected={true}
-    data-css-1p9dg7s=""
+    data-css-192bud=""
     onClick={[Function]}
     role="radio"
   >
@@ -386,13 +395,14 @@ exports[`Storyshots options count one 1`] = `
 
 exports[`Storyshots options count three 1`] = `
 <div
-  data-css-1ifazk6=""
+  data-css-12bar4o=""
   role="radiogroup"
 >
   <div
     aria-hidden={true}
-    data-css-ztmayk=""
+    data-css-1282r6f=""
     style={Object {}}
+    themeName="dark"
   >
     <span
       data-css-1jyyyen=""
@@ -402,7 +412,7 @@ exports[`Storyshots options count three 1`] = `
   </div>
   <button
     aria-selected={true}
-    data-css-1p9dg7s=""
+    data-css-192bud=""
     onClick={[Function]}
     role="radio"
   >
@@ -410,7 +420,7 @@ exports[`Storyshots options count three 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -418,7 +428,7 @@ exports[`Storyshots options count three 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -429,13 +439,14 @@ exports[`Storyshots options count three 1`] = `
 
 exports[`Storyshots options count two 1`] = `
 <div
-  data-css-1ifazk6=""
+  data-css-12bar4o=""
   role="radiogroup"
 >
   <div
     aria-hidden={true}
-    data-css-ztmayk=""
+    data-css-1282r6f=""
     style={Object {}}
+    themeName="dark"
   >
     <span
       data-css-1jyyyen=""
@@ -445,7 +456,7 @@ exports[`Storyshots options count two 1`] = `
   </div>
   <button
     aria-selected={true}
-    data-css-1p9dg7s=""
+    data-css-192bud=""
     onClick={[Function]}
     role="radio"
   >
@@ -453,7 +464,7 @@ exports[`Storyshots options count two 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -464,13 +475,14 @@ exports[`Storyshots options count two 1`] = `
 
 exports[`Storyshots text length all long 1`] = `
 <div
-  data-css-1ifazk6=""
+  data-css-12bar4o=""
   role="radiogroup"
 >
   <div
     aria-hidden={true}
-    data-css-ztmayk=""
+    data-css-1282r6f=""
     style={Object {}}
+    themeName="dark"
   >
     <span
       data-css-1jyyyen=""
@@ -480,7 +492,7 @@ exports[`Storyshots text length all long 1`] = `
   </div>
   <button
     aria-selected={true}
-    data-css-1p9dg7s=""
+    data-css-192bud=""
     onClick={[Function]}
     role="radio"
   >
@@ -488,7 +500,7 @@ exports[`Storyshots text length all long 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -496,7 +508,7 @@ exports[`Storyshots text length all long 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -507,13 +519,14 @@ exports[`Storyshots text length all long 1`] = `
 
 exports[`Storyshots text length differing lengths 1`] = `
 <div
-  data-css-1ifazk6=""
+  data-css-12bar4o=""
   role="radiogroup"
 >
   <div
     aria-hidden={true}
-    data-css-ztmayk=""
+    data-css-1282r6f=""
     style={Object {}}
+    themeName="dark"
   >
     <span
       data-css-1jyyyen=""
@@ -523,7 +536,7 @@ exports[`Storyshots text length differing lengths 1`] = `
   </div>
   <button
     aria-selected={true}
-    data-css-1p9dg7s=""
+    data-css-192bud=""
     onClick={[Function]}
     role="radio"
   >
@@ -531,7 +544,7 @@ exports[`Storyshots text length differing lengths 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >
@@ -539,7 +552,7 @@ exports[`Storyshots text length differing lengths 1`] = `
   </button>
   <button
     aria-selected={false}
-    data-css-1eee2k7=""
+    data-css-118ipcw=""
     onClick={[Function]}
     role="radio"
   >

--- a/packages/viewtoggle/src/react/index.js
+++ b/packages/viewtoggle/src/react/index.js
@@ -1,8 +1,8 @@
+import filterReactProps from '@pluralsight/ps-design-system-filter-react-props'
+import { useTheme } from '@pluralsight/ps-design-system-theme'
 import { compose, css } from 'glamor'
 import PropTypes from 'prop-types'
 import React from 'react'
-
-import filterReactProps from '@pluralsight/ps-design-system-filter-react-props'
 
 import stylesheet from '../css/index.js'
 import * as vars from '../vars/index.js'
@@ -10,16 +10,28 @@ import * as vars from '../vars/index.js'
 const styles = {
   optionButton: props =>
     compose(
-      css(stylesheet['.psds-viewtoggle__option']),
+      css(
+        stylesheet['.psds-viewtoggle__option'],
+        stylesheet[`.psds-viewtoggle__option.psds-theme--${props.themeName}`]
+      ),
       props.active && css(stylesheet['.psds-viewtoggle__option--active'])
     ),
-  list: () => css(stylesheet['.psds-viewtoggle']),
-  activePillBg: () => css(stylesheet['.psds-viewtoggle__option-bg']),
+  list: props =>
+    css(
+      stylesheet['.psds-viewtoggle'],
+      stylesheet[`.psds-viewtoggle.psds-theme--${props.themeName}`]
+    ),
+  activePillBg: props =>
+    css(
+      stylesheet['.psds-viewtoggle__option-bg'],
+      stylesheet[`.psds-viewtoggle__option-bg.psds-theme--${props.themeName}`]
+    ),
   pillBgSpacer: () => css(stylesheet['.psds-viewtoggle__option-bg__spacer'])
 }
 
 const ViewToggle = React.forwardRef(({ onSelect, ...props }, forwardedRef) => {
   const ref = forwardedRef || React.useRef()
+  const themeName = useTheme()
   const hasRenderedOnce = useHasRenderedOnce()
 
   const initialIndex = React.useMemo(() => findActiveIndex(props.children), [
@@ -51,7 +63,7 @@ const ViewToggle = React.forwardRef(({ onSelect, ...props }, forwardedRef) => {
     }
 
     return (
-      <ActivePillBg aria-hidden style={activePillStyle}>
+      <ActivePillBg aria-hidden style={activePillStyle} themeName={themeName}>
         <PillBgSpacer>{activeEl.props.children}</PillBgSpacer>
       </ActivePillBg>
     )
@@ -64,13 +76,14 @@ const ViewToggle = React.forwardRef(({ onSelect, ...props }, forwardedRef) => {
       return React.cloneElement(child, {
         _i: i,
         _onSelect: handleSelect,
-        active: activeIndex === i
+        active: activeIndex === i,
+        themeName
       })
     })
   }
 
   return (
-    <List ref={ref} role="radiogroup" {...props}>
+    <List ref={ref} role="radiogroup" themeName={themeName} {...props}>
       {renderActivePill()}
       {renderChildren()}
     </List>
@@ -82,9 +95,9 @@ ViewToggle.propTypes = {
   onSelect: PropTypes.func
 }
 
-const List = React.forwardRef((props, ref) => (
-  <div ref={ref} {...styles.list(props)} {...filterReactProps(props)} />
-))
+const List = React.forwardRef((props, ref) => {
+  return <div ref={ref} {...styles.list(props)} {...filterReactProps(props)} />
+})
 
 const ActivePillBg = props => <div {...styles.activePillBg(props)} {...props} />
 
@@ -118,13 +131,15 @@ Option.defaultProps = {
   active: false
 }
 
-const OptionButton = React.forwardRef((props, ref) => (
-  <button
-    ref={ref}
-    {...styles.optionButton(props)}
-    {...filterReactProps(props, { tagName: 'button' })}
-  />
-))
+const OptionButton = React.forwardRef((props, ref) => {
+  return (
+    <button
+      ref={ref}
+      {...styles.optionButton(props)}
+      {...filterReactProps(props, { tagName: 'button' })}
+    />
+  )
+})
 
 function findActiveIndex(els) {
   const index = React.Children.toArray(els).findIndex(el => el.props.active)


### PR DESCRIPTION
2020, baby!

Besides just the color *conversion*, there were some visual changes in figma vs the code.  Perhaps I shouldn't have made those, because, thinking about it, if it's happening here, this probably won't be the last component to have this issue.

The color conversion shouldn't have to be visual maintenance at the same time, though it's probably ok to make a few adjustments if it doesn't gum up the PR or slow down this color conversion.

For instance, this component now looks different between themes.  It has new borders, and it dropped a shadow.  That is, if I read the diffs right in the PR.

@sweeting this is my first conversion, so I'm interested in getting your eyes on this too so I don't continue to make the same mistakes.  

Thanks, all!