### PR TITLE
refactor(switch): apply 2020 color palette

### DIFF
--- a/packages/form/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/form/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -766,10 +766,10 @@ exports[`Storyshots Sample Form sample 1`] = `
               data-css-480533=""
             >
               <div
-                data-css-1rncajx=""
+                data-css-rao1gl=""
               >
                 <div
-                  data-css-1nqr5a6=""
+                  data-css-12e9w50=""
                 />
               </div>
             </div>
@@ -781,7 +781,7 @@ exports[`Storyshots Sample Form sample 1`] = `
               type="checkbox"
             />
             <label
-              data-css-1wrf03j=""
+              data-css-on3oux=""
             >
               toggle
             </label>

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -24,7 +24,6 @@
     "@pluralsight/ps-design-system-core": "^5.4.6",
     "@pluralsight/ps-design-system-filter-react-props": "^1.1.16",
     "@pluralsight/ps-design-system-halo": "^6.0.15",
-    "@pluralsight/ps-design-system-util": "^3.0.10",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/switch/src/css/index.js
+++ b/packages/switch/src/css/index.js
@@ -3,7 +3,6 @@ import {
   defaultName as themeDefaultName,
   names as themeNames
 } from '@pluralsight/ps-design-system-theme'
-import { transparentize } from '@pluralsight/ps-design-system-util'
 
 import * as vars from '../vars/index.js'
 
@@ -30,10 +29,14 @@ export default {
     flexDirection: 'row-reverse'
   },
 
-  [`.psds-switch__track`]: {
+  '.psds-switch__track': {
     position: 'relative',
-    backgroundColor: core.colors.gray03,
+    backgroundColor: core.colorsBackgroundUtility[25],
+    border: `1px solid ${core.colorsBorder.lowOnDark}`,
     transition: `background-color ${core.motion.speedFast} ease-in-out`
+  },
+  [`.psds-switch__track.psds-theme--${themeNames.light}`]: {
+    border: `1px solid ${core.colorsBorder.lowOnLight}`
   },
   [`.psds-switch__track.psds-switch__track--size-${vars.sizes.small}`]: {
     height: '12px',
@@ -43,28 +46,31 @@ export default {
   [`.psds-switch__track.psds-switch__track--size-${vars.sizes.large}`]: {
     height: '24px',
     width: '48px',
-    borderRadius: '12px',
-    padding: '1px'
+    borderRadius: '12px'
+    // padding: '1px'
   },
   [`.psds-switch__track--checked.psds-switch__track--color-${vars.colors.blue}`]: {
-    backgroundColor: core.colors.blue
+    backgroundColor: core.colorsBlue.base,
+    borderColor: 'transparent'
   },
   [`.psds-switch__track--checked.psds-switch__track--color-${vars.colors.green}`]: {
-    backgroundColor: core.colors.green
+    backgroundColor: core.colorsGreen.base,
+    borderColor: 'transparent'
   },
   [`.psds-switch__track--checked.psds-switch__track--color-${vars.colors.orange}`]: {
-    backgroundColor: core.colors.orange
+    // NOTE: temp: make orange blue until we do a breaking change to remove orange
+    backgroundColor: core.colorsBlue.base,
+    borderColor: 'transparent'
   },
 
   [`.psds-switch__thumb`]: {
     backgroundColor: core.colors.white,
     borderRadius: '50%',
-    boxShadow: `0 0 2px ${transparentize(0.5, core.colors.black)}`,
     transition: `transform ${core.motion.speedFast} ease-in-out`
   },
   [`.psds-switch__thumb--size-${vars.sizes.small}`]: {
-    height: '12px',
-    width: '12px'
+    height: '10px',
+    width: '10px'
   },
   [`.psds-switch__thumb--size-${vars.sizes.large}`]: {
     height: '22px',
@@ -100,10 +106,10 @@ export default {
     marginLeft: core.layout.spacingMedium
   },
   [`.psds-switch__label.psds-theme--${themeNames.light}`]: {
-    color: core.colors.gray05
+    color: core.colorsTextIcon.highOnLight
   },
   [`.psds-switch__label.psds-theme--${themeDefaultName}`]: {
-    color: core.colors.bone
+    color: core.colorsTextIcon.highOnDark
   },
 
   '.psds-switch__checkbox': core.accessibility.screenReaderOnly

--- a/packages/switch/src/css/index.js
+++ b/packages/switch/src/css/index.js
@@ -47,7 +47,6 @@ export default {
     height: '24px',
     width: '48px',
     borderRadius: '12px'
-    // padding: '1px'
   },
   [`.psds-switch__track--checked.psds-switch__track--color-${vars.colors.blue}`]: {
     backgroundColor: core.colorsBlue.base,

--- a/packages/switch/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/switch/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -17,10 +17,10 @@ exports[`Storyshots checked false 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1rncajx=""
+        data-css-rao1gl=""
       >
         <div
-          data-css-1nqr5a6=""
+          data-css-12e9w50=""
         />
       </div>
     </div>
@@ -32,7 +32,7 @@ exports[`Storyshots checked false 1`] = `
       type="checkbox"
     />
     <label
-      data-css-1wrf03j=""
+      data-css-on3oux=""
     >
       Click me
     </label>
@@ -57,10 +57,10 @@ exports[`Storyshots checked true 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1t8mno4=""
+        data-css-3p558u=""
       >
         <div
-          data-css-4g7l16=""
+          data-css-1pmieqv=""
         />
       </div>
     </div>
@@ -72,7 +72,7 @@ exports[`Storyshots checked true 1`] = `
       type="checkbox"
     />
     <label
-      data-css-1wrf03j=""
+      data-css-on3oux=""
     >
       Click me
     </label>
@@ -97,10 +97,10 @@ exports[`Storyshots click large toggles 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1rncajx=""
+        data-css-rao1gl=""
       >
         <div
-          data-css-1nqr5a6=""
+          data-css-12e9w50=""
         />
       </div>
     </div>
@@ -132,10 +132,10 @@ exports[`Storyshots click small toggles 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1m9fpc5=""
+        data-css-2sz0ak=""
       >
         <div
-          data-css-1qt5hlf=""
+          data-css-1ua381t=""
         />
       </div>
     </div>
@@ -167,10 +167,10 @@ exports[`Storyshots color blue 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1yognj7=""
+        data-css-3p558u=""
       >
         <div
-          data-css-4g7l16=""
+          data-css-1pmieqv=""
         />
       </div>
     </div>
@@ -182,7 +182,7 @@ exports[`Storyshots color blue 1`] = `
       type="checkbox"
     />
     <label
-      data-css-1wrf03j=""
+      data-css-on3oux=""
     >
       Click me
     </label>
@@ -207,10 +207,10 @@ exports[`Storyshots color green 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1ecl5dy=""
+        data-css-1ad2n5h=""
       >
         <div
-          data-css-4g7l16=""
+          data-css-1pmieqv=""
         />
       </div>
     </div>
@@ -222,7 +222,7 @@ exports[`Storyshots color green 1`] = `
       type="checkbox"
     />
     <label
-      data-css-1wrf03j=""
+      data-css-on3oux=""
     >
       Click me
     </label>
@@ -247,10 +247,10 @@ exports[`Storyshots color orange 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1t8mno4=""
+        data-css-3p558u=""
       >
         <div
-          data-css-4g7l16=""
+          data-css-1pmieqv=""
         />
       </div>
     </div>
@@ -262,7 +262,7 @@ exports[`Storyshots color orange 1`] = `
       type="checkbox"
     />
     <label
-      data-css-1wrf03j=""
+      data-css-on3oux=""
     >
       Click me
     </label>
@@ -287,10 +287,10 @@ exports[`Storyshots disabled false 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1rncajx=""
+        data-css-rao1gl=""
       >
         <div
-          data-css-1nqr5a6=""
+          data-css-12e9w50=""
         />
       </div>
     </div>
@@ -322,10 +322,10 @@ exports[`Storyshots disabled true 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1rncajx=""
+        data-css-rao1gl=""
       >
         <div
-          data-css-1nqr5a6=""
+          data-css-12e9w50=""
         />
       </div>
     </div>
@@ -357,10 +357,10 @@ exports[`Storyshots error false 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1rncajx=""
+        data-css-rao1gl=""
       >
         <div
-          data-css-1nqr5a6=""
+          data-css-12e9w50=""
         />
       </div>
     </div>
@@ -392,10 +392,10 @@ exports[`Storyshots error true 1`] = `
       data-css-11lyqbs=""
     >
       <div
-        data-css-1rncajx=""
+        data-css-rao1gl=""
       >
         <div
-          data-css-1nqr5a6=""
+          data-css-12e9w50=""
         />
       </div>
     </div>
@@ -407,7 +407,7 @@ exports[`Storyshots error true 1`] = `
       type="checkbox"
     />
     <label
-      data-css-1wrf03j=""
+      data-css-on3oux=""
     >
       Clickable in error state
     </label>
@@ -432,10 +432,10 @@ exports[`Storyshots error true w/ disabled 1`] = `
       data-css-11lyqbs=""
     >
       <div
-        data-css-1rncajx=""
+        data-css-rao1gl=""
       >
         <div
-          data-css-1nqr5a6=""
+          data-css-12e9w50=""
         />
       </div>
     </div>
@@ -447,7 +447,7 @@ exports[`Storyshots error true w/ disabled 1`] = `
       type="checkbox"
     />
     <label
-      data-css-1wrf03j=""
+      data-css-on3oux=""
     >
       Such errors
     </label>
@@ -472,10 +472,10 @@ exports[`Storyshots label large left 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1rncajx=""
+        data-css-rao1gl=""
       >
         <div
-          data-css-1nqr5a6=""
+          data-css-12e9w50=""
         />
       </div>
     </div>
@@ -487,7 +487,7 @@ exports[`Storyshots label large left 1`] = `
       type="checkbox"
     />
     <label
-      data-css-aau49w=""
+      data-css-qisca0=""
     >
       Click me
     </label>
@@ -512,10 +512,10 @@ exports[`Storyshots label large right 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1rncajx=""
+        data-css-rao1gl=""
       >
         <div
-          data-css-1nqr5a6=""
+          data-css-12e9w50=""
         />
       </div>
     </div>
@@ -527,7 +527,7 @@ exports[`Storyshots label large right 1`] = `
       type="checkbox"
     />
     <label
-      data-css-1wrf03j=""
+      data-css-on3oux=""
     >
       Click me
     </label>
@@ -552,10 +552,10 @@ exports[`Storyshots label small left 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1m9fpc5=""
+        data-css-2sz0ak=""
       >
         <div
-          data-css-1qt5hlf=""
+          data-css-1ua381t=""
         />
       </div>
     </div>
@@ -567,7 +567,7 @@ exports[`Storyshots label small left 1`] = `
       type="checkbox"
     />
     <label
-      data-css-1waj6du=""
+      data-css-kccklm=""
     >
       Click me
     </label>
@@ -592,10 +592,10 @@ exports[`Storyshots label small right 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1m9fpc5=""
+        data-css-2sz0ak=""
       >
         <div
-          data-css-1qt5hlf=""
+          data-css-1ua381t=""
         />
       </div>
     </div>
@@ -607,7 +607,7 @@ exports[`Storyshots label small right 1`] = `
       type="checkbox"
     />
     <label
-      data-css-6olsyv=""
+      data-css-yktx6h=""
     >
       Click me
     </label>
@@ -632,10 +632,10 @@ exports[`Storyshots size large 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1rncajx=""
+        data-css-rao1gl=""
       >
         <div
-          data-css-1nqr5a6=""
+          data-css-12e9w50=""
         />
       </div>
     </div>
@@ -647,7 +647,7 @@ exports[`Storyshots size large 1`] = `
       type="checkbox"
     />
     <label
-      data-css-1wrf03j=""
+      data-css-on3oux=""
     >
       Click me
     </label>
@@ -672,10 +672,10 @@ exports[`Storyshots size small 1`] = `
       data-css-480533=""
     >
       <div
-        data-css-1m9fpc5=""
+        data-css-2sz0ak=""
       >
         <div
-          data-css-1qt5hlf=""
+          data-css-1ua381t=""
         />
       </div>
     </div>
@@ -687,7 +687,7 @@ exports[`Storyshots size small 1`] = `
       type="checkbox"
     />
     <label
-      data-css-6olsyv=""
+      data-css-yktx6h=""
     >
       Click me
     </label>

--- a/packages/switch/src/react/index.js
+++ b/packages/switch/src/react/index.js
@@ -20,6 +20,7 @@ const styles = {
   track: (themeName, { checked, color, size }) =>
     compose(
       css(stylesheet['.psds-switch__track']),
+      css(stylesheet[`.psds-switch__track.psds-theme--${themeName}`]),
       checked &&
         css(
           stylesheet[


### PR DESCRIPTION
util/transparentize removed -- just another case where it seems we could do w/o;  small size switch had the "thumb" changed from 12px to 10px.  New border on unchecked state. Orange color made blue in anticipation of later removal of orange option.  Waiting on that later removal change so that Brian can make a determination if we want to go from 2 options (green/blue) down to just one, essentially removing the color prop.