### PR TITLE
row: Remove Row.Action, use DS Button instead

### DIFF
--- a/packages/drawer/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/drawer/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -371,7 +371,7 @@ exports[`Storyshots drawer row component with actions 1`] = `
             </div>
           </div>
           <div
-            data-css-1akhza9=""
+            data-css-7b22zo=""
           >
             <button
               data-css-j5lae8=""
@@ -1258,24 +1258,33 @@ exports[`Storyshots drawer with row component 1`] = `
             </div>
           </div>
           <div
-            data-css-okadky=""
+            data-css-7zyoug=""
           >
             <button
-              data-css-2qvjr2=""
+              data-css-j5lae8=""
+              disabled={false}
+              style={Object {}}
             >
               <div
-                data-css-otejxm=""
+                data-css-y80vay=""
               >
-                <svg
-                  aria-label="more icon"
-                  role="img"
-                  viewBox="0 0 24 24"
+                <div
+                  data-css-otejxm=""
                 >
-                  <path
-                    d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
-                  />
-                </svg>
+                  <svg
+                    aria-label="more icon"
+                    role="img"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
+                    />
+                  </svg>
+                </div>
               </div>
+              <span
+                data-css-15b13by=""
+              />
             </button>
           </div>
         </div>

--- a/packages/drawer/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/drawer/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -374,22 +374,31 @@ exports[`Storyshots drawer row component with actions 1`] = `
             data-css-1akhza9=""
           >
             <button
-              data-css-2qvjr2=""
+              data-css-j5lae8=""
+              disabled={false}
               onClick={[Function]}
+              style={Object {}}
             >
               <div
-                data-css-otejxm=""
+                data-css-y80vay=""
               >
-                <svg
-                  aria-label="more icon"
-                  role="img"
-                  viewBox="0 0 24 24"
+                <div
+                  data-css-otejxm=""
                 >
-                  <path
-                    d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
-                  />
-                </svg>
+                  <svg
+                    aria-label="more icon"
+                    role="img"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
+                    />
+                  </svg>
+                </div>
               </div>
+              <span
+                data-css-15b13by=""
+              />
             </button>
           </div>
         </div>

--- a/packages/drawer/src/react/__stories__/index.story.js
+++ b/packages/drawer/src/react/__stories__/index.story.js
@@ -128,7 +128,14 @@ storiesOf('drawer', module)
     <Drawer
       base={
         <Row
-          actionBar={[<Row.Action key="iHeartCats" icon={<Icon.MoreIcon />} />]}
+          actionBar={[
+            <Button
+              size={Button.sizes.small}
+              appearance={Button.appearances.flat}
+              key="iHeartCats"
+              icon={<Icon.MoreIcon />}
+            />
+          ]}
           actionBarVisible
           image={<Row.Image src="https://cataas.com/cat" />}
           metadata1={['Kitten McCatbuns', '23 hours of cuteness']}
@@ -145,7 +152,9 @@ storiesOf('drawer', module)
       base={
         <Row
           actionBar={[
-            <Row.Action
+            <Button
+              size={Button.sizes.small}
+              appearance={Button.appearances.flat}
               key="iHeartCats"
               icon={<Icon.MoreIcon />}
               onClick={action('action')}

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^1.11.10",
+    "@pluralsight/ps-design-system-button": "*",
     "@pluralsight/ps-design-system-drawer": "^6.0.21",
     "@pluralsight/ps-design-system-icon": "^16.1.9",
     "@pluralsight/ps-design-system-storybook-addon-theme": "^5.0.14",

--- a/packages/row/src/css/index.js
+++ b/packages/row/src/css/index.js
@@ -89,45 +89,17 @@ export default {
     lineHeight: 0,
     height: '64px',
     transition: `opacity ${core.motion.speedNormal}`,
-    opacity: 0
+    opacity: 0,
+
+    '& > button, & > a': {
+      marginLeft: vars.style.actionBarActionMarginLeft
+    }
   },
   '.psds-row__action-bar--fullOverlay': {
     background: 'none'
   },
   '.psds-row__action-bar--actionBarVisible': {
     opacity: 1
-  },
-
-  // __action-bar__button
-  '.psds-row__action-bar__button': {
-    fontSize: core.type.fontSizeXSmall,
-    marginLeft: vars.style.actionBarActionMarginLeft,
-    padding: 0,
-    lineHeight: 0,
-    cursor: 'pointer',
-    border: 'none',
-    background: 'none',
-    transition: `all ${core.motion.speedNormal}`
-  },
-  [`.psds-row__action-bar__button.psds-theme--${themeDefaultName}`]: {
-    color: core.colors.gray02,
-
-    '&:active, &:hover': { color: core.colors.white }
-  },
-  [`.psds-row__action-bar__button.psds-theme--${themeNames.light}`]: {
-    color: core.colors.gray03,
-
-    '&:active, &:hover': { color: core.colors.black }
-  },
-
-  '.psds-row__action-bar__button--disabled': {
-    color: core.colors.gray02,
-    background: core.colors.gray03,
-
-    '&:hover': {
-      color: core.colors.gray02,
-      background: core.colors.gray03
-    }
   },
 
   // __progress

--- a/packages/row/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/row/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -25,24 +25,33 @@ exports[`Storyshots actionBar locked visible 1`] = `
         </div>
       </div>
       <div
-        data-css-okadky=""
+        data-css-7zyoug=""
       >
         <button
-          data-css-2qvjr2=""
+          data-css-j5lae8=""
+          disabled={false}
+          style={Object {}}
         >
           <div
-            data-css-otejxm=""
+            data-css-y80vay=""
           >
-            <svg
-              aria-label="bookmark icon"
-              role="img"
-              viewBox="0 0 24 24"
+            <div
+              data-css-otejxm=""
             >
-              <path
-                d="M17.501 2H9C6.794 2 5 3.795 5 6v17l5.5-6 5.5 6V10h4a1 1 0 001-1V6c0-2.205-1.292-4-3.499-4zM14 6v12l-3.5-4L7 18V6c0-1.104.897-2 2-2h5.536A3.99 3.99 0 0014 6zm5 2h-3V6c0-1.104.398-2 1.501-2C18.603 4 19 4.896 19 6v2z"
-              />
-            </svg>
+              <svg
+                aria-label="bookmark icon"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17.501 2H9C6.794 2 5 3.795 5 6v17l5.5-6 5.5 6V10h4a1 1 0 001-1V6c0-2.205-1.292-4-3.499-4zM14 6v12l-3.5-4L7 18V6c0-1.104.897-2 2-2h5.536A3.99 3.99 0 0014 6zm5 2h-3V6c0-1.104.398-2 1.501-2C18.603 4 19 4.896 19 6v2z"
+                />
+              </svg>
+            </div>
           </div>
+          <span
+            data-css-15b13by=""
+          />
         </button>
       </div>
     </div>
@@ -75,24 +84,33 @@ exports[`Storyshots actionBar long title 1`] = `
         </div>
       </div>
       <div
-        data-css-elqoo0=""
+        data-css-1pe5xb7=""
       >
         <button
-          data-css-2qvjr2=""
+          data-css-j5lae8=""
+          disabled={false}
+          style={Object {}}
         >
           <div
-            data-css-otejxm=""
+            data-css-y80vay=""
           >
-            <svg
-              aria-label="bookmark icon"
-              role="img"
-              viewBox="0 0 24 24"
+            <div
+              data-css-otejxm=""
             >
-              <path
-                d="M17.501 2H9C6.794 2 5 3.795 5 6v17l5.5-6 5.5 6V10h4a1 1 0 001-1V6c0-2.205-1.292-4-3.499-4zM14 6v12l-3.5-4L7 18V6c0-1.104.897-2 2-2h5.536A3.99 3.99 0 0014 6zm5 2h-3V6c0-1.104.398-2 1.501-2C18.603 4 19 4.896 19 6v2z"
-              />
-            </svg>
+              <svg
+                aria-label="bookmark icon"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17.501 2H9C6.794 2 5 3.795 5 6v17l5.5-6 5.5 6V10h4a1 1 0 001-1V6c0-2.205-1.292-4-3.499-4zM14 6v12l-3.5-4L7 18V6c0-1.104.897-2 2-2h5.536A3.99 3.99 0 0014 6zm5 2h-3V6c0-1.104.398-2 1.501-2C18.603 4 19 4.896 19 6v2z"
+                />
+              </svg>
+            </div>
           </div>
+          <span
+            data-css-15b13by=""
+          />
         </button>
       </div>
     </div>
@@ -125,24 +143,33 @@ exports[`Storyshots actionBar long title with image 1`] = `
         </div>
       </div>
       <div
-        data-css-elqoo0=""
+        data-css-1pe5xb7=""
       >
         <button
-          data-css-2qvjr2=""
+          data-css-j5lae8=""
+          disabled={false}
+          style={Object {}}
         >
           <div
-            data-css-otejxm=""
+            data-css-y80vay=""
           >
-            <svg
-              aria-label="bookmark icon"
-              role="img"
-              viewBox="0 0 24 24"
+            <div
+              data-css-otejxm=""
             >
-              <path
-                d="M17.501 2H9C6.794 2 5 3.795 5 6v17l5.5-6 5.5 6V10h4a1 1 0 001-1V6c0-2.205-1.292-4-3.499-4zM14 6v12l-3.5-4L7 18V6c0-1.104.897-2 2-2h5.536A3.99 3.99 0 0014 6zm5 2h-3V6c0-1.104.398-2 1.501-2C18.603 4 19 4.896 19 6v2z"
-              />
-            </svg>
+              <svg
+                aria-label="bookmark icon"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17.501 2H9C6.794 2 5 3.795 5 6v17l5.5-6 5.5 6V10h4a1 1 0 001-1V6c0-2.205-1.292-4-3.499-4zM14 6v12l-3.5-4L7 18V6c0-1.104.897-2 2-2h5.536A3.99 3.99 0 0014 6zm5 2h-3V6c0-1.104.398-2 1.501-2C18.603 4 19 4.896 19 6v2z"
+                />
+              </svg>
+            </div>
           </div>
+          <span
+            data-css-15b13by=""
+          />
         </button>
       </div>
     </div>
@@ -175,24 +202,33 @@ exports[`Storyshots actionBar one action 1`] = `
         </div>
       </div>
       <div
-        data-css-elqoo0=""
+        data-css-1pe5xb7=""
       >
         <button
-          data-css-2qvjr2=""
+          data-css-j5lae8=""
+          disabled={false}
+          style={Object {}}
         >
           <div
-            data-css-otejxm=""
+            data-css-y80vay=""
           >
-            <svg
-              aria-label="bookmark icon"
-              role="img"
-              viewBox="0 0 24 24"
+            <div
+              data-css-otejxm=""
             >
-              <path
-                d="M17.501 2H9C6.794 2 5 3.795 5 6v17l5.5-6 5.5 6V10h4a1 1 0 001-1V6c0-2.205-1.292-4-3.499-4zM14 6v12l-3.5-4L7 18V6c0-1.104.897-2 2-2h5.536A3.99 3.99 0 0014 6zm5 2h-3V6c0-1.104.398-2 1.501-2C18.603 4 19 4.896 19 6v2z"
-              />
-            </svg>
+              <svg
+                aria-label="bookmark icon"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17.501 2H9C6.794 2 5 3.795 5 6v17l5.5-6 5.5 6V10h4a1 1 0 001-1V6c0-2.205-1.292-4-3.499-4zM14 6v12l-3.5-4L7 18V6c0-1.104.897-2 2-2h5.536A3.99 3.99 0 0014 6zm5 2h-3V6c0-1.104.398-2 1.501-2C18.603 4 19 4.896 19 6v2z"
+                />
+              </svg>
+            </div>
           </div>
+          <span
+            data-css-15b13by=""
+          />
         </button>
       </div>
     </div>
@@ -216,7 +252,7 @@ exports[`Storyshots combo everything 1`] = `
       data-css-vl7fes=""
     >
       <div
-        data-css-1dgg89l=""
+        data-css-5n4uhw=""
       >
         <div
           data-css-1vvatyd=""
@@ -297,60 +333,87 @@ exports[`Storyshots combo everything 1`] = `
         </div>
       </div>
       <div
-        data-css-1akhza9=""
+        data-css-7b22zo=""
       >
         <button
-          data-css-2qvjr2=""
+          data-css-j5lae8=""
+          disabled={false}
+          style={Object {}}
         >
           <div
-            data-css-otejxm=""
+            data-css-y80vay=""
           >
-            <svg
-              aria-label="bookmark icon"
-              role="img"
-              viewBox="0 0 24 24"
+            <div
+              data-css-otejxm=""
             >
-              <path
-                d="M17.501 2H9C6.794 2 5 3.795 5 6v17l5.5-6 5.5 6V10h4a1 1 0 001-1V6c0-2.205-1.292-4-3.499-4zM14 6v12l-3.5-4L7 18V6c0-1.104.897-2 2-2h5.536A3.99 3.99 0 0014 6zm5 2h-3V6c0-1.104.398-2 1.501-2C18.603 4 19 4.896 19 6v2z"
-              />
-            </svg>
+              <svg
+                aria-label="bookmark icon"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17.501 2H9C6.794 2 5 3.795 5 6v17l5.5-6 5.5 6V10h4a1 1 0 001-1V6c0-2.205-1.292-4-3.499-4zM14 6v12l-3.5-4L7 18V6c0-1.104.897-2 2-2h5.536A3.99 3.99 0 0014 6zm5 2h-3V6c0-1.104.398-2 1.501-2C18.603 4 19 4.896 19 6v2z"
+                />
+              </svg>
+            </div>
           </div>
+          <span
+            data-css-15b13by=""
+          />
         </button>
         <button
-          data-css-2qvjr2=""
+          data-css-j5lae8=""
+          disabled={false}
+          style={Object {}}
         >
           <div
-            data-css-otejxm=""
+            data-css-y80vay=""
           >
-            <svg
-              aria-label="gear icon"
-              role="img"
-              viewBox="0 0 24 24"
+            <div
+              data-css-otejxm=""
             >
-              <path
-                clipRule="evenodd"
-                d="M4 12c0-.377.026-.748.077-1.111L2.274 9.848a.5.5 0 01-.183-.683l2.5-4.33a.5.5 0 01.683-.183l1.804 1.041A7.988 7.988 0 019 4.581V2.5a.5.5 0 01.5-.5h5a.5.5 0 01.5.5v2.082a7.99 7.99 0 011.922 1.112l1.805-1.042a.5.5 0 01.683.183l2.5 4.33a.5.5 0 01-.183.683l-1.804 1.042a8.063 8.063 0 010 2.22l1.804 1.042a.5.5 0 01.183.683l-2.5 4.33a.5.5 0 01-.683.183l-1.805-1.042A7.992 7.992 0 0115 19.418V21.5a.5.5 0 01-.5.5h-5a.5.5 0 01-.5-.5v-2.081a7.985 7.985 0 01-1.923-1.112l-1.804 1.041a.5.5 0 01-.683-.183l-2.5-4.33a.5.5 0 01.183-.683l1.803-1.04A8.077 8.077 0 014 12zm9-8h-2v2.083a5.994 5.994 0 00-3.623 2.092L5.573 7.133l-1 1.732 1.803 1.04A5.986 5.986 0 006 12c0 .736.132 1.44.375 2.092l-1.803 1.041 1 1.732 1.804-1.041A5.993 5.993 0 0011 17.917V20h2v-2.083a5.994 5.994 0 003.625-2.094l1.805 1.042 1-1.732-1.805-1.042A5.987 5.987 0 0018 12a5.99 5.99 0 00-.375-2.093l1.804-1.042-1-1.732-1.806 1.042A5.994 5.994 0 0013 6.083V4zm-5 8a4 4 0 108 0 4 4 0 00-8 0zm4 2a2 2 0 100-4 2 2 0 000 4z"
-                fillRule="evenodd"
-              />
-            </svg>
+              <svg
+                aria-label="gear icon"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  clipRule="evenodd"
+                  d="M4 12c0-.377.026-.748.077-1.111L2.274 9.848a.5.5 0 01-.183-.683l2.5-4.33a.5.5 0 01.683-.183l1.804 1.041A7.988 7.988 0 019 4.581V2.5a.5.5 0 01.5-.5h5a.5.5 0 01.5.5v2.082a7.99 7.99 0 011.922 1.112l1.805-1.042a.5.5 0 01.683.183l2.5 4.33a.5.5 0 01-.183.683l-1.804 1.042a8.063 8.063 0 010 2.22l1.804 1.042a.5.5 0 01.183.683l-2.5 4.33a.5.5 0 01-.683.183l-1.805-1.042A7.992 7.992 0 0115 19.418V21.5a.5.5 0 01-.5.5h-5a.5.5 0 01-.5-.5v-2.081a7.985 7.985 0 01-1.923-1.112l-1.804 1.041a.5.5 0 01-.683-.183l-2.5-4.33a.5.5 0 01.183-.683l1.803-1.04A8.077 8.077 0 014 12zm9-8h-2v2.083a5.994 5.994 0 00-3.623 2.092L5.573 7.133l-1 1.732 1.803 1.04A5.986 5.986 0 006 12c0 .736.132 1.44.375 2.092l-1.803 1.041 1 1.732 1.804-1.041A5.993 5.993 0 0011 17.917V20h2v-2.083a5.994 5.994 0 003.625-2.094l1.805 1.042 1-1.732-1.805-1.042A5.987 5.987 0 0018 12a5.99 5.99 0 00-.375-2.093l1.804-1.042-1-1.732-1.806 1.042A5.994 5.994 0 0013 6.083V4zm-5 8a4 4 0 108 0 4 4 0 00-8 0zm4 2a2 2 0 100-4 2 2 0 000 4z"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </div>
           </div>
+          <span
+            data-css-15b13by=""
+          />
         </button>
         <button
-          data-css-2qvjr2=""
+          data-css-j5lae8=""
+          disabled={false}
+          style={Object {}}
         >
           <div
-            data-css-otejxm=""
+            data-css-y80vay=""
           >
-            <svg
-              aria-label="more icon"
-              role="img"
-              viewBox="0 0 24 24"
+            <div
+              data-css-otejxm=""
             >
-              <path
-                d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
-              />
-            </svg>
+              <svg
+                aria-label="more icon"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
+                />
+              </svg>
+            </div>
           </div>
+          <span
+            data-css-15b13by=""
+          />
         </button>
       </div>
     </div>
@@ -812,24 +875,33 @@ exports[`Storyshots in a stack no top border on first row 1`] = `
         </div>
       </div>
       <div
-        data-css-okadky=""
+        data-css-7zyoug=""
       >
         <button
-          data-css-2qvjr2=""
+          data-css-j5lae8=""
+          disabled={false}
+          style={Object {}}
         >
           <div
-            data-css-otejxm=""
+            data-css-y80vay=""
           >
-            <svg
-              aria-label="more icon"
-              role="img"
-              viewBox="0 0 24 24"
+            <div
+              data-css-otejxm=""
             >
-              <path
-                d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
-              />
-            </svg>
+              <svg
+                aria-label="more icon"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
+                />
+              </svg>
+            </div>
           </div>
+          <span
+            data-css-15b13by=""
+          />
         </button>
       </div>
     </div>
@@ -855,24 +927,33 @@ exports[`Storyshots in a stack no top border on first row 1`] = `
         </div>
       </div>
       <div
-        data-css-okadky=""
+        data-css-7zyoug=""
       >
         <button
-          data-css-2qvjr2=""
+          data-css-j5lae8=""
+          disabled={false}
+          style={Object {}}
         >
           <div
-            data-css-otejxm=""
+            data-css-y80vay=""
           >
-            <svg
-              aria-label="more icon"
-              role="img"
-              viewBox="0 0 24 24"
+            <div
+              data-css-otejxm=""
             >
-              <path
-                d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
-              />
-            </svg>
+              <svg
+                aria-label="more icon"
+                role="img"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
+                />
+              </svg>
+            </div>
           </div>
+          <span
+            data-css-15b13by=""
+          />
         </button>
       </div>
     </div>
@@ -931,25 +1012,34 @@ exports[`Storyshots in drawer medium 1`] = `
               </div>
             </div>
             <div
-              data-css-okadky=""
+              data-css-7zyoug=""
             >
               <button
-                data-css-2qvjr2=""
+                data-css-j5lae8=""
+                disabled={false}
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
-                  data-css-otejxm=""
+                  data-css-y80vay=""
                 >
-                  <svg
-                    aria-label="more icon"
-                    role="img"
-                    viewBox="0 0 24 24"
+                  <div
+                    data-css-otejxm=""
                   >
-                    <path
-                      d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
-                    />
-                  </svg>
+                    <svg
+                      aria-label="more icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
+                      />
+                    </svg>
+                  </div>
                 </div>
+                <span
+                  data-css-15b13by=""
+                />
               </button>
             </div>
           </div>
@@ -1043,25 +1133,34 @@ exports[`Storyshots in drawer small 1`] = `
               </div>
             </div>
             <div
-              data-css-okadky=""
+              data-css-7zyoug=""
             >
               <button
-                data-css-2qvjr2=""
+                data-css-j5lae8=""
+                disabled={false}
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
-                  data-css-otejxm=""
+                  data-css-y80vay=""
                 >
-                  <svg
-                    aria-label="more icon"
-                    role="img"
-                    viewBox="0 0 24 24"
+                  <div
+                    data-css-otejxm=""
                   >
-                    <path
-                      d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
-                    />
-                  </svg>
+                    <svg
+                      aria-label="more icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M6 14.5a2 2 0 110-4 2 2 0 010 4zm12 0a2 2 0 110-4 2 2 0 010 4zm-6 0a2 2 0 110-4 2 2 0 010 4z"
+                      />
+                    </svg>
+                  </div>
                 </div>
+                <span
+                  data-css-15b13by=""
+                />
               </button>
             </div>
           </div>

--- a/packages/row/src/react/__stories__/index.story.js
+++ b/packages/row/src/react/__stories__/index.story.js
@@ -2,6 +2,7 @@ import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 
+import Button from '@pluralsight/ps-design-system-button'
 import Drawer from '@pluralsight/ps-design-system-drawer'
 import * as Icon from '@pluralsight/ps-design-system-icon'
 
@@ -54,9 +55,24 @@ storiesOf('combo', module).add('everything', _ => (
     ))}
     metadata2={['Goodness me!']}
     actionBar={[
-      <Row.Action key="bookmark" icon={<Icon.BookmarkIcon />} />,
-      <Row.Action key="gear" icon={<Icon.GearIcon />} />,
-      <Row.Action key="more" icon={<Icon.MoreIcon />} />
+      <Button
+        size={Button.sizes.small}
+        appearance={Button.appearances.flat}
+        key="bookmark"
+        icon={<Icon.BookmarkIcon />}
+      />,
+      <Button
+        size={Button.sizes.small}
+        appearance={Button.appearances.flat}
+        key="gear"
+        icon={<Icon.GearIcon />}
+      />,
+      <Button
+        size={Button.sizes.small}
+        appearance={Button.appearances.flat}
+        key="more"
+        icon={<Icon.MoreIcon />}
+      />
     ]}
     actionBarVisible
   />
@@ -266,19 +282,40 @@ storiesOf('actionBar', module)
   .add('one action', _ => (
     <Row
       title="Ready, Action, Bar!"
-      actionBar={[<Row.Action key="bookmark" icon={<Icon.BookmarkIcon />} />]}
+      actionBar={[
+        <Button
+          size={Button.sizes.small}
+          appearance={Button.appearances.flat}
+          key="bookmark"
+          icon={<Icon.BookmarkIcon />}
+        />
+      ]}
     />
   ))
   .add('long title', _ => (
     <Row
       title="Amazingly, the Longest Title in the World Because It's Known That If You Give Room For This Kind of a Title, It Will Definitely Come to Pass 2000"
-      actionBar={[<Row.Action key="bookmark" icon={<Icon.BookmarkIcon />} />]}
+      actionBar={[
+        <Button
+          size={Button.sizes.small}
+          appearance={Button.appearances.flat}
+          key="bookmark"
+          icon={<Icon.BookmarkIcon />}
+        />
+      ]}
     />
   ))
   .add('long title with image', _ => (
     <Row
       title="Amazingly, the Longest Title in the World Because It's Known That If You Give Room For This Kind of a Title, It Will Definitely Come to Pass 2000"
-      actionBar={[<Row.Action key="bookmark" icon={<Icon.BookmarkIcon />} />]}
+      actionBar={[
+        <Button
+          size={Button.sizes.small}
+          appearance={Button.appearances.flat}
+          key="bookmark"
+          icon={<Icon.BookmarkIcon />}
+        />
+      ]}
       image={<Row.Image src={getImgSrc()} />}
     />
   ))
@@ -286,7 +323,14 @@ storiesOf('actionBar', module)
     <Row
       actionBarVisible
       title="Amazingly, the Longest Title in the World Because It's Known That If You Give Room For This Kind of a Title, It Will Definitely Come to Pass 2000"
-      actionBar={[<Row.Action key="bookmark" icon={<Icon.BookmarkIcon />} />]}
+      actionBar={[
+        <Button
+          size={Button.sizes.small}
+          appearance={Button.appearances.flat}
+          key="bookmark"
+          icon={<Icon.BookmarkIcon />}
+        />
+      ]}
       image={<Row.Image src={getImgSrc()} />}
     />
   ))
@@ -353,7 +397,9 @@ Object.keys(Row.sizes).forEach(size =>
           metadata1={['1m 46s']}
           image={<Row.Image src={getImgSrc()} />}
           actionBar={[
-            <Row.Action
+            <Button
+              size={Button.sizes.small}
+              appearance={Button.appearances.flat}
               icon={<Icon.MoreIcon />}
               key="more"
               onClick={action('clicked action')}
@@ -375,14 +421,28 @@ storiesOf('in a stack', module).add('no top border on first row', _ => (
       title="Course thing you do"
       metadata1={['1m 46s']}
       image={<Row.Image src={getImgSrc()} />}
-      actionBar={[<Row.Action icon={<Icon.MoreIcon />} key="more" />]}
+      actionBar={[
+        <Button
+          size={Button.sizes.small}
+          appearance={Button.appearances.flat}
+          icon={<Icon.MoreIcon />}
+          key="more"
+        />
+      ]}
       actionBarVisible
     />
     <Row
       title="Course thing you do"
       metadata1={['1m 46s']}
       image={<Row.Image src={getImgSrc()} />}
-      actionBar={[<Row.Action icon={<Icon.MoreIcon />} key="more" />]}
+      actionBar={[
+        <Button
+          size={Button.sizes.small}
+          appearance={Button.appearances.flat}
+          icon={<Icon.MoreIcon />}
+          key="more"
+        />
+      ]}
       actionBarVisible
     />
   </>

--- a/packages/row/src/react/index.js
+++ b/packages/row/src/react/index.js
@@ -34,12 +34,6 @@ const styles = {
       fullOverlay && css(stylesheet['.psds-row__action-bar--fullOverlay']),
       visible && css(stylesheet['.psds-row__action-bar--actionBarVisible'])
     ),
-  actionBarAction: ({ disabled, themeName }) =>
-    compose(
-      css(stylesheet['.psds-row__action-bar__button']),
-      css(stylesheet[`.psds-row__action-bar__button.psds-theme--${themeName}`]),
-      disabled && css(stylesheet['.psds-row__action-bar__button--disabled'])
-    ),
   fullOverlay: ({ fullOverlayVisible: visible, isFocused }) =>
     compose(
       css(stylesheet['.psds-row__full-overlay']),
@@ -99,23 +93,6 @@ const styles = {
 const ActionBar = props => (
   <div {...styles.actionBar(props)} {...filterReactProps(props)} />
 )
-
-const ActionBarAction = withTheme(
-  React.forwardRef((props, ref) => {
-    // eslint-disable-next-line react/prop-types
-    const { icon, ...rest } = props
-    const filteredProps = filterReactProps(rest, { tagName: 'button' })
-
-    return (
-      <button {...styles.actionBarAction(props)} ref={ref} {...filteredProps}>
-        {icon}
-      </button>
-    )
-  })
-)
-
-ActionBarAction.displayName = 'Row.Action'
-ActionBarAction.propTypes = { icon: PropTypes.element.isRequired }
 
 const FullOverlayFocusManager = ({ fullOverlayVisible, fullOverlay }) => {
   const [isFocused, setFocused] = useState(false)
@@ -389,7 +366,7 @@ const Row = ({ title, titleTruncated, ...props }) => {
 }
 
 Row.propTypes = {
-  actionBar: PropTypes.arrayOf(elementOfType(ActionBarAction)),
+  actionBar: PropTypes.arrayOf(PropTypes.object), // <Button size="small" appearance="secondary" />
   actionBarVisible: PropTypes.bool,
   fullOverlay: PropTypes.oneOfType([
     PropTypes.element,
@@ -430,7 +407,6 @@ Row.defaultProps = {
 Row.sizes = vars.sizes
 export const sizes = Row.sizes
 
-Row.Action = ActionBarAction
 Row.FullOverlayLink = FullOverlayLink
 Row.Image = Image
 Row.ImageLink = ImageLink

--- a/packages/row/src/vars/index.js
+++ b/packages/row/src/vars/index.js
@@ -8,5 +8,5 @@ export const style = {
   overlaysWidth: '96px',
   overlaysMarginRight: core.layout.spacingLarge,
   actionBarActionWidth: xSmallIconWidth,
-  actionBarActionMarginLeft: core.layout.spacingMedium
+  actionBarActionMarginLeft: core.layout.spacingXSmall
 }

--- a/packages/site/pages/components/drawer.js
+++ b/packages/site/pages/components/drawer.js
@@ -1,3 +1,4 @@
+import Button from '@pluralsight/ps-design-system-button'
 import * as core from '@pluralsight/ps-design-system-core'
 import Drawer from '@pluralsight/ps-design-system-drawer'
 import { BookmarkIcon } from '@pluralsight/ps-design-system-icon'
@@ -39,14 +40,28 @@ const ExampleDrawerPanel = () => (
     <Row
       title="Course Overview"
       metadata1={['1m 46s']}
-      actionBar={[<Row.Action icon={<BookmarkIcon />} key="bookmark" />]}
+      actionBar={[
+        <Button
+          size={Button.sizes.small}
+          appearance={Button.appearances.flat}
+          icon={<BookmarkIcon />}
+          key="bookmark"
+        />
+      ]}
       size={Row.sizes.small}
       actionBarVisible
     />
     <Row
       title="What is ASP.NET Core?"
       metadata1={['39m 28s']}
-      actionBar={[<Row.Action icon={<BookmarkIcon />} key="bookmark" />]}
+      actionBar={[
+        <Button
+          size={Button.sizes.small}
+          appearance={Button.appearances.flat}
+          icon={<BookmarkIcon />}
+          key="bookmark"
+        />
+      ]}
       size={Row.sizes.small}
       actionBarVisible
     />

--- a/packages/site/pages/components/row.js
+++ b/packages/site/pages/components/row.js
@@ -1,8 +1,11 @@
 import * as core from '@pluralsight/ps-design-system-core'
 import React from 'react'
 
+import Badge from '@pluralsight/ps-design-system-badge'
+import Button from '@pluralsight/ps-design-system-button'
 import { BookmarkIcon, MoreIcon } from '@pluralsight/ps-design-system-icon'
 import Row from '@pluralsight/ps-design-system-row'
+import * as Text from '@pluralsight/ps-design-system-text'
 import Theme from '@pluralsight/ps-design-system-theme'
 
 import {
@@ -106,7 +109,7 @@ export default _ => (
             PropTypes.row([
               'actionBar',
               <span>
-                <code>Row.Action[]</code>
+                <code>Button</code>
               </span>,
               null,
               null,
@@ -185,17 +188,6 @@ export default _ => (
               'limit title to 2 lines'
             ])
           ],
-          'Row.Action': [
-            PropTypes.row([
-              'icon',
-              <span>
-                <code>*Icon</code>
-              </span>,
-              true,
-              null,
-              'icon representing action'
-            ])
-          ],
           'Row.Image': [
             PropTypes.row(['src', 'string', true, null, 'image url'])
           ]
@@ -214,7 +206,7 @@ export default _ => (
       <P>The size will determine certain base measurements.</P>
       <Example.React
         orient="vertical"
-        includes={{ Row }}
+        includes={{ Button, Row }}
         themeToggle
         codes={[
           `
@@ -243,7 +235,7 @@ export default _ => (
       </P>
       <Example.React
         orient="vertical"
-        includes={{ Row, BookmarkIcon }}
+        includes={{ Button, Row, BookmarkIcon }}
         themeToggle
         codes={[
           `
@@ -268,7 +260,7 @@ export default _ => (
     </Row.ImageLink>
   }
   title="Linked image with other overlays"
-  actionBar={[<Row.Action key="bookmark" icon={<BookmarkIcon />} />]}
+  actionBar={[<Button size={Button.sizes.small} appearance={Button.appearances.flat} key="bookmark" icon={<BookmarkIcon />} />]}
   fullOverlay={
     <Row.FullOverlayLink>
       <a href="https://google.com?q=full%20overlay" target="_blank">
@@ -288,7 +280,7 @@ export default _ => (
       </P>
       <Example.React
         orient="vertical"
-        includes={{ Row }}
+        includes={{ Button, Row }}
         themeToggle
         codes={[
           `
@@ -319,7 +311,7 @@ export default _ => (
       <P>The title will grow indefinitely, never truncating.</P>
       <Example.React
         orient="vertical"
-        includes={{ Row }}
+        includes={{ Button, Row }}
         themeToggle
         codes={[
           `
@@ -358,7 +350,7 @@ export default _ => (
       </P>
       <Example.React
         orient="vertical"
-        includes={{ Row }}
+        includes={{ Button, Row }}
         themeToggle
         codes={[
           `
@@ -398,14 +390,22 @@ export default _ => (
         The action bar contains the on-row affordances a user can take besides
         linking straight to the content. These are usually buttons.
       </P>
+      <P>
+        <Badge color={Badge.colors.yellow}>Note</Badge> Prior to v9.0.0, there
+        used to be a sub-component called <Text.Code>Row.Action</Text.Code> that
+        was used in the Action Bar. It has been removed to provide needed
+        flexibility. You will now want to use{' '}
+        <Text.Code>{`<Button size={Button.sizes.small} appearance={Button.appearances.flat} />`}</Text.Code>{' '}
+        instead.
+      </P>
       <Example.React
         orient="vertical"
-        includes={{ Row, BookmarkIcon, MoreIcon }}
+        includes={{ Button, Row, BookmarkIcon, MoreIcon }}
         themeToggle
         codes={[
           `
 <Row
-  actionBar={[<Row.Action key="bookmark" icon={<BookmarkIcon />} />]}
+  actionBar={[<Button size={Button.sizes.small} appearance={Button.appearances.flat} key="bookmark" icon={<BookmarkIcon />} />]}
   title="Action bar appears on hover"
   image={<Row.Image src="/static/img/course2.jpg" />}
 />
@@ -414,8 +414,8 @@ export default _ => (
           `
 <Row
   actionBar={[
-    <Row.Action key="bookmark" icon={<BookmarkIcon />} />,
-    <Row.Action key="more" icon={<MoreIcon />} />
+    <Button size={Button.sizes.small} appearance={Button.appearances.flat} key="bookmark" icon={<BookmarkIcon />} />,
+    <Button size={Button.sizes.small} appearance={Button.appearances.flat} key="more" icon={<MoreIcon />} />
   ]}
   title="Multiple actions"
   image={<Row.Image src="/static/img/course2.jpg" />}
@@ -425,8 +425,8 @@ export default _ => (
           `
 <Row
   actionBar={[
-    <Row.Action key="bookmark" icon={<BookmarkIcon />} />,
-    <Row.Action key="more" icon={<MoreIcon />} />
+    <Button size={Button.sizes.small} appearance={Button.appearances.flat} key="bookmark" icon={<BookmarkIcon />} />,
+    <Button size={Button.sizes.small} appearance={Button.appearances.flat} key="more" icon={<MoreIcon />} />
   ]}
   actionBarVisible
   title="Action bar locked visible"
@@ -447,7 +447,7 @@ export default _ => (
       </P>
       <Example.React
         orient="vertical"
-        includes={{ Row, BookmarkIcon }}
+        includes={{ Button, Row, BookmarkIcon }}
         themeToggle
         codes={[
           `
@@ -472,7 +472,7 @@ export default _ => (
       <a href="https://pluralsight.com" target="_blank">Custom Link</a>
     </Row.FullOverlayLink>
   }
-  actionBar={[<Row.Action key="bookmark" icon={<BookmarkIcon />} />]}
+  actionBar={[<Button size={Button.sizes.small} appearance={Button.appearances.flat} key="bookmark" icon={<BookmarkIcon />} />]}
   title="Combined with other overlays"
   image={<Row.Image src="/static/img/course3.jpg" />}
 />


### PR DESCRIPTION
In response to a request from Will

https://pluralsight.slack.com/archives/C70HPSJPP/p1579719708014300o
    
His use case is wanting to use another icon button that is provided as official widget from another BC.

This solution was in consultation with @sweeting .