### PR TITLE
fix(typo): duplicated word in Icon docs

### DIFF
--- a/packages/site/pages/components/icon.js
+++ b/packages/site/pages/components/icon.js
@@ -187,7 +187,7 @@ export default _ => (
       <P>
         Note: To override the size and color of a custom SVG, remove any{' '}
         <Text.Code>height</Text.Code>, <Text.Code>width</Text.Code>, and{' '}
-        <Text.Code>fill</Text.Code> attributes from from the SVG after exporting
+        <Text.Code>fill</Text.Code> attributes from the SVG after exporting
         it.
       </P>
     </Content>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65950/72949175-84ef2100-3d55-11ea-9b1e-fab0b104d6d7.png)
