### PR TITLE
icon: apply 2020 colors

### DIFF
--- a/packages/icon/src/css/index.js
+++ b/packages/icon/src/css/index.js
@@ -1,4 +1,10 @@
-import * as core from '@pluralsight/ps-design-system-core'
+import {
+  colorsTextIcon,
+  colorsRed,
+  colorsBlue,
+  colorsGreen,
+  colorsYellow
+} from '@pluralsight/ps-design-system-core'
 
 import * as vars from '../vars/index.js'
 
@@ -21,10 +27,28 @@ export default {
   [`.psds-icon > svg`]: {
     fill: 'currentColor'
   },
-  ...Object.keys(vars.colors).reduce((acc, color) => {
-    acc[`.psds-icon--color-${color} > svg`] = {
-      fill: core.colors[color]
-    }
-    return acc
-  }, {})
+  '.psds-icon--color-textIconHighOnDark > svg': {
+    fill: colorsTextIcon.highOnDark
+  },
+  '.psds-icon--color-textIconLowOnDark > svg': {
+    fill: colorsTextIcon.lowOnDark
+  },
+  '.psds-icon--color-textIconHighOnLight > svg': {
+    fill: colorsTextIcon.highOnLight
+  },
+  '.psds-icon--color-textIconLowOnLight > svg': {
+    fill: colorsTextIcon.lowOnLight
+  },
+  '.psds-icon--color-red > svg': {
+    fill: colorsRed.base
+  },
+  '.psds-icon--color-blue > svg': {
+    fill: colorsBlue.base
+  },
+  '.psds-icon--color-green > svg': {
+    fill: colorsGreen.base
+  },
+  '.psds-icon--color-yellow > svg': {
+    fill: colorsYellow.base
+  }
 }

--- a/packages/icon/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/icon/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -1,264 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots appearance black 1`] = `
-<div
-  data-css-1tiz5r9=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
 exports[`Storyshots appearance blue 1`] = `
 <div
-  data-css-48v2ba=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance bone 1`] = `
-<div
-  data-css-1v5r0q7=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance codeBlue 1`] = `
-<div
-  data-css-1nvlpe4=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance codeGreen 1`] = `
-<div
-  data-css-13hzk1y=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance codeOrange 1`] = `
-<div
-  data-css-1ptri0m=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance codePurple 1`] = `
-<div
-  data-css-1n6ftrg=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance codeRed 1`] = `
-<div
-  data-css-6x200g=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance codeSand 1`] = `
-<div
-  data-css-bwh6gu=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance codeTurquoise 1`] = `
-<div
-  data-css-1bfgu4v=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance codeYellow 1`] = `
-<div
-  data-css-ewrbgk=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance gray01 1`] = `
-<div
-  data-css-qfdobr=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance gray02 1`] = `
-<div
-  data-css-1iwwm4u=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance gray03 1`] = `
-<div
-  data-css-1ct2z2u=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance gray04 1`] = `
-<div
-  data-css-p9j7jz=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance gray05 1`] = `
-<div
-  data-css-1q7hgfl=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance gray06 1`] = `
-<div
-  data-css-4oz4oq=""
+  data-css-1654i9h=""
 >
   <svg
     aria-label="check icon"
@@ -274,71 +18,7 @@ exports[`Storyshots appearance gray06 1`] = `
 
 exports[`Storyshots appearance green 1`] = `
 <div
-  data-css-1s05snf=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance greenLight 1`] = `
-<div
-  data-css-185g5oo=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance orange 1`] = `
-<div
-  data-css-5z1xiy=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance orangeLight 1`] = `
-<div
-  data-css-1vnhyc8=""
->
-  <svg
-    aria-label="check icon"
-    role="img"
-    viewBox="0 0 24 24"
-  >
-    <path
-      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
-    />
-  </svg>
-</div>
-`;
-
-exports[`Storyshots appearance pink 1`] = `
-<div
-  data-css-15auvj7=""
+  data-css-1cekh9z=""
 >
   <svg
     aria-label="check icon"
@@ -354,7 +34,7 @@ exports[`Storyshots appearance pink 1`] = `
 
 exports[`Storyshots appearance red 1`] = `
 <div
-  data-css-rst0ce=""
+  data-css-it1fsf=""
 >
   <svg
     aria-label="check icon"
@@ -368,9 +48,57 @@ exports[`Storyshots appearance red 1`] = `
 </div>
 `;
 
-exports[`Storyshots appearance white 1`] = `
+exports[`Storyshots appearance textIconHighOnDark 1`] = `
 <div
-  data-css-10dvu6c=""
+  data-css-adcgpe=""
+>
+  <svg
+    aria-label="check icon"
+    role="img"
+    viewBox="0 0 24 24"
+  >
+    <path
+      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
+    />
+  </svg>
+</div>
+`;
+
+exports[`Storyshots appearance textIconHighOnLight 1`] = `
+<div
+  data-css-n8dd83=""
+>
+  <svg
+    aria-label="check icon"
+    role="img"
+    viewBox="0 0 24 24"
+  >
+    <path
+      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
+    />
+  </svg>
+</div>
+`;
+
+exports[`Storyshots appearance textIconLowOnDark 1`] = `
+<div
+  data-css-10kj9q4=""
+>
+  <svg
+    aria-label="check icon"
+    role="img"
+    viewBox="0 0 24 24"
+  >
+    <path
+      d="M9.59 14.58l-2.818-2.818a.5.5 0 00-.706-.001l-.71.705a.5.5 0 00-.002.708l3.882 3.882a.5.5 0 00.708 0l9.292-9.292a.5.5 0 000-.708l-.702-.702a.5.5 0 00-.708 0L9.59 14.58z"
+    />
+  </svg>
+</div>
+`;
+
+exports[`Storyshots appearance textIconLowOnLight 1`] = `
+<div
+  data-css-12fyh6p=""
 >
   <svg
     aria-label="check icon"
@@ -386,7 +114,7 @@ exports[`Storyshots appearance white 1`] = `
 
 exports[`Storyshots appearance yellow 1`] = `
 <div
-  data-css-3pplc0=""
+  data-css-m4m5mt=""
 >
   <svg
     aria-label="check icon"
@@ -402,7 +130,7 @@ exports[`Storyshots appearance yellow 1`] = `
 
 exports[`Storyshots custom icon aria-label 1`] = `
 <div
-  data-css-10dvu6c=""
+  data-css-adcgpe=""
 >
   <svg
     aria-label="account icon"
@@ -418,7 +146,7 @@ exports[`Storyshots custom icon aria-label 1`] = `
 
 exports[`Storyshots custom props aria-label 1`] = `
 <div
-  data-css-10dvu6c=""
+  data-css-adcgpe=""
 >
   <svg
     aria-label="completed"
@@ -434,7 +162,7 @@ exports[`Storyshots custom props aria-label 1`] = `
 
 exports[`Storyshots names AccountIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="account icon"
@@ -450,7 +178,7 @@ exports[`Storyshots names AccountIcon 1`] = `
 
 exports[`Storyshots names AnalyticsIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="analytics icon"
@@ -468,7 +196,7 @@ exports[`Storyshots names AnalyticsIcon 1`] = `
 
 exports[`Storyshots names ArrowDownIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="arrow down icon"
@@ -486,7 +214,7 @@ exports[`Storyshots names ArrowDownIcon 1`] = `
 
 exports[`Storyshots names ArrowDownRightIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="arrow down right icon"
@@ -502,7 +230,7 @@ exports[`Storyshots names ArrowDownRightIcon 1`] = `
 
 exports[`Storyshots names ArrowLeftIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="arrow left icon"
@@ -520,7 +248,7 @@ exports[`Storyshots names ArrowLeftIcon 1`] = `
 
 exports[`Storyshots names ArrowRightIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="arrow right icon"
@@ -538,7 +266,7 @@ exports[`Storyshots names ArrowRightIcon 1`] = `
 
 exports[`Storyshots names ArrowUpIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="arrow up icon"
@@ -556,7 +284,7 @@ exports[`Storyshots names ArrowUpIcon 1`] = `
 
 exports[`Storyshots names ArrowUpRightIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="arrow up right icon"
@@ -572,7 +300,7 @@ exports[`Storyshots names ArrowUpRightIcon 1`] = `
 
 exports[`Storyshots names ArticleIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="article icon"
@@ -588,7 +316,7 @@ exports[`Storyshots names ArticleIcon 1`] = `
 
 exports[`Storyshots names AuthorKitIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="author kit icon"
@@ -606,7 +334,7 @@ exports[`Storyshots names AuthorKitIcon 1`] = `
 
 exports[`Storyshots names AuthorsNestIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="authors nest icon"
@@ -624,7 +352,7 @@ exports[`Storyshots names AuthorsNestIcon 1`] = `
 
 exports[`Storyshots names BellIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="bell icon"
@@ -642,7 +370,7 @@ exports[`Storyshots names BellIcon 1`] = `
 
 exports[`Storyshots names BellRungIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="bell rung icon"
@@ -660,7 +388,7 @@ exports[`Storyshots names BellRungIcon 1`] = `
 
 exports[`Storyshots names BookmarkFillIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="bookmark fill icon"
@@ -676,7 +404,7 @@ exports[`Storyshots names BookmarkFillIcon 1`] = `
 
 exports[`Storyshots names BookmarkIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="bookmark icon"
@@ -692,7 +420,7 @@ exports[`Storyshots names BookmarkIcon 1`] = `
 
 exports[`Storyshots names BriefcaseIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="briefcase icon"
@@ -710,7 +438,7 @@ exports[`Storyshots names BriefcaseIcon 1`] = `
 
 exports[`Storyshots names BrowseIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="browse icon"
@@ -728,7 +456,7 @@ exports[`Storyshots names BrowseIcon 1`] = `
 
 exports[`Storyshots names BuildingIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="building icon"
@@ -746,7 +474,7 @@ exports[`Storyshots names BuildingIcon 1`] = `
 
 exports[`Storyshots names CalendarIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="calendar icon"
@@ -762,7 +490,7 @@ exports[`Storyshots names CalendarIcon 1`] = `
 
 exports[`Storyshots names CaretAltDownIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="caret alt down icon"
@@ -780,7 +508,7 @@ exports[`Storyshots names CaretAltDownIcon 1`] = `
 
 exports[`Storyshots names CaretAltLeftIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="caret alt left icon"
@@ -798,7 +526,7 @@ exports[`Storyshots names CaretAltLeftIcon 1`] = `
 
 exports[`Storyshots names CaretAltRightIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="caret alt right icon"
@@ -816,7 +544,7 @@ exports[`Storyshots names CaretAltRightIcon 1`] = `
 
 exports[`Storyshots names CaretAltUpIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="caret alt up icon"
@@ -834,7 +562,7 @@ exports[`Storyshots names CaretAltUpIcon 1`] = `
 
 exports[`Storyshots names CaretDownIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="caret down icon"
@@ -850,7 +578,7 @@ exports[`Storyshots names CaretDownIcon 1`] = `
 
 exports[`Storyshots names CaretLeftIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="caret left icon"
@@ -866,7 +594,7 @@ exports[`Storyshots names CaretLeftIcon 1`] = `
 
 exports[`Storyshots names CaretRightIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="caret right icon"
@@ -882,7 +610,7 @@ exports[`Storyshots names CaretRightIcon 1`] = `
 
 exports[`Storyshots names CaretUpIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="caret up icon"
@@ -898,7 +626,7 @@ exports[`Storyshots names CaretUpIcon 1`] = `
 
 exports[`Storyshots names ChannelAddIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="channel add icon"
@@ -916,7 +644,7 @@ exports[`Storyshots names ChannelAddIcon 1`] = `
 
 exports[`Storyshots names ChannelIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="channel icon"
@@ -934,7 +662,7 @@ exports[`Storyshots names ChannelIcon 1`] = `
 
 exports[`Storyshots names ChatIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="chat icon"
@@ -952,7 +680,7 @@ exports[`Storyshots names ChatIcon 1`] = `
 
 exports[`Storyshots names CheckCircleFillIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="check circle fill icon"
@@ -968,7 +696,7 @@ exports[`Storyshots names CheckCircleFillIcon 1`] = `
 
 exports[`Storyshots names CheckCircleIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="check circle icon"
@@ -986,7 +714,7 @@ exports[`Storyshots names CheckCircleIcon 1`] = `
 
 exports[`Storyshots names CheckIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="check icon"
@@ -1002,7 +730,7 @@ exports[`Storyshots names CheckIcon 1`] = `
 
 exports[`Storyshots names ClockIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="clock icon"
@@ -1018,7 +746,7 @@ exports[`Storyshots names ClockIcon 1`] = `
 
 exports[`Storyshots names ClockWarningIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="clock warning icon"
@@ -1036,7 +764,7 @@ exports[`Storyshots names ClockWarningIcon 1`] = `
 
 exports[`Storyshots names CloseCaptionedFillIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="close captioned fill icon"
@@ -1052,7 +780,7 @@ exports[`Storyshots names CloseCaptionedFillIcon 1`] = `
 
 exports[`Storyshots names CloseCaptionedIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="close captioned icon"
@@ -1070,7 +798,7 @@ exports[`Storyshots names CloseCaptionedIcon 1`] = `
 
 exports[`Storyshots names CloseIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="close icon"
@@ -1086,7 +814,7 @@ exports[`Storyshots names CloseIcon 1`] = `
 
 exports[`Storyshots names CloudIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="cloud icon"
@@ -1102,7 +830,7 @@ exports[`Storyshots names CloudIcon 1`] = `
 
 exports[`Storyshots names CloudOffIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="cloud off icon"
@@ -1118,7 +846,7 @@ exports[`Storyshots names CloudOffIcon 1`] = `
 
 exports[`Storyshots names CodeBrandedIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="code branded icon"
@@ -1136,7 +864,7 @@ exports[`Storyshots names CodeBrandedIcon 1`] = `
 
 exports[`Storyshots names CodeIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="code icon"
@@ -1153,7 +881,7 @@ exports[`Storyshots names CodeIcon 1`] = `
 
 exports[`Storyshots names ConnectionWarningIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="connection warning icon"
@@ -1171,7 +899,7 @@ exports[`Storyshots names ConnectionWarningIcon 1`] = `
 
 exports[`Storyshots names CopyIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="copy icon"
@@ -1192,7 +920,7 @@ exports[`Storyshots names CopyIcon 1`] = `
 
 exports[`Storyshots names CoursesIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="courses icon"
@@ -1210,7 +938,7 @@ exports[`Storyshots names CoursesIcon 1`] = `
 
 exports[`Storyshots names CurriculumIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="curriculum icon"
@@ -1236,7 +964,7 @@ exports[`Storyshots names CurriculumIcon 1`] = `
 
 exports[`Storyshots names DashboardIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="dashboard icon"
@@ -1252,7 +980,7 @@ exports[`Storyshots names DashboardIcon 1`] = `
 
 exports[`Storyshots names DesktopIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="desktop icon"
@@ -1270,7 +998,7 @@ exports[`Storyshots names DesktopIcon 1`] = `
 
 exports[`Storyshots names DownloadIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="download icon"
@@ -1289,7 +1017,7 @@ exports[`Storyshots names DownloadIcon 1`] = `
 
 exports[`Storyshots names EnvelopeArrowIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="envelope arrow icon"
@@ -1307,7 +1035,7 @@ exports[`Storyshots names EnvelopeArrowIcon 1`] = `
 
 exports[`Storyshots names EnvelopeIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="envelope icon"
@@ -1323,7 +1051,7 @@ exports[`Storyshots names EnvelopeIcon 1`] = `
 
 exports[`Storyshots names ExternalLinkIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="external link icon"
@@ -1339,7 +1067,7 @@ exports[`Storyshots names ExternalLinkIcon 1`] = `
 
 exports[`Storyshots names EyeIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="eye icon"
@@ -1357,7 +1085,7 @@ exports[`Storyshots names EyeIcon 1`] = `
 
 exports[`Storyshots names EyeOffIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="eye off icon"
@@ -1375,7 +1103,7 @@ exports[`Storyshots names EyeOffIcon 1`] = `
 
 exports[`Storyshots names FileIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="file icon"
@@ -1391,7 +1119,7 @@ exports[`Storyshots names FileIcon 1`] = `
 
 exports[`Storyshots names FilterIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="filter icon"
@@ -1409,7 +1137,7 @@ exports[`Storyshots names FilterIcon 1`] = `
 
 exports[`Storyshots names FullscreenExitIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="fullscreen exit icon"
@@ -1427,7 +1155,7 @@ exports[`Storyshots names FullscreenExitIcon 1`] = `
 
 exports[`Storyshots names FullscreenIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="fullscreen icon"
@@ -1445,7 +1173,7 @@ exports[`Storyshots names FullscreenIcon 1`] = `
 
 exports[`Storyshots names GearIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="gear icon"
@@ -1463,7 +1191,7 @@ exports[`Storyshots names GearIcon 1`] = `
 
 exports[`Storyshots names GlobeIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="globe icon"
@@ -1481,7 +1209,7 @@ exports[`Storyshots names GlobeIcon 1`] = `
 
 exports[`Storyshots names HandIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="hand icon"
@@ -1503,7 +1231,7 @@ exports[`Storyshots names HandIcon 1`] = `
 
 exports[`Storyshots names HelpIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="help icon"
@@ -1521,7 +1249,7 @@ exports[`Storyshots names HelpIcon 1`] = `
 
 exports[`Storyshots names HistoryIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="history icon"
@@ -1539,7 +1267,7 @@ exports[`Storyshots names HistoryIcon 1`] = `
 
 exports[`Storyshots names HomeAdminToolsIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="home admin tools icon"
@@ -1555,7 +1283,7 @@ exports[`Storyshots names HomeAdminToolsIcon 1`] = `
 
 exports[`Storyshots names HomeContentToolsIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="home content tools icon"
@@ -1571,7 +1299,7 @@ exports[`Storyshots names HomeContentToolsIcon 1`] = `
 
 exports[`Storyshots names HomeIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="home icon"
@@ -1589,7 +1317,7 @@ exports[`Storyshots names HomeIcon 1`] = `
 
 exports[`Storyshots names InfoIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="info icon"
@@ -1607,7 +1335,7 @@ exports[`Storyshots names InfoIcon 1`] = `
 
 exports[`Storyshots names InteractiveIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="interactive icon"
@@ -1623,7 +1351,7 @@ exports[`Storyshots names InteractiveIcon 1`] = `
 
 exports[`Storyshots names IqIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="iq icon"
@@ -1641,7 +1369,7 @@ exports[`Storyshots names IqIcon 1`] = `
 
 exports[`Storyshots names LinkIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="link icon"
@@ -1659,7 +1387,7 @@ exports[`Storyshots names LinkIcon 1`] = `
 
 exports[`Storyshots names ListIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="list icon"
@@ -1677,7 +1405,7 @@ exports[`Storyshots names ListIcon 1`] = `
 
 exports[`Storyshots names LocationIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="location icon"
@@ -1695,7 +1423,7 @@ exports[`Storyshots names LocationIcon 1`] = `
 
 exports[`Storyshots names LockFillIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="lock fill icon"
@@ -1713,7 +1441,7 @@ exports[`Storyshots names LockFillIcon 1`] = `
 
 exports[`Storyshots names LockIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="lock icon"
@@ -1729,7 +1457,7 @@ exports[`Storyshots names LockIcon 1`] = `
 
 exports[`Storyshots names MenuCloseIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="menu close icon"
@@ -1747,7 +1475,7 @@ exports[`Storyshots names MenuCloseIcon 1`] = `
 
 exports[`Storyshots names MenuIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="menu icon"
@@ -1765,7 +1493,7 @@ exports[`Storyshots names MenuIcon 1`] = `
 
 exports[`Storyshots names MicIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="mic icon"
@@ -1783,7 +1511,7 @@ exports[`Storyshots names MicIcon 1`] = `
 
 exports[`Storyshots names MoreIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="more icon"
@@ -1799,7 +1527,7 @@ exports[`Storyshots names MoreIcon 1`] = `
 
 exports[`Storyshots names MoveIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="move icon"
@@ -1817,7 +1545,7 @@ exports[`Storyshots names MoveIcon 1`] = `
 
 exports[`Storyshots names NextIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="next icon"
@@ -1835,7 +1563,7 @@ exports[`Storyshots names NextIcon 1`] = `
 
 exports[`Storyshots names NoteIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="note icon"
@@ -1853,7 +1581,7 @@ exports[`Storyshots names NoteIcon 1`] = `
 
 exports[`Storyshots names NotificationsIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="notifications icon"
@@ -1871,7 +1599,7 @@ exports[`Storyshots names NotificationsIcon 1`] = `
 
 exports[`Storyshots names NotificationsNewIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="notifications new icon"
@@ -1889,7 +1617,7 @@ exports[`Storyshots names NotificationsNewIcon 1`] = `
 
 exports[`Storyshots names ObjectiveIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="objective icon"
@@ -1907,7 +1635,7 @@ exports[`Storyshots names ObjectiveIcon 1`] = `
 
 exports[`Storyshots names OrgIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="org icon"
@@ -1923,7 +1651,7 @@ exports[`Storyshots names OrgIcon 1`] = `
 
 exports[`Storyshots names PathIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="path icon"
@@ -1941,7 +1669,7 @@ exports[`Storyshots names PathIcon 1`] = `
 
 exports[`Storyshots names PauseIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="pause icon"
@@ -1959,7 +1687,7 @@ exports[`Storyshots names PauseIcon 1`] = `
 
 exports[`Storyshots names PencilIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="pencil icon"
@@ -1975,7 +1703,7 @@ exports[`Storyshots names PencilIcon 1`] = `
 
 exports[`Storyshots names PeopleIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="people icon"
@@ -1991,7 +1719,7 @@ exports[`Storyshots names PeopleIcon 1`] = `
 
 exports[`Storyshots names PhoneDownIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="phone down icon"
@@ -2009,7 +1737,7 @@ exports[`Storyshots names PhoneDownIcon 1`] = `
 
 exports[`Storyshots names PhoneIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="phone icon"
@@ -2027,7 +1755,7 @@ exports[`Storyshots names PhoneIcon 1`] = `
 
 exports[`Storyshots names PlaceholderIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="placeholder icon"
@@ -2043,7 +1771,7 @@ exports[`Storyshots names PlaceholderIcon 1`] = `
 
 exports[`Storyshots names PlayCircleIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="play circle icon"
@@ -2061,7 +1789,7 @@ exports[`Storyshots names PlayCircleIcon 1`] = `
 
 exports[`Storyshots names PlayIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="play icon"
@@ -2079,7 +1807,7 @@ exports[`Storyshots names PlayIcon 1`] = `
 
 exports[`Storyshots names PlusCircleFillIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="plus circle fill icon"
@@ -2097,7 +1825,7 @@ exports[`Storyshots names PlusCircleFillIcon 1`] = `
 
 exports[`Storyshots names PlusCircleIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="plus circle icon"
@@ -2113,7 +1841,7 @@ exports[`Storyshots names PlusCircleIcon 1`] = `
 
 exports[`Storyshots names PlusIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="plus icon"
@@ -2129,7 +1857,7 @@ exports[`Storyshots names PlusIcon 1`] = `
 
 exports[`Storyshots names PodcastIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="podcast icon"
@@ -2147,7 +1875,7 @@ exports[`Storyshots names PodcastIcon 1`] = `
 
 exports[`Storyshots names PreviousIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="previous icon"
@@ -2165,7 +1893,7 @@ exports[`Storyshots names PreviousIcon 1`] = `
 
 exports[`Storyshots names ProjectIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="project icon"
@@ -2181,7 +1909,7 @@ exports[`Storyshots names ProjectIcon 1`] = `
 
 exports[`Storyshots names QNAIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="q n a icon"
@@ -2202,7 +1930,7 @@ exports[`Storyshots names QNAIcon 1`] = `
 
 exports[`Storyshots names QuestionFilledIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="question filled icon"
@@ -2220,7 +1948,7 @@ exports[`Storyshots names QuestionFilledIcon 1`] = `
 
 exports[`Storyshots names QuestionIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="question icon"
@@ -2238,7 +1966,7 @@ exports[`Storyshots names QuestionIcon 1`] = `
 
 exports[`Storyshots names RedoIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="redo icon"
@@ -2254,7 +1982,7 @@ exports[`Storyshots names RedoIcon 1`] = `
 
 exports[`Storyshots names ReloadIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="reload icon"
@@ -2270,7 +1998,7 @@ exports[`Storyshots names ReloadIcon 1`] = `
 
 exports[`Storyshots names ReportIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="report icon"
@@ -2286,7 +2014,7 @@ exports[`Storyshots names ReportIcon 1`] = `
 
 exports[`Storyshots names ScopeIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="scope icon"
@@ -2302,7 +2030,7 @@ exports[`Storyshots names ScopeIcon 1`] = `
 
 exports[`Storyshots names ScreenshareIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="screenshare icon"
@@ -2320,7 +2048,7 @@ exports[`Storyshots names ScreenshareIcon 1`] = `
 
 exports[`Storyshots names SearchIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="search icon"
@@ -2338,7 +2066,7 @@ exports[`Storyshots names SearchIcon 1`] = `
 
 exports[`Storyshots names ServiceBoxIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="service box icon"
@@ -2356,7 +2084,7 @@ exports[`Storyshots names ServiceBoxIcon 1`] = `
 
 exports[`Storyshots names ServiceDropboxIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="service dropbox icon"
@@ -2374,7 +2102,7 @@ exports[`Storyshots names ServiceDropboxIcon 1`] = `
 
 exports[`Storyshots names ServiceGoogleDriveIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="service google drive icon"
@@ -2392,7 +2120,7 @@ exports[`Storyshots names ServiceGoogleDriveIcon 1`] = `
 
 exports[`Storyshots names ShareIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="share icon"
@@ -2408,7 +2136,7 @@ exports[`Storyshots names ShareIcon 1`] = `
 
 exports[`Storyshots names SignoutIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="signout icon"
@@ -2426,7 +2154,7 @@ exports[`Storyshots names SignoutIcon 1`] = `
 
 exports[`Storyshots names SkipBackwardIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="skip backward icon"
@@ -2444,7 +2172,7 @@ exports[`Storyshots names SkipBackwardIcon 1`] = `
 
 exports[`Storyshots names SkipForwardIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="skip forward icon"
@@ -2462,7 +2190,7 @@ exports[`Storyshots names SkipForwardIcon 1`] = `
 
 exports[`Storyshots names SocialDribbbleIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="social dribbble icon"
@@ -2480,7 +2208,7 @@ exports[`Storyshots names SocialDribbbleIcon 1`] = `
 
 exports[`Storyshots names SocialFacebookIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="social facebook icon"
@@ -2498,7 +2226,7 @@ exports[`Storyshots names SocialFacebookIcon 1`] = `
 
 exports[`Storyshots names SocialGithubIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="social github icon"
@@ -2516,7 +2244,7 @@ exports[`Storyshots names SocialGithubIcon 1`] = `
 
 exports[`Storyshots names SocialGooglePlusIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="social google plus icon"
@@ -2534,7 +2262,7 @@ exports[`Storyshots names SocialGooglePlusIcon 1`] = `
 
 exports[`Storyshots names SocialLinkedinIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="social linkedin icon"
@@ -2552,7 +2280,7 @@ exports[`Storyshots names SocialLinkedinIcon 1`] = `
 
 exports[`Storyshots names SocialMediumIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="social medium icon"
@@ -2568,7 +2296,7 @@ exports[`Storyshots names SocialMediumIcon 1`] = `
 
 exports[`Storyshots names SocialRssIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="social rss icon"
@@ -2586,7 +2314,7 @@ exports[`Storyshots names SocialRssIcon 1`] = `
 
 exports[`Storyshots names SocialStackoverflowIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="social stackoverflow icon"
@@ -2604,7 +2332,7 @@ exports[`Storyshots names SocialStackoverflowIcon 1`] = `
 
 exports[`Storyshots names SocialTwitterIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="social twitter icon"
@@ -2622,7 +2350,7 @@ exports[`Storyshots names SocialTwitterIcon 1`] = `
 
 exports[`Storyshots names SortAscIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="sort asc icon"
@@ -2638,7 +2366,7 @@ exports[`Storyshots names SortAscIcon 1`] = `
 
 exports[`Storyshots names SortDescIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="sort desc icon"
@@ -2654,7 +2382,7 @@ exports[`Storyshots names SortDescIcon 1`] = `
 
 exports[`Storyshots names SortIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="sort icon"
@@ -2670,7 +2398,7 @@ exports[`Storyshots names SortIcon 1`] = `
 
 exports[`Storyshots names StarFillIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="star fill icon"
@@ -2686,7 +2414,7 @@ exports[`Storyshots names StarFillIcon 1`] = `
 
 exports[`Storyshots names StarIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="star icon"
@@ -2702,7 +2430,7 @@ exports[`Storyshots names StarIcon 1`] = `
 
 exports[`Storyshots names StopIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="stop icon"
@@ -2720,7 +2448,7 @@ exports[`Storyshots names StopIcon 1`] = `
 
 exports[`Storyshots names TagAssignmentIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="tag assignment icon"
@@ -2751,7 +2479,7 @@ exports[`Storyshots names TagAssignmentIcon 1`] = `
 
 exports[`Storyshots names TagIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="tag icon"
@@ -2767,7 +2495,7 @@ exports[`Storyshots names TagIcon 1`] = `
 
 exports[`Storyshots names TagManagementIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="tag management icon"
@@ -2790,7 +2518,7 @@ exports[`Storyshots names TagManagementIcon 1`] = `
 
 exports[`Storyshots names TestIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="test icon"
@@ -2808,7 +2536,7 @@ exports[`Storyshots names TestIcon 1`] = `
 
 exports[`Storyshots names ThumbDownFillIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="thumb down fill icon"
@@ -2825,7 +2553,7 @@ exports[`Storyshots names ThumbDownFillIcon 1`] = `
 
 exports[`Storyshots names ThumbDownIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="thumb down icon"
@@ -2842,7 +2570,7 @@ exports[`Storyshots names ThumbDownIcon 1`] = `
 
 exports[`Storyshots names ThumbUpFillIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="thumb up fill icon"
@@ -2859,7 +2587,7 @@ exports[`Storyshots names ThumbUpFillIcon 1`] = `
 
 exports[`Storyshots names ThumbUpIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="thumb up icon"
@@ -2876,7 +2604,7 @@ exports[`Storyshots names ThumbUpIcon 1`] = `
 
 exports[`Storyshots names TranscriptIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="transcript icon"
@@ -2894,7 +2622,7 @@ exports[`Storyshots names TranscriptIcon 1`] = `
 
 exports[`Storyshots names TrashIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="trash icon"
@@ -2912,7 +2640,7 @@ exports[`Storyshots names TrashIcon 1`] = `
 
 exports[`Storyshots names UndoIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="undo icon"
@@ -2928,7 +2656,7 @@ exports[`Storyshots names UndoIcon 1`] = `
 
 exports[`Storyshots names UnionIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="union icon"
@@ -2952,7 +2680,7 @@ exports[`Storyshots names UnionIcon 1`] = `
 
 exports[`Storyshots names UploadIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="upload icon"
@@ -2971,7 +2699,7 @@ exports[`Storyshots names UploadIcon 1`] = `
 
 exports[`Storyshots names UserAddIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="user add icon"
@@ -2989,7 +2717,7 @@ exports[`Storyshots names UserAddIcon 1`] = `
 
 exports[`Storyshots names UserIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="user icon"
@@ -3007,7 +2735,7 @@ exports[`Storyshots names UserIcon 1`] = `
 
 exports[`Storyshots names VideoIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="video icon"
@@ -3025,7 +2753,7 @@ exports[`Storyshots names VideoIcon 1`] = `
 
 exports[`Storyshots names VolumeHighIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="volume high icon"
@@ -3043,7 +2771,7 @@ exports[`Storyshots names VolumeHighIcon 1`] = `
 
 exports[`Storyshots names VolumeLowIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="volume low icon"
@@ -3061,7 +2789,7 @@ exports[`Storyshots names VolumeLowIcon 1`] = `
 
 exports[`Storyshots names VolumeMediumIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="volume medium icon"
@@ -3079,7 +2807,7 @@ exports[`Storyshots names VolumeMediumIcon 1`] = `
 
 exports[`Storyshots names VolumeOffIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="volume off icon"
@@ -3097,7 +2825,7 @@ exports[`Storyshots names VolumeOffIcon 1`] = `
 
 exports[`Storyshots names WarningFilledIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="warning filled icon"
@@ -3115,7 +2843,7 @@ exports[`Storyshots names WarningFilledIcon 1`] = `
 
 exports[`Storyshots names WarningIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="warning icon"
@@ -3133,7 +2861,7 @@ exports[`Storyshots names WarningIcon 1`] = `
 
 exports[`Storyshots names WindowIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="window icon"
@@ -3151,7 +2879,7 @@ exports[`Storyshots names WindowIcon 1`] = `
 
 exports[`Storyshots names XCircleFillIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="x circle fill icon"
@@ -3169,7 +2897,7 @@ exports[`Storyshots names XCircleFillIcon 1`] = `
 
 exports[`Storyshots names XCircleIcon 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="x circle icon"
@@ -3193,7 +2921,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="account icon"
@@ -3210,7 +2938,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="analytics icon"
@@ -3229,7 +2957,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="arrow down icon"
@@ -3248,7 +2976,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="arrow down right icon"
@@ -3265,7 +2993,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="arrow left icon"
@@ -3284,7 +3012,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="arrow right icon"
@@ -3303,7 +3031,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="arrow up icon"
@@ -3322,7 +3050,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="arrow up right icon"
@@ -3339,7 +3067,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="article icon"
@@ -3356,7 +3084,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="author kit icon"
@@ -3375,7 +3103,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="authors nest icon"
@@ -3394,7 +3122,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="bell icon"
@@ -3413,7 +3141,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="bell rung icon"
@@ -3432,7 +3160,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="bookmark fill icon"
@@ -3449,7 +3177,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="bookmark icon"
@@ -3466,7 +3194,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="briefcase icon"
@@ -3485,7 +3213,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="browse icon"
@@ -3504,7 +3232,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="building icon"
@@ -3523,7 +3251,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="calendar icon"
@@ -3540,7 +3268,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="caret alt down icon"
@@ -3559,7 +3287,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="caret alt left icon"
@@ -3578,7 +3306,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="caret alt right icon"
@@ -3597,7 +3325,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="caret alt up icon"
@@ -3616,7 +3344,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="caret down icon"
@@ -3633,7 +3361,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="caret left icon"
@@ -3650,7 +3378,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="caret right icon"
@@ -3667,7 +3395,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="caret up icon"
@@ -3684,7 +3412,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="channel add icon"
@@ -3703,7 +3431,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="channel icon"
@@ -3722,7 +3450,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="chat icon"
@@ -3741,7 +3469,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="check circle fill icon"
@@ -3758,7 +3486,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="check circle icon"
@@ -3777,7 +3505,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="check icon"
@@ -3794,7 +3522,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="clock icon"
@@ -3811,7 +3539,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="clock warning icon"
@@ -3830,7 +3558,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="close captioned fill icon"
@@ -3847,7 +3575,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="close captioned icon"
@@ -3866,7 +3594,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="close icon"
@@ -3883,7 +3611,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="cloud icon"
@@ -3900,7 +3628,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="cloud off icon"
@@ -3917,7 +3645,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="code branded icon"
@@ -3936,7 +3664,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="code icon"
@@ -3954,7 +3682,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="connection warning icon"
@@ -3973,7 +3701,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="copy icon"
@@ -3995,7 +3723,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="courses icon"
@@ -4014,7 +3742,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="curriculum icon"
@@ -4041,7 +3769,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="dashboard icon"
@@ -4058,7 +3786,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="desktop icon"
@@ -4077,7 +3805,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="download icon"
@@ -4097,7 +3825,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="envelope arrow icon"
@@ -4116,7 +3844,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="envelope icon"
@@ -4133,7 +3861,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="external link icon"
@@ -4150,7 +3878,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="eye icon"
@@ -4169,7 +3897,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="eye off icon"
@@ -4188,7 +3916,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="file icon"
@@ -4205,7 +3933,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="filter icon"
@@ -4224,7 +3952,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="fullscreen exit icon"
@@ -4243,7 +3971,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="fullscreen icon"
@@ -4262,7 +3990,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="gear icon"
@@ -4281,7 +4009,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="globe icon"
@@ -4300,7 +4028,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="hand icon"
@@ -4323,7 +4051,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="help icon"
@@ -4342,7 +4070,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="history icon"
@@ -4361,7 +4089,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="home admin tools icon"
@@ -4378,7 +4106,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="home content tools icon"
@@ -4395,7 +4123,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="home icon"
@@ -4414,7 +4142,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="info icon"
@@ -4433,7 +4161,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="interactive icon"
@@ -4450,7 +4178,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="iq icon"
@@ -4469,7 +4197,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="link icon"
@@ -4488,7 +4216,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="list icon"
@@ -4507,7 +4235,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="location icon"
@@ -4526,7 +4254,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="lock fill icon"
@@ -4545,7 +4273,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="lock icon"
@@ -4562,7 +4290,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="menu close icon"
@@ -4581,7 +4309,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="menu icon"
@@ -4600,7 +4328,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="mic icon"
@@ -4619,7 +4347,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="more icon"
@@ -4636,7 +4364,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="move icon"
@@ -4655,7 +4383,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="next icon"
@@ -4674,7 +4402,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="note icon"
@@ -4693,7 +4421,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="notifications icon"
@@ -4712,7 +4440,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="notifications new icon"
@@ -4731,7 +4459,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="objective icon"
@@ -4750,7 +4478,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="org icon"
@@ -4767,7 +4495,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="path icon"
@@ -4786,7 +4514,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="pause icon"
@@ -4805,7 +4533,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="pencil icon"
@@ -4822,7 +4550,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="people icon"
@@ -4839,7 +4567,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="phone down icon"
@@ -4858,7 +4586,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="phone icon"
@@ -4877,7 +4605,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="placeholder icon"
@@ -4894,7 +4622,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="play circle icon"
@@ -4913,7 +4641,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="play icon"
@@ -4932,7 +4660,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="plus circle fill icon"
@@ -4951,7 +4679,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="plus circle icon"
@@ -4968,7 +4696,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="plus icon"
@@ -4985,7 +4713,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="podcast icon"
@@ -5004,7 +4732,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="previous icon"
@@ -5023,7 +4751,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="project icon"
@@ -5040,7 +4768,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="q n a icon"
@@ -5062,7 +4790,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="question filled icon"
@@ -5081,7 +4809,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="question icon"
@@ -5100,7 +4828,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="redo icon"
@@ -5117,7 +4845,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="reload icon"
@@ -5134,7 +4862,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="report icon"
@@ -5151,7 +4879,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="scope icon"
@@ -5168,7 +4896,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="screenshare icon"
@@ -5187,7 +4915,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="search icon"
@@ -5206,7 +4934,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="service box icon"
@@ -5225,7 +4953,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="service dropbox icon"
@@ -5244,7 +4972,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="service google drive icon"
@@ -5263,7 +4991,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="share icon"
@@ -5280,7 +5008,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="signout icon"
@@ -5299,7 +5027,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="skip backward icon"
@@ -5318,7 +5046,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="skip forward icon"
@@ -5337,7 +5065,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="social dribbble icon"
@@ -5356,7 +5084,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="social facebook icon"
@@ -5375,7 +5103,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="social github icon"
@@ -5394,7 +5122,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="social google plus icon"
@@ -5413,7 +5141,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="social linkedin icon"
@@ -5432,7 +5160,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="social medium icon"
@@ -5449,7 +5177,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="social rss icon"
@@ -5468,7 +5196,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="social stackoverflow icon"
@@ -5487,7 +5215,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="social twitter icon"
@@ -5506,7 +5234,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="sort asc icon"
@@ -5523,7 +5251,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="sort desc icon"
@@ -5540,7 +5268,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="sort icon"
@@ -5557,7 +5285,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="star fill icon"
@@ -5574,7 +5302,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="star icon"
@@ -5591,7 +5319,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="stop icon"
@@ -5610,7 +5338,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="tag assignment icon"
@@ -5642,7 +5370,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="tag icon"
@@ -5659,7 +5387,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="tag management icon"
@@ -5683,7 +5411,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="test icon"
@@ -5702,7 +5430,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="thumb down fill icon"
@@ -5720,7 +5448,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="thumb down icon"
@@ -5738,7 +5466,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="thumb up fill icon"
@@ -5756,7 +5484,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="thumb up icon"
@@ -5774,7 +5502,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="transcript icon"
@@ -5793,7 +5521,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="trash icon"
@@ -5812,7 +5540,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="undo icon"
@@ -5829,7 +5557,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="union icon"
@@ -5854,7 +5582,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="upload icon"
@@ -5874,7 +5602,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="user add icon"
@@ -5893,7 +5621,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="user icon"
@@ -5912,7 +5640,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="video icon"
@@ -5931,7 +5659,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="volume high icon"
@@ -5950,7 +5678,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="volume low icon"
@@ -5969,7 +5697,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="volume medium icon"
@@ -5988,7 +5716,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="volume off icon"
@@ -6007,7 +5735,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="warning filled icon"
@@ -6026,7 +5754,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="warning icon"
@@ -6045,7 +5773,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="window icon"
@@ -6064,7 +5792,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="x circle fill icon"
@@ -6083,7 +5811,7 @@ exports[`Storyshots names all export names 1`] = `
     data-css-1abx40i=""
   >
     <div
-      data-css-10dvu6c=""
+      data-css-adcgpe=""
     >
       <svg
         aria-label="x circle icon"
@@ -6103,7 +5831,7 @@ exports[`Storyshots names all export names 1`] = `
 
 exports[`Storyshots size large 1`] = `
 <div
-  data-css-6f8y6t=""
+  data-css-10pr3ns=""
 >
   <svg
     aria-label="check icon"
@@ -6119,7 +5847,7 @@ exports[`Storyshots size large 1`] = `
 
 exports[`Storyshots size medium 1`] = `
 <div
-  data-css-10dvu6c=""
+  data-css-adcgpe=""
 >
   <svg
     aria-label="check icon"
@@ -6135,7 +5863,7 @@ exports[`Storyshots size medium 1`] = `
 
 exports[`Storyshots size small 1`] = `
 <div
-  data-css-4oczle=""
+  data-css-35c0uv=""
 >
   <svg
     aria-label="check icon"

--- a/packages/icon/src/react/__stories__/index.story.js
+++ b/packages/icon/src/react/__stories__/index.story.js
@@ -26,13 +26,13 @@ const GridItem = props => <div {...props} {...styles.gridItem} />
 
 const colorStory = storiesOf('appearance', module)
 Object.values(Icon.colors).forEach(color =>
-  colorStory.add(color, _ => <Icons.CheckIcon color={color} />)
+  colorStory.add(color, _ => <Icons.CheckIcon color={Icon.colors[color]} />)
 )
 
 const sizeStory = storiesOf('size', module)
 Object.values(Icon.sizes).forEach(size =>
   sizeStory.add(size, _ => (
-    <Icons.CheckIcon color={Icon.colors.white} size={size} />
+    <Icons.CheckIcon color={Icon.colors.textIconHighOnDark} size={size} />
   ))
 )
 
@@ -43,7 +43,7 @@ idStory.add('all export names', () => (
       const Comp = Icons[id]
       return (
         <GridItem key={`item-${id}`}>
-          <Comp color={Icon.colors.white} />
+          <Comp color={Icon.colors.textIconHighOnDark} />
         </GridItem>
       )
     })}
@@ -52,12 +52,17 @@ idStory.add('all export names', () => (
 Object.keys(Icons).forEach(id =>
   idStory.add(id, _ => {
     const Comp = Icons[id]
-    return <Comp color={Icon.colors.white} size={Icon.sizes.large} />
+    return (
+      <Comp color={Icon.colors.textIconHighOnDark} size={Icon.sizes.large} />
+    )
   })
 )
 
 storiesOf('custom props', module).add('aria-label', () => (
-  <Icons.CheckIcon color={Icon.colors.white} aria-label="completed" />
+  <Icons.CheckIcon
+    color={Icon.colors.textIconHighOnDark}
+    aria-label="completed"
+  />
 ))
 
 const SvgAccounticon = props => (
@@ -67,7 +72,7 @@ const SvgAccounticon = props => (
 )
 
 storiesOf('custom icon', module).add('aria-label', () => (
-  <Icon color={Icon.colors.white}>
+  <Icon color={Icon.colors.textIconHighOnDark}>
     <SvgAccounticon />
   </Icon>
 ))

--- a/packages/icon/src/vars/index.js
+++ b/packages/icon/src/vars/index.js
@@ -1,5 +1,3 @@
-import * as core from '@pluralsight/ps-design-system-core'
-
 export const sizes = {
   small: 'small',
   medium: 'medium',
@@ -12,9 +10,13 @@ export const widths = {
   large: '48px'
 }
 
-export const colors = Object.keys(core.colors)
-  .filter(c => !/gradient/.test(c))
-  .reduce((acc, c) => {
-    acc[c] = c
-    return acc
-  }, {})
+export const colors = {
+  textIconHighOnDark: 'textIconHighOnDark',
+  textIconLowOnDark: 'textIconLowOnDark',
+  textIconHighOnLight: 'textIconHighOnLight',
+  textIconLowOnLight: 'textIconLowOnLight',
+  red: 'red',
+  blue: 'blue',
+  green: 'green',
+  yellow: 'yellow'
+}

--- a/packages/site/pages/components/icon.js
+++ b/packages/site/pages/components/icon.js
@@ -2,7 +2,10 @@ import React from 'react'
 
 import * as core from '@pluralsight/ps-design-system-core'
 import Icon, {
+  colors,
   sizes,
+  widths,
+  StarIcon,
   CodeIcon,
   PathIcon
 } from '@pluralsight/ps-design-system-icon'
@@ -92,12 +95,10 @@ export default _ => (
         props={[
           PropTypes.row([
             'color',
-            <span>
-              <code>*Icon.colors</code> enum
-            </span>,
+            PropTypes.union(colors),
             null,
-            null,
-            'all flat Core colors'
+            <code>currentColor</code>,
+            'color presets'
           ]),
           PropTypes.row([
             'size',
@@ -125,9 +126,29 @@ export default _ => (
 
       <SectionHeading>Color</SectionHeading>
       <P>
+        The <Text.Code>color</Text.Code> prop makes available the following
+        colors.
+      </P>
+      <Example.React
+        includes={{ StarIcon }}
+        outputStyle={{
+          display: 'grid',
+          gap: core.layout.spacingLarge,
+          gridTemplateColumns: `repeat(auto-fill, minmax(${widths.large}, 1fr))`
+        }}
+        outputChildStyle={{ margin: 0 }}
+        codes={Object.keys(Icon.colors).map(
+          colorKey =>
+            `
+  <StarIcon color={StarIcon.colors.${StarIcon.colors[colorKey]}} size={StarIcon.sizes.large} />
+`
+        )}
+        themeToggle
+      />
+      <P>
         Icon color will usually match the surrounding text color. It can also be
-        overridden Core <TextLink href="/core/color">colors</TextLink> or any
-        fill.
+        overridden with Core <TextLink href="/core/color">colors</TextLink> or
+        any fill color.
       </P>
       <Example.React
         includes={{ PathIcon }}
@@ -138,11 +159,8 @@ export default _ => (
 </div>
 `,
           `
-<PathIcon style={{ color: 'red' }} size={CodeIcon.sizes.large} />
-`,
-          `
-<PathIcon color={PathIcon.colors.orange} size={CodeIcon.sizes.large} />
- `
+<PathIcon style={{ color: 'rebeccapurple' }} size={CodeIcon.sizes.large} />
+`
         ]}
       />
 
@@ -187,8 +205,7 @@ export default _ => (
       <P>
         Note: To override the size and color of a custom SVG, remove any{' '}
         <Text.Code>height</Text.Code>, <Text.Code>width</Text.Code>, and{' '}
-        <Text.Code>fill</Text.Code> attributes from the SVG after exporting
-        it.
+        <Text.Code>fill</Text.Code> attributes from the SVG after exporting it.
       </P>
     </Content>
   </Chrome>


### PR DESCRIPTION
Removed a bunch of colors with Brian.  Breaking change release.

    Kept only most likely icon colors:
    
    - Text Icon
    - Primary action, without semantics
    - Statuses, without semantics