### PR TITLE
refactor(datawell): apply 2020 colors

### DIFF
--- a/packages/datawell/src/css/index.js
+++ b/packages/datawell/src/css/index.js
@@ -1,37 +1,51 @@
-import * as core from '@pluralsight/ps-design-system-core'
+import {
+  colorsBorder,
+  colorsTextIcon,
+  layout,
+  type
+} from '@pluralsight/ps-design-system-core'
 import { names as themeNames } from '@pluralsight/ps-design-system-theme'
 
 export default {
   '.psds-datawell': {
-    borderLeft: `1px solid ${core.colors.gray03}`,
+    borderLeft: `1px solid ${colorsBorder.lowOnDark}`,
     minHeight: '104px',
-    padding: `0 ${core.layout.spacingMedium} ${core.layout.spacingMedium} ${core.layout.spacingLarge}`
+    padding: `0 ${layout.spacingMedium} ${layout.spacingMedium} ${layout.spacingLarge}`
   },
   [`.psds-datawell.psds-theme--${themeNames.light}`]: {
-    borderLeft: `1px solid ${core.colors.gray01}`
+    borderColor: colorsBorder.lowOnLight
   },
   '.psds-datawell__label': {
     margin: 0,
-    fontSize: core.type.fontSizeXSmall,
-    lineHeight: '16px'
+    fontSize: type.fontSizeXSmall,
+    lineHeight: '16px',
+
+    '& > div': {
+      color: colorsTextIcon.lowOnDark
+    }
+  },
+  [`.psds-datawell__label.psds-theme--${themeNames.light}`]: {
+    '& > div': {
+      color: colorsTextIcon.lowOnLight
+    }
   },
   '.psds-datawell__data': {
-    fontWeight: core.type.fontWeightMedium,
-    fontSize: core.type.fontSizeXXLarge,
-    lineHeight: core.type.lineHeightHuge,
-    color: core.colors.white,
-    marginBottom: core.layout.spacingMedium,
+    fontWeight: type.fontWeightMedium,
+    fontSize: type.fontSizeXXLarge,
+    lineHeight: type.lineHeightHuge,
+    color: colorsTextIcon.highOnDark,
+    marginBottom: layout.spacingMedium,
     wordWrap: 'break-word'
   },
   [`.psds-datawell__data.psds-theme--${themeNames.light}`]: {
-    color: core.colors.gray06
+    color: colorsTextIcon.highOnLight
   },
   '.psds-datawell__sublabel': {
-    fontSize: core.type.fontSizeXSmall,
+    fontSize: type.fontSizeXSmall,
     lineHeight: '16px',
-    color: core.colors.gray02
+    color: colorsTextIcon.lowOnDark
   },
   [`.psds-datawell__sublabel.psds-theme--${themeNames.light}`]: {
-    color: core.colors.gray03
+    color: colorsTextIcon.lowOnLight
   }
 }

--- a/packages/datawell/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/datawell/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -5,81 +5,81 @@ exports[`Storyshots DataWell fixed width in row, no spaces 1`] = `
   data-css-1s5t7h8=""
 >
   <div
-    data-css-12p1bh2=""
+    data-css-76j83k=""
   >
     <div
       data-css-1oooiac=""
-      data-css-chiflz=""
+      data-css-1pudd7j=""
       size="smallCaps"
     >
       Dog count
     </div>
     <div
-      data-css-176w4cm=""
+      data-css-1m134w8=""
     >
       234,345
     </div>
     <div
-      data-css-qnx2q6=""
+      data-css-18gefer=""
     >
       All the doggies
     </div>
   </div>
   <div
-    data-css-12p1bh2=""
+    data-css-76j83k=""
   >
     <div
       data-css-1oooiac=""
-      data-css-chiflz=""
+      data-css-1pudd7j=""
       size="smallCaps"
     >
       Cat count
     </div>
     <div
-      data-css-176w4cm=""
+      data-css-1m134w8=""
     >
       123
     </div>
     <div
-      data-css-qnx2q6=""
+      data-css-18gefer=""
     />
   </div>
   <div
-    data-css-12p1bh2=""
+    data-css-76j83k=""
   >
     <div
       data-css-1oooiac=""
-      data-css-chiflz=""
+      data-css-1pudd7j=""
       size="smallCaps"
     >
       Rafters on the River
     </div>
     <div
-      data-css-176w4cm=""
+      data-css-1m134w8=""
     >
       1,345/23,235
     </div>
     <div
-      data-css-qnx2q6=""
+      data-css-18gefer=""
     />
   </div>
   <div
-    data-css-12p1bh2=""
+    data-css-76j83k=""
   >
     <div
       data-css-1oooiac=""
-      data-css-chiflz=""
+      data-css-1pudd7j=""
       size="smallCaps"
     >
       Flotsam
     </div>
     <div
-      data-css-176w4cm=""
+      data-css-1m134w8=""
     >
       About 3
     </div>
     <div
-      data-css-qnx2q6=""
+      data-css-18gefer=""
     />
   </div>
 </div>
@@ -87,44 +87,44 @@ exports[`Storyshots DataWell fixed width in row, no spaces 1`] = `
 
 exports[`Storyshots DataWell label/data 1`] = `
 <div
-  data-css-12p1bh2=""
+  data-css-76j83k=""
 >
   <div
     data-css-1oooiac=""
-    data-css-chiflz=""
+    data-css-1pudd7j=""
     size="smallCaps"
   >
     Dog count
   </div>
   <div
-    data-css-176w4cm=""
+    data-css-1m134w8=""
   >
     123
   </div>
   <div
-    data-css-qnx2q6=""
+    data-css-18gefer=""
   />
 </div>
 `;
 
 exports[`Storyshots DataWell label/data/subLabel 1`] = `
 <div
-  data-css-12p1bh2=""
+  data-css-76j83k=""
 >
   <div
     data-css-1oooiac=""
-    data-css-chiflz=""
+    data-css-1pudd7j=""
     size="smallCaps"
   >
     Dog count
   </div>
   <div
-    data-css-176w4cm=""
+    data-css-1m134w8=""
   >
     234,345
   </div>
   <div
-    data-css-qnx2q6=""
+    data-css-18gefer=""
   >
     All the doggies
   </div>
@@ -140,81 +140,81 @@ exports[`Storyshots DataWell row 1`] = `
   }
 >
   <div
-    data-css-12p1bh2=""
+    data-css-76j83k=""
   >
     <div
       data-css-1oooiac=""
-      data-css-chiflz=""
+      data-css-1pudd7j=""
       size="smallCaps"
     >
       Dog count
     </div>
     <div
-      data-css-176w4cm=""
+      data-css-1m134w8=""
     >
       234,345
     </div>
     <div
-      data-css-qnx2q6=""
+      data-css-18gefer=""
     >
       All the doggies
     </div>
   </div>
   <div
-    data-css-12p1bh2=""
+    data-css-76j83k=""
   >
     <div
       data-css-1oooiac=""
-      data-css-chiflz=""
+      data-css-1pudd7j=""
       size="smallCaps"
     >
       Cat count
     </div>
     <div
-      data-css-176w4cm=""
+      data-css-1m134w8=""
     >
       123
     </div>
     <div
-      data-css-qnx2q6=""
+      data-css-18gefer=""
     />
   </div>
   <div
-    data-css-12p1bh2=""
+    data-css-76j83k=""
   >
     <div
       data-css-1oooiac=""
-      data-css-chiflz=""
+      data-css-1pudd7j=""
       size="smallCaps"
     >
       Rafters on the River
     </div>
     <div
-      data-css-176w4cm=""
+      data-css-1m134w8=""
     >
       12/23
     </div>
     <div
-      data-css-qnx2q6=""
+      data-css-18gefer=""
     />
   </div>
   <div
-    data-css-12p1bh2=""
+    data-css-76j83k=""
   >
     <div
       data-css-1oooiac=""
-      data-css-chiflz=""
+      data-css-1pudd7j=""
       size="smallCaps"
     >
       Flotsam
     </div>
     <div
-      data-css-176w4cm=""
+      data-css-1m134w8=""
     >
       About 3
     </div>
     <div
-      data-css-qnx2q6=""
+      data-css-18gefer=""
     >
       The icky stuff that is not cats or dogs, floating in the river
     </div>


### PR DESCRIPTION
When you pull this up, will you please see if storybook will show you a theme switcher on datawell stories?

I didn't get one and didn't visually test this on light theme.

If you have this problem, I'll consider it not just a fluke of my env, and jump back on to troubleshoot it more.