### PR TITLE
dialog: fix tail

### DIFF
--- a/packages/dialog/src/css/index.js
+++ b/packages/dialog/src/css/index.js
@@ -20,17 +20,21 @@ export default {
     background: core.colors.white,
     borderRadius: '2px',
     boxShadow: `0 1px 2px ${transparentize(0.5, core.colors.black)}`,
-    color: core.colors.gray05,
-    display: 'inline-block',
-    fontSize: core.type.fontSizeSmall,
-    fontWeight: core.type.fontWeightMedium,
-    lineHeight: core.type.lineHeightTight,
+    display: 'inline-flex',
     opacity: 0,
-    overflowY: 'auto',
-    padding: core.layout.spacingLarge,
     position: 'relative',
     transform: `translateY(${core.layout.spacingXSmall})`
   }),
+
+  '.psds-dialog__content': {
+    color: core.colors.gray05,
+    fontSize: core.type.fontSizeSmall,
+    fontWeight: core.type.fontWeightMedium,
+    lineHeight: core.type.lineHeightTight,
+    padding: core.layout.spacingLarge,
+    flex: '1 1 auto',
+    overflowY: 'auto'
+  },
 
   // --w-tail
   '.psds-dialog--w-tail': {
@@ -103,8 +107,8 @@ export default {
     lineHeight: '0',
     padding: '0',
     position: 'absolute',
-    right: core.layout.spacingXSmall,
-    top: core.layout.spacingXSmall,
+    right: core.layout.spacingMedium,
+    top: core.layout.spacingMedium,
 
     '& > svg': {
       fill: core.colors.gray03,

--- a/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -59,13 +59,15 @@ exports[`Storyshots modal default 1`] = `
         role="region"
       >
         <div
-          data-css-192xfnn=""
+          data-css-15z5i26=""
           onKeyUp={[Function]}
         >
-          <div>
+          <div
+            data-css-7e9vg6=""
+          >
             <button
               aria-label="Close dialog"
-              data-css-1gmw1mr=""
+              data-css-124fqrw=""
               onClick={[Function]}
             >
               <svg
@@ -218,13 +220,15 @@ exports[`Storyshots modal no click overlay 1`] = `
         role="region"
       >
         <div
-          data-css-192xfnn=""
+          data-css-15z5i26=""
           onKeyUp={[Function]}
         >
-          <div>
+          <div
+            data-css-7e9vg6=""
+          >
             <button
               aria-label="Close dialog"
-              data-css-1gmw1mr=""
+              data-css-124fqrw=""
               onClick={[Function]}
             >
               <svg
@@ -377,10 +381,12 @@ exports[`Storyshots modal no close button 1`] = `
         role="region"
       >
         <div
-          data-css-192xfnn=""
+          data-css-15z5i26=""
           onKeyUp={[Function]}
         >
-          <div>
+          <div
+            data-css-7e9vg6=""
+          >
             <h1
               data-css-7941k5=""
               size="large"
@@ -520,12 +526,14 @@ exports[`Storyshots modal no escape key 1`] = `
         role="region"
       >
         <div
-          data-css-192xfnn=""
+          data-css-15z5i26=""
         >
-          <div>
+          <div
+            data-css-7e9vg6=""
+          >
             <button
               aria-label="Close dialog"
-              data-css-1gmw1mr=""
+              data-css-124fqrw=""
               onClick={[Function]}
             >
               <svg
@@ -678,13 +686,15 @@ exports[`Storyshots modal no focus on mount 1`] = `
         role="region"
       >
         <div
-          data-css-192xfnn=""
+          data-css-15z5i26=""
           onKeyUp={[Function]}
         >
-          <div>
+          <div
+            data-css-7e9vg6=""
+          >
             <button
               aria-label="Close dialog"
-              data-css-1gmw1mr=""
+              data-css-124fqrw=""
               onClick={[Function]}
             >
               <svg
@@ -837,13 +847,15 @@ exports[`Storyshots modal no focusable child elements 1`] = `
         role="region"
       >
         <div
-          data-css-192xfnn=""
+          data-css-15z5i26=""
           onKeyUp={[Function]}
         >
-          <div>
+          <div
+            data-css-7e9vg6=""
+          >
             <button
               aria-label="Close dialog"
-              data-css-1gmw1mr=""
+              data-css-124fqrw=""
               onClick={[Function]}
             >
               <svg
@@ -930,13 +942,15 @@ exports[`Storyshots modal overflow-y 1`] = `
         role="region"
       >
         <div
-          data-css-192xfnn=""
+          data-css-15z5i26=""
           onKeyUp={[Function]}
         >
-          <div>
+          <div
+            data-css-7e9vg6=""
+          >
             <button
               aria-label="Close dialog"
-              data-css-1gmw1mr=""
+              data-css-124fqrw=""
               onClick={[Function]}
             >
               <svg
@@ -1357,13 +1371,15 @@ exports[`Storyshots modal overflow-y with tail 1`] = `
         role="region"
       >
         <div
-          data-css-1u1saw0=""
+          data-css-qz85yh=""
           onKeyUp={[Function]}
         >
-          <div>
+          <div
+            data-css-7e9vg6=""
+          >
             <button
               aria-label="Close dialog"
-              data-css-1gmw1mr=""
+              data-css-124fqrw=""
               onClick={[Function]}
             >
               <svg
@@ -1737,13 +1753,15 @@ exports[`Storyshots onClose with onClose 1`] = `
     }
   >
     <div
-      data-css-gnd6c=""
+      data-css-9fm7lf=""
       onKeyUp={[Function]}
     >
-      <div>
+      <div
+        data-css-7e9vg6=""
+      >
         <button
           aria-label="Close dialog"
-          data-css-1gmw1mr=""
+          data-css-124fqrw=""
           onClick={[Function]}
         >
           <svg
@@ -1847,9 +1865,11 @@ exports[`Storyshots tailPosition bottomCenter 1`] = `
     }
   >
     <div
-      data-css-wmucfn=""
+      data-css-7yrv6i=""
     >
-      <div>
+      <div
+        data-css-7e9vg6=""
+      >
         <h1
           data-css-7941k5=""
           size="large"
@@ -1940,9 +1960,11 @@ exports[`Storyshots tailPosition bottomLeft 1`] = `
     }
   >
     <div
-      data-css-kvhto4=""
+      data-css-egcwx=""
     >
-      <div>
+      <div
+        data-css-7e9vg6=""
+      >
         <h1
           data-css-7941k5=""
           size="large"
@@ -2033,9 +2055,11 @@ exports[`Storyshots tailPosition bottomRight 1`] = `
     }
   >
     <div
-      data-css-1y967xl=""
+      data-css-1dkyu1u=""
     >
-      <div>
+      <div
+        data-css-7e9vg6=""
+      >
         <h1
           data-css-7941k5=""
           size="large"
@@ -2126,9 +2150,11 @@ exports[`Storyshots tailPosition none 1`] = `
     }
   >
     <div
-      data-css-gnd6c=""
+      data-css-9fm7lf=""
     >
-      <div>
+      <div
+        data-css-7e9vg6=""
+      >
         <h1
           data-css-7941k5=""
           size="large"
@@ -2219,9 +2245,11 @@ exports[`Storyshots tailPosition topCenter 1`] = `
     }
   >
     <div
-      data-css-g3vmsd=""
+      data-css-582zur=""
     >
-      <div>
+      <div
+        data-css-7e9vg6=""
+      >
         <h1
           data-css-7941k5=""
           size="large"
@@ -2312,9 +2340,11 @@ exports[`Storyshots tailPosition topLeft 1`] = `
     }
   >
     <div
-      data-css-s54oy9=""
+      data-css-wam50j=""
     >
-      <div>
+      <div
+        data-css-7e9vg6=""
+      >
         <h1
           data-css-7941k5=""
           size="large"
@@ -2405,9 +2435,11 @@ exports[`Storyshots tailPosition topRight 1`] = `
     }
   >
     <div
-      data-css-r7qi1n=""
+      data-css-zzyd7d=""
     >
-      <div>
+      <div
+        data-css-7e9vg6=""
+      >
         <h1
           data-css-7941k5=""
           size="large"

--- a/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -1298,6 +1298,433 @@ exports[`Storyshots modal overflow-y 1`] = `
 </div>
 `;
 
+exports[`Storyshots modal overflow-y with tail 1`] = `
+<div
+  data-css-1so76ss=""
+>
+  <div
+    style={
+      Object {
+        "padding": "48px",
+      }
+    }
+  >
+    <div>
+      <p
+        data-css-145tgfu=""
+      >
+        Macaroon danish I love candy macaroon danish toffee muffin. Cotton candy chupa chups cupcake I love. Chocolate I love bonbon carrot cake cupcake cookie muffin liquorice. I love I love I love jelly-o fruitcake
+        <a
+          href="#"
+        >
+          I love chocolate cake
+        </a>
+         wafer chupa chups.
+      </p>
+      <p
+        data-css-145tgfu=""
+      >
+        Sesame snaps cake pudding I love chupa chups I love. Cotton candy biscuit oat cake dessert donut I love lemon drops. Cookie croissant dragée tootsie roll marzipan I love. Apple pie cheesecake jelly-o cheesecake I love cheesecake.
+      </p>
+      <button
+        data-css-126c1n5=""
+        disabled={false}
+        onClick={[Function]}
+        style={Object {}}
+      >
+        <span
+          data-css-15b13by=""
+        >
+          close modal
+        </span>
+      </button>
+      <p
+        data-css-145tgfu=""
+      >
+        Sweet soufflé 
+        <a
+          href="#"
+        >
+          apple pie
+        </a>
+        . Halvah icing pudding pastry ice cream gingerbread tart candy canes dragée. Pie gingerbread icing.
+      </p>
+      <div
+        aria-label="Storybook Modal"
+        data-css-19y8f6h=""
+        id="psds-dialog__overlay"
+        onClick={[Function]}
+        role="region"
+      >
+        <div
+          data-css-1u1saw0=""
+          onKeyUp={[Function]}
+        >
+          <div>
+            <button
+              aria-label="Close dialog"
+              data-css-1gmw1mr=""
+              onClick={[Function]}
+            >
+              <svg
+                aria-label="close icon"
+                role="img"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M18 7.41L16.59 6 12 10.59 7.41 6 6 7.41 10.59 12 6 16.59 7.41 18 12 13.41 16.59 18 18 16.59 13.41 12"
+                />
+              </svg>
+            </button>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+            <p
+              data-css-15w0yq1=""
+            >
+              <a
+                href="#"
+              >
+                Brownie bear claw
+              </a>
+               liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice.
+               
+              <a
+                href="#"
+              >
+                Tart donut
+              </a>
+               lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots onClose with onClose 1`] = `
 <div
   data-css-1so76ss=""

--- a/packages/dialog/src/react/__stories__/index.story.js
+++ b/packages/dialog/src/react/__stories__/index.story.js
@@ -160,3 +160,21 @@ storiesOf('modal', module)
       )}
     </ModalStory>
   ))
+  .add('overflow-y with tail', _ => (
+    <ModalStory>
+      {props => (
+        <MockDialog {...props} tailPosition={Dialog.tailPositions.topCenter}>
+          {Array.from(Array(20)).map((_, i) => (
+            <Text.P key={i}>
+              <a href="#">Brownie bear claw</a> liquorice dragée candy canes
+              pastry topping. Chocolate cake soufflé sweet roll jelly beans oat
+              cake donut. Wafer chocolate cake pastry chocolate bar fruitcake.
+              Cupcake jelly-o croissant lollipop liquorice.{' '}
+              <a href="#">Tart donut</a> lollipop dragée tootsie roll wafer
+              lemon drops cupcake chocolate bar.
+            </Text.P>
+          ))}
+        </MockDialog>
+      )}
+    </ModalStory>
+  ))

--- a/packages/dialog/src/react/index.js
+++ b/packages/dialog/src/react/index.js
@@ -27,6 +27,7 @@ const styles = {
           stylesheet[`.psds-dialog--tailPosition-${tailPosition}`]
         )
     ),
+  content: () => css(stylesheet['.psds-dialog__content']),
   close: _ => css(stylesheet['.psds-dialog__close']),
   overlay: _ => css(stylesheet['.psds-dialog__overlay'])
 }
@@ -53,7 +54,7 @@ const Dialog = React.forwardRef((props, ref) => {
       ref={ref}
     >
       <Theme name={Theme.names.light}>
-        <div>
+        <div {...styles.content()}>
           {!props.disableCloseButton && isFunction(props.onClose) && (
             <CloseButton onClick={props.onClose} />
           )}

--- a/packages/dialog/src/react/index.js
+++ b/packages/dialog/src/react/index.js
@@ -50,6 +50,7 @@ const Dialog = React.forwardRef((props, ref) => {
       {...(props.modal && { 'aria-label': undefined })}
       autofocus={autofocus}
       trapped={trapped}
+      ref={ref}
     >
       <Theme name={Theme.names.light}>
         <div>

--- a/packages/site/pages/components/dialog.js
+++ b/packages/site/pages/components/dialog.js
@@ -1,9 +1,11 @@
 import * as core from '@pluralsight/ps-design-system-core'
 import Button from '@pluralsight/ps-design-system-button'
 import Dialog from '@pluralsight/ps-design-system-dialog'
+import { Below } from '@pluralsight/ps-design-system-position'
 import * as Text from '@pluralsight/ps-design-system-text'
 import { transparentize } from '@pluralsight/ps-design-system-util'
 import React from 'react'
+import Theme from '@pluralsight/ps-design-system-theme'
 
 import {
   Chrome,
@@ -18,6 +20,127 @@ import {
   PropTypes,
   SectionHeading
 } from '../../src/ui/index.js'
+
+function InAppExample() {
+  const [isHovered, setHovered] = React.useState(false)
+  const [isClicked, setClicked] = React.useState(false)
+  console.log({ isHovered })
+  return (
+    <div>
+      <div className="examples">
+        <Theme name={Theme.names.dark}>
+          <div className="example">
+            <Below
+              show={
+                <Dialog
+                  style={{ outline: '2px solid blue' }}
+                  tailPosition={Dialog.tailPositions.topCenter}
+                >
+                  Dialog
+                </Dialog>
+              }
+              when
+            >
+              <Button
+                appearance={Button.appearances.secondary}
+                className="text"
+              >
+                Look at me
+              </Button>
+            </Below>
+          </div>
+
+          <div className="example">
+            <Below
+              show={
+                <Dialog tailPosition={Dialog.tailPositions.topCenter}>
+                  Dialog
+                </Dialog>
+              }
+              when={isHovered}
+            >
+              <Button
+                appearance={Button.appearances.secondary}
+                className="text"
+                onMouseEnter={_ => setHovered(true)}
+                onMouseOut={_ => setHovered(false)}
+              >
+                Hover me
+              </Button>
+            </Below>
+          </div>
+
+          <div className="example">
+            <Below
+              show={
+                <Dialog tailPosition={Dialog.tailPositions.topCenter}>
+                  Dialog
+                </Dialog>
+              }
+              when={isClicked}
+            >
+              <Button
+                appearance={Button.appearances.secondary}
+                className="text"
+                onClick={_ => setClicked(!isClicked)}
+              >
+                Click me
+              </Button>
+            </Below>
+          </div>
+        </Theme>
+      </div>
+      <Code
+        collapsible
+        lang="javascript"
+      >{`import Button from '@pluralsight/ps-design-system-button'
+import { Below } from '@pluralsight/ps-design-system-position'
+import Dialog from '@pluralsight/ps-design-system-dialog'
+
+function HoverExampleOnly() {
+  const [isHovered, setHovered] = React.useState(false)
+  return (
+    <Below
+      show={
+        <Dialog tailPosition={Dialog.tailPositions.topCenter}>
+          Dialog
+        </Dialog>
+      }
+      when={isHovered}
+    >
+      <Button
+        appearance={Button.appearances.secondary}
+        onMouseEnter={_ => setHovered(true)}
+        onMouseOut={_ => setHovered(false)}
+      >
+        Hover me
+      </Button>
+    </Below>
+  )
+}`}</Code>
+
+      <style jsx>{`
+        .examples {
+          display: flex;
+          padding: ${core.layout.spacingLarge};
+          padding-bottom: 188px;
+          color: ${core.colors.gray02};
+          font-weight: ${core.type.fontWeightMedium};
+          background: ${core.colors.gray06};
+        }
+        .example {
+          margin-right: calc(${core.layout.spacingLarge} * 2);
+        }
+        .text {
+          display: inline-block;
+        }
+        .example:last-child {
+          margin-right: 0;
+        }
+      `}</style>
+    </div>
+  )
+}
 
 const ContentGridVisual = _ => (
   <div className="grid">
@@ -133,7 +256,7 @@ export default _ => (
         appear contextually or as a <Link href="#modal">modal</Link>. The Dialog
         adapts to various amounts and types of content. For contextual,
         non-actionable messaging, consider the{' '}
-        <Link href="/components/tooltip">Tooltip</Link> instead.
+        <Link href="/components/tooltip">Dialog</Link> instead.
       </Intro>
 
       <P>Install the component dependency:</P>
@@ -215,6 +338,13 @@ export default _ => (
           ])
         ]}
       />
+
+      <SectionHeading>In-app example</SectionHeading>
+      <P>
+        Dialogs can appear automatically, or be triggered by hover, focus, tap
+        or click.
+      </P>
+      <InAppExample />
 
       <SectionHeading>Tail</SectionHeading>
       <P>

--- a/packages/site/pages/components/dialog.js
+++ b/packages/site/pages/components/dialog.js
@@ -256,7 +256,7 @@ export default _ => (
         appear contextually or as a <Link href="#modal">modal</Link>. The Dialog
         adapts to various amounts and types of content. For contextual,
         non-actionable messaging, consider the{' '}
-        <Link href="/components/tooltip">Dialog</Link> instead.
+        <Link href="/components/tooltip">Tooltip</Link> instead.
       </Intro>
 
       <P>Install the component dependency:</P>


### PR DESCRIPTION
- add site doc for showing dialog in context
- fix doc link
- fix dialog to show tail (was regression from overflow support a while back).  Solution is to have an inner div to handle scrolling.  This solution now doesn't automatically move the close button the left when a scrollbar is present.  For this reason, I increased the close button margin generally.  I want to double check this, design-wise, with @sweeting .  There may be better alternatives.