### PR TITLE
badge: Simplify the css selector utility naming

### DIFF
--- a/packages/badge/src/css/index.js
+++ b/packages/badge/src/css/index.js
@@ -11,8 +11,8 @@ import {
 } from '@pluralsight/ps-design-system-core'
 import { names as themeNames } from '@pluralsight/ps-design-system-theme'
 
-import { defaultWithColor, subtleThemeWithColor } from '../js/index.js'
-import { colors } from '../vars/index.js'
+import { appearances, colors } from '../vars/index.js'
+import { select } from '../js/index.js'
 
 export default {
   '.psds-badge': {
@@ -26,104 +26,101 @@ export default {
     textTransform: 'uppercase'
   },
 
-  [defaultWithColor(themeNames.dark, colors.gray)]: {
+  [select(themeNames.dark, appearances.default, colors.gray)]: {
     color: colorsTextIcon.highOnDark,
     backgroundColor: colorsBackgroundUtility[25],
     borderColor: colorsBackgroundUtility[25]
   },
-  [defaultWithColor(themeNames.dark, colors.green)]: {
+  [select(themeNames.dark, appearances.default, colors.green)]: {
     color: colorsTextIcon.highOnDark,
     backgroundColor: colorsGreen.base,
     borderColor: colorsGreen.base
   },
-  [defaultWithColor(themeNames.dark, colors.yellow)]: {
+  [select(themeNames.dark, appearances.default, colors.yellow)]: {
     color: '#181818',
     backgroundColor: colorsYellow.base,
     borderColor: colorsYellow.base
   },
-  [defaultWithColor(themeNames.dark, colors.red)]: {
+  [select(themeNames.dark, appearances.default, colors.red)]: {
     color: colorsTextIcon.highOnDark,
     backgroundColor: colorsRed.base,
     borderColor: colorsRed.base
   },
-  [defaultWithColor(themeNames.dark, colors.blue)]: {
+  [select(themeNames.dark, appearances.default, colors.blue)]: {
     color: colorsTextIcon.highOnDark,
     backgroundColor: colorsBlue.base,
     borderColor: colorsBlue.base
   },
 
-  [defaultWithColor(themeNames.light, colors.gray)]: {
+  [select(themeNames.light, appearances.default, colors.gray)]: {
     color: colorsTextIcon.highOnLight,
     backgroundColor: colorsBackgroundUtility[25],
     borderColor: colorsBackgroundUtility[25]
   },
-  [defaultWithColor(themeNames.light, colors.green)]: {
+  [select(themeNames.light, appearances.default, colors.green)]: {
     color: colorsTextIcon.highOnDark,
     backgroundColor: colorsGreen.base,
     borderColor: colorsGreen.base
   },
-  [defaultWithColor(themeNames.light, colors.yellow)]: {
+  [select(themeNames.light, appearances.default, colors.yellow)]: {
     color: '#181818',
     backgroundColor: colorsYellow.base,
     borderColor: colorsYellow.base
   },
-  [defaultWithColor(themeNames.light, colors.red)]: {
+  [select(themeNames.light, appearances.default, colors.red)]: {
     color: colorsTextIcon.highOnDark,
     backgroundColor: colorsRed.base,
     borderColor: colorsRed.base
   },
-  [defaultWithColor(themeNames.light, colors.blue)]: {
+  [select(themeNames.light, appearances.default, colors.blue)]: {
     color: colorsTextIcon.highOnDark,
     backgroundColor: colorsBlue.base,
     borderColor: colorsBlue.base
   },
 
-  [subtleThemeWithColor(themeNames.dark, colors.gray)]: {
+  [select(themeNames.dark, appearances.subtle, colors.gray)]: {
     color: colorsTextIcon.lowOnDark,
     borderColor: colorsBorder.highOnDark
   },
-
-  [subtleThemeWithColor(themeNames.dark, colors.green)]: {
+  [select(themeNames.dark, appearances.subtle, colors.green)]: {
     color: colorsGreen.base,
     borderColor: colorsGreen.base
   },
-
-  [subtleThemeWithColor(themeNames.dark, colors.yellow)]: {
+  [select(themeNames.dark, appearances.subtle, colors.yellow)]: {
     color: colorsYellow.base,
     borderColor: colorsYellow.base
   },
-
-  [subtleThemeWithColor(themeNames.dark, colors.red)]: {
+  [select(themeNames.dark, appearances.subtle, colors.red)]: {
     color: colorsRed.base,
     borderColor: colorsRed.base
   },
 
-  [subtleThemeWithColor(themeNames.dark, colors.blue)]: {
+  [select(themeNames.dark, appearances.subtle, colors.blue)]: {
     color: colorsBlue.base,
     borderColor: colorsBlue.base
   },
 
-  [subtleThemeWithColor(themeNames.light, colors.gray)]: {
+  [select(themeNames.light, appearances.subtle, colors.gray)]: {
     color: colorsTextIcon.highOnLight,
     backgroundColor: colorsBackgroundUtility[25],
     borderColor: colorsBackgroundUtility[25]
   },
-  [subtleThemeWithColor(themeNames.light, colors.green)]: {
+  [select(themeNames.light, appearances.subtle, colors.green)]: {
     color: colorsTextIcon.highOnLight,
     backgroundColor: colorsGreen[1],
     borderColor: colorsGreen[1]
   },
-  [subtleThemeWithColor(themeNames.light, colors.yellow)]: {
+  [select(themeNames.light, appearances.subtle, colors.yellow)]: {
     color: colorsTextIcon.highOnLight,
     backgroundColor: colorsYellow[1],
     borderColor: colorsYellow[1]
   },
-  [subtleThemeWithColor(themeNames.light, colors.red)]: {
+  [select(themeNames.light, appearances.subtle, colors.red)]: {
     color: colorsTextIcon.highOnLight,
     backgroundColor: colorsRed[1],
     borderColor: colorsRed[1]
   },
-  [subtleThemeWithColor(themeNames.light, colors.blue)]: {
+  [select(themeNames.light, appearances.subtle, colors.blue)]: {
     color: colorsTextIcon.highOnLight,
     backgroundColor: colorsBlue[3],
     borderColor: colorsBlue[3]

--- a/packages/badge/src/js/index.js
+++ b/packages/badge/src/js/index.js
@@ -1,21 +1,10 @@
-import { appearances } from '../vars/index.js'
-
-export function defaultWithColor(themeName, c) {
-  return appearance(appearances.default) + theme(themeName) + color(c)
-}
-
-export function subtleThemeWithColor(themeName, c) {
-  return appearance(appearances.subtle) + theme(themeName) + color(c)
-}
-
-function appearance(a) {
-  return `.psds-badge--appearance-${a}`
-}
-
-function color(c) {
-  return `.psds-badge--color-${c}`
-}
-
-function theme(t) {
-  return `.psds-theme--${t}`
+export function select(themeName, appearance, color) {
+  return (
+    '.psds-badge--apearance-' +
+    appearance +
+    '.psds-badge--color-' +
+    color +
+    '.psds-theme--' +
+    themeName
+  )
 }

--- a/packages/badge/src/react/index.js
+++ b/packages/badge/src/react/index.js
@@ -6,16 +6,14 @@ import filterReactProps from '@pluralsight/ps-design-system-filter-react-props'
 import { useTheme } from '@pluralsight/ps-design-system-theme'
 
 import stylesheet from '../css/index.js'
-import { defaultWithColor, subtleThemeWithColor } from '../js/index.js'
+import { select } from '../js/index.js'
 import * as vars from '../vars/index.js'
 
 const styles = {
   badge: props =>
     css(
       stylesheet['.psds-badge'],
-      props.appearance === appearances.default
-        ? stylesheet[defaultWithColor(props.themeName, props.color)]
-        : stylesheet[subtleThemeWithColor(props.themeName, props.color)]
+      stylesheet[select(props.themeName, props.appearance, props.color)]
     )
 }
 


### PR DESCRIPTION
An attempt to make it more readable.  See last commit only.  Merge after #829.