### PR TITLE
fix(core): remove 2020 from color css var names

### DIFF
--- a/packages/core/css/colors-2020.module.css
+++ b/packages/core/css/colors-2020.module.css
@@ -1,157 +1,156 @@
 :root {
-  /* 2020 palette - temporarily separate */
-  --psColors2020BlueBase: #0084bd;
-  --psColors2020Blue1: #d9f1ff;
-  --psColors2020Blue2: #b9e4fd;
-  --psColors2020Blue3: #8ed1f6;
-  --psColors2020Blue4: #58b9eb;
-  --psColors2020Blue5: #2ea0d6;
-  --psColors2020Blue6: #0084bd;
-  --psColors2020Blue7: #0074ab;
-  --psColors2020Blue8: #006395;
-  --psColors2020Blue9: #005685;
-  --psColors2020Blue10: #00446b;
+  --psColorsBlueBase: #0084bd;
+  --psColorsBlue1: #d9f1ff;
+  --psColorsBlue2: #b9e4fd;
+  --psColorsBlue3: #8ed1f6;
+  --psColorsBlue4: #58b9eb;
+  --psColorsBlue5: #2ea0d6;
+  --psColorsBlue6: #0084bd;
+  --psColorsBlue7: #0074ab;
+  --psColorsBlue8: #006395;
+  --psColorsBlue9: #005685;
+  --psColorsBlue10: #00446b;
 
-  --psColors2020TealBase: #00baa5;
-  --psColors2020Teal1: #d5faf5;
-  --psColors2020Teal2: #affaef;
-  --psColors2020Teal3: #84f0e1;
-  --psColors2020Teal4: #5ce6d4;
-  --psColors2020Teal5: #2fd1be;
-  --psColors2020Teal6: #00baa5;
-  --psColors2020Teal7: #00a894;
-  --psColors2020Teal8: #009380;
-  --psColors2020Teal9: #007a6a;
-  --psColors2020Teal10: #006658;
+  --psColorsTealBase: #00baa5;
+  --psColorsTeal1: #d5faf5;
+  --psColorsTeal2: #affaef;
+  --psColorsTeal3: #84f0e1;
+  --psColorsTeal4: #5ce6d4;
+  --psColorsTeal5: #2fd1be;
+  --psColorsTeal6: #00baa5;
+  --psColorsTeal7: #00a894;
+  --psColorsTeal8: #009380;
+  --psColorsTeal9: #007a6a;
+  --psColorsTeal10: #006658;
 
-  --psColors2020GreenBase: #009e52;
-  --psColors2020Green1: #d9fae5;
-  --psColors2020Green2: #adf0c8;
-  --psColors2020Green3: #82e2ab;
-  --psColors2020Green4: #57d08e;
-  --psColors2020Green5: #2bb970;
-  --psColors2020Green6: #009e52;
-  --psColors2020Green7: #008f46;
-  --psColors2020Green8: #007c3a;
-  --psColors2020Green9: #00672e;
-  --psColors2020Green10: #005724;
+  --psColorsGreenBase: #009e52;
+  --psColorsGreen1: #d9fae5;
+  --psColorsGreen2: #adf0c8;
+  --psColorsGreen3: #82e2ab;
+  --psColorsGreen4: #57d08e;
+  --psColorsGreen5: #2bb970;
+  --psColorsGreen6: #009e52;
+  --psColorsGreen7: #008f46;
+  --psColorsGreen8: #007c3a;
+  --psColorsGreen9: #00672e;
+  --psColorsGreen10: #005724;
 
-  --psColors2020LimeBase: #8cca08;
-  --psColors2020Lime1: #ecffc7;
-  --psColors2020Lime2: #deffa3;
-  --psColors2020Lime3: #ccfc7a;
-  --psColors2020Lime4: #b8f052;
-  --psColors2020Lime5: #a3e029;
-  --psColors2020Lime6: #8cca08;
-  --psColors2020Lime7: #7bb600;
-  --psColors2020Lime8: #6ba300;
-  --psColors2020Lime9: #588a00;
-  --psColors2020Lime10: #4c7700;
+  --psColorsLimeBase: #8cca08;
+  --psColorsLime1: #ecffc7;
+  --psColorsLime2: #deffa3;
+  --psColorsLime3: #ccfc7a;
+  --psColorsLime4: #b8f052;
+  --psColorsLime5: #a3e029;
+  --psColorsLime6: #8cca08;
+  --psColorsLime7: #7bb600;
+  --psColorsLime8: #6ba300;
+  --psColorsLime9: #588a00;
+  --psColorsLime10: #4c7700;
 
-  --psColors2020YellowBase: #fad000;
-  --psColors2020Yellow1: #fffbcc;
-  --psColors2020Yellow2: #fff7a8;
-  --psColors2020Yellow3: #fff380;
-  --psColors2020Yellow4: #ffeb57;
-  --psColors2020Yellow5: #ffdf29;
-  --psColors2020Yellow6: #fad000;
-  --psColors2020Yellow7: #e2b500;
-  --psColors2020Yellow8: #cc9e00;
-  --psColors2020Yellow9: #b28300;
-  --psColors2020Yellow10: #946500;
+  --psColorsYellowBase: #fad000;
+  --psColorsYellow1: #fffbcc;
+  --psColorsYellow2: #fff7a8;
+  --psColorsYellow3: #fff380;
+  --psColorsYellow4: #ffeb57;
+  --psColorsYellow5: #ffdf29;
+  --psColorsYellow6: #fad000;
+  --psColorsYellow7: #e2b500;
+  --psColorsYellow8: #cc9e00;
+  --psColorsYellow9: #b28300;
+  --psColorsYellow10: #946500;
 
-  --psColors2020OrangeBase: #f59127;
-  --psColors2020Orange1: #ffecd1;
-  --psColors2020Orange2: #ffdcad;
-  --psColors2020Orange3: #ffcd8a;
-  --psColors2020Orange4: #ffba61;
-  --psColors2020Orange5: #ffa43e;
-  --psColors2020Orange6: #f59127;
-  --psColors2020Orange7: #e27a18;
-  --psColors2020Orange8: #cb670b;
-  --psColors2020Orange9: #b85500;
-  --psColors2020Orange10: #9e4100;
+  --psColorsOrangeBase: #f59127;
+  --psColorsOrange1: #ffecd1;
+  --psColorsOrange2: #ffdcad;
+  --psColorsOrange3: #ffcd8a;
+  --psColorsOrange4: #ffba61;
+  --psColorsOrange5: #ffa43e;
+  --psColorsOrange6: #f59127;
+  --psColorsOrange7: #e27a18;
+  --psColorsOrange8: #cb670b;
+  --psColorsOrange9: #b85500;
+  --psColorsOrange10: #9e4100;
 
-  --psColors2020RedBase: #d21c09;
-  --psColors2020Red1: #ffd6d6;
-  --psColors2020Red2: #ffb3b3;
-  --psColors2020Red3: #ff8a8a;
-  --psColors2020Red4: #f86968;
-  --psColors2020Red5: #e94a3f;
-  --psColors2020Red6: #d21c09;
-  --psColors2020Red7: #c00f00;
-  --psColors2020Red8: #ab0600;
-  --psColors2020Red9: #920000;
-  --psColors2020Red10: #750000;
+  --psColorsRedBase: #d21c09;
+  --psColorsRed1: #ffd6d6;
+  --psColorsRed2: #ffb3b3;
+  --psColorsRed3: #ff8a8a;
+  --psColorsRed4: #f86968;
+  --psColorsRed5: #e94a3f;
+  --psColorsRed6: #d21c09;
+  --psColorsRed7: #c00f00;
+  --psColorsRed8: #ab0600;
+  --psColorsRed9: #920000;
+  --psColorsRed10: #750000;
 
-  --psColors2020PinkBase: #e7558b;
-  --psColors2020Pink1: #ffddeb;
-  --psColors2020Pink2: #ffc2db;
-  --psColors2020Pink3: #ffa3c8;
-  --psColors2020Pink4: #ff8ab5;
-  --psColors2020Pink5: #f66fa1;
-  --psColors2020Pink6: #e7558b;
-  --psColors2020Pink7: #d1487b;
-  --psColors2020Pink8: #c13368;
-  --psColors2020Pink9: #a22554;
-  --psColors2020Pink10: #8a1a45;
+  --psColorsPinkBase: #e7558b;
+  --psColorsPink1: #ffddeb;
+  --psColorsPink2: #ffc2db;
+  --psColorsPink3: #ffa3c8;
+  --psColorsPink4: #ff8ab5;
+  --psColorsPink5: #f66fa1;
+  --psColorsPink6: #e7558b;
+  --psColorsPink7: #d1487b;
+  --psColorsPink8: #c13368;
+  --psColorsPink9: #a22554;
+  --psColorsPink10: #8a1a45;
 
-  --psColors2020PurpleBase: #8359df;
-  --psColors2020Purple1: #e9deff;
-  --psColors2020Purple2: #d6c2ff;
-  --psColors2020Purple3: #c0a3ff;
-  --psColors2020Purple4: #a883f8;
-  --psColors2020Purple5: #956ced;
-  --psColors2020Purple6: #8359df;
-  --psColors2020Purple7: #7048c6;
-  --psColors2020Purple8: #5934ac;
-  --psColors2020Purple9: #482592;
-  --psColors2020Purple10: #351973;
+  --psColorsPurpleBase: #8359df;
+  --psColorsPurple1: #e9deff;
+  --psColorsPurple2: #d6c2ff;
+  --psColorsPurple3: #c0a3ff;
+  --psColorsPurple4: #a883f8;
+  --psColorsPurple5: #956ced;
+  --psColorsPurple6: #8359df;
+  --psColorsPurple7: #7048c6;
+  --psColorsPurple8: #5934ac;
+  --psColorsPurple9: #482592;
+  --psColorsPurple10: #351973;
 
-  --psColors2020TextIconHighOnDark: rgba(255, 255, 255, 0.95);
-  --psColors2020TextIconHighOnLight: rgba(0, 0, 0, 0.95);
-  --psColors2020TextIconLowOnDark: rgba(255, 255, 255, 0.65);
-  --psColors2020TextIconLowOnLight: rgba(0, 0, 0, 0.55);
+  --psColorsTextIconHighOnDark: rgba(255, 255, 255, 0.95);
+  --psColorsTextIconHighOnLight: rgba(0, 0, 0, 0.95);
+  --psColorsTextIconLowOnDark: rgba(255, 255, 255, 0.65);
+  --psColorsTextIconLowOnLight: rgba(0, 0, 0, 0.55);
 
-  --psColors2020BorderHighOnDark: rgba(255, 255, 255, 0.3);
-  --psColors2020BorderHighOnLight: rgba(0, 0, 0, 0.3);
-  --psColors2020BorderLowOnDark: rgba(255, 255, 255, 0.15);
-  --psColors2020BorderLowOnLight: rgba(0, 0, 0, 0.15);
+  --psColorsBorderHighOnDark: rgba(255, 255, 255, 0.3);
+  --psColorsBorderHighOnLight: rgba(0, 0, 0, 0.3);
+  --psColorsBorderLowOnDark: rgba(255, 255, 255, 0.15);
+  --psColorsBorderLowOnLight: rgba(0, 0, 0, 0.15);
 
-  --psColors2020BackgroundDark1: #0f0f0f;
-  --psColors2020BackgroundDark2: #1b1b1b;
-  --psColors2020BackgroundDark3: #232323;
+  --psColorsBackgroundDark1: #0f0f0f;
+  --psColorsBackgroundDark2: #1b1b1b;
+  --psColorsBackgroundDark3: #232323;
 
-  --psColors2020BackgroundLight1: #f2f2f2;
-  --psColors2020BackgroundLight2: #f8f8f8;
-  --psColors2020BackgroundLight3: #ffffff;
+  --psColorsBackgroundLight1: #f2f2f2;
+  --psColorsBackgroundLight2: #f8f8f8;
+  --psColorsBackgroundLight3: #ffffff;
 
-  --psColors2020BackgroundUtilityBase: #b0b0b0;
-  --psColors2020BackgroundUtility25: rgba(176, 176, 176, 0.25);
-  --psColors2020BackgroundUtility30: rgba(176, 176, 176, 0.3);
-  --psColors2020BackgroundUtility30: rgba(176, 176, 176, 0.4);
+  --psColorsBackgroundUtilityBase: #b0b0b0;
+  --psColorsBackgroundUtility25: rgba(176, 176, 176, 0.25);
+  --psColorsBackgroundUtility30: rgba(176, 176, 176, 0.3);
+  --psColorsBackgroundUtility30: rgba(176, 176, 176, 0.4);
 
-  --psColors2020GradientSkillsBackground: linear-gradient(
+  --psColorsGradientSkillsBackground: linear-gradient(
     90deg,
     #e80a89 0%,
     #f15b2a 100%
   );
-  --psColors2020GradientSkillsStop0: #e80a89;
-  --psColors2020GradientSkillsStop100: #f15b2a;
-  --psColors2020GradientFlowBackground: linear-gradient(
+  --psColorsGradientSkillsStop0: #e80a89;
+  --psColorsGradientSkillsStop100: #f15b2a;
+  --psColorsGradientFlowBackground: linear-gradient(
     90deg,
     #2968b2 0%,
     #27aae1 100%
   );
-  --psColors2020GradientFlowStop0: #2968b2;
-  --psColors2020GradientFlowStop100: #27aae1;
+  --psColorsGradientFlowStop0: #2968b2;
+  --psColorsGradientFlowStop100: #27aae1;
 
-  --psColors2020PrimaryActionBackground: #0084bd;
-  --psColors2020PrimaryActionTextDarkTheme: #2ea0d6;
-  --psColors2020PrimaryActionTextLightTheme: #0074ab;
+  --psColorsPrimaryActionBackground: #0084bd;
+  --psColorsPrimaryActionTextDarkTheme: #2ea0d6;
+  --psColorsPrimaryActionTextLightTheme: #0074ab;
 
-  --psColors2020StatusError: var(--psColors2020RedBase);
-  --psColors2020StatusInfo: var(--psColors2020BlueBase);
-  --psColors2020StatusSuccess: var(--psColors2020GreenBase);
-  --psColors2020StatusWarning: var(--psColors2020YellowBase);
+  --psColorsStatusError: var(--psColorsRedBase);
+  --psColorsStatusInfo: var(--psColorsBlueBase);
+  --psColorsStatusSuccess: var(--psColorsGreenBase);
+  --psColorsStatusWarning: var(--psColorsYellowBase);
 }

--- a/packages/core/css/colors.module.css
+++ b/packages/core/css/colors.module.css
@@ -1,7 +1,17 @@
 :root {
-  /* ui colors */
   --psColorsWhite: #ffffff;
   --psColorsBone: #f2f2f2;
+
+  --psColorsCodeRed: #f26d6d;
+  --psColorsCodeOrange: #ff9466;
+  --psColorsCodeYellow: #ffca80;
+  --psColorsCodeGreen: #b8cc7a;
+  --psColorsCodeTurquoise: #abd9c6;
+  --psColorsCodeBlue: #8ac7e6;
+  --psColorsCodePurple: #e695bd;
+  --psColorsCodeSand: #d99077;
+
+  /* deprecated */
   --psColorsGray01: #cccccc;
   --psColorsGray02: #aaaaaa;
   --psColorsGray03: #555555;
@@ -19,16 +29,6 @@
   --psColorsGreen: #23aa5a;
   --psColorsBlue: #137bc2;
 
-  /* gradients */
   --psColorsGradientHorz: linear-gradient(to right, #f05a28, #e80a89);
   --psColorsGradientVert: linear-gradient(to bottom, #f05a28, #e80a89);
-
-  --psColorsCodeRed: #f26d6d;
-  --psColorsCodeOrange: #ff9466;
-  --psColorsCodeYellow: #ffca80;
-  --psColorsCodeGreen: #b8cc7a;
-  --psColorsCodeTurquoise: #abd9c6;
-  --psColorsCodeBlue: #8ac7e6;
-  --psColorsCodePurple: #e695bd;
-  --psColorsCodeSand: #d99077;
 }


### PR DESCRIPTION
Fix to address Kristie's discovery
https://pluralsight.slack.com/archives/C70HPSJPP/p1580402336051300

Should match docs var names.