### PR TITLE
ci: integrate commitizen with commitlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     "pattern library"
   ],
   "main": "packages/site/index.js",
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/@commitlint/prompt"
+    }
+  },
   "scripts": {
     "bootstrap": "lerna bootstrap --hoist && link-parent-bin",
     "clean": "lerna clean",
@@ -73,6 +78,7 @@
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-angular": "^8.2.0",
     "@commitlint/config-lerna-scopes": "^8.2.0",
+    "@commitlint/prompt": "^8.3.5",
     "@octopusdeploy/gulp-octo": "0.0.12",
     "@storybook/addon-actions": "^5.2.5",
     "@storybook/addon-links": "^5.2.5",


### PR DESCRIPTION
use the commitlint config as the template for commitzen. try it and tell me what you think - it's different..not sure i like it

why: 
- `chore` isn't a valid scope even though commitizen tells you it is
- tab completion for package names