### PR TITLE
fix(core): export valid sass variables

### DIFF
--- a/packages/core/css/colors-2020.module.css
+++ b/packages/core/css/colors-2020.module.css
@@ -149,8 +149,8 @@
   --psColorsPrimaryActionTextDarkTheme: #2ea0d6;
   --psColorsPrimaryActionTextLightTheme: #0074ab;
 
-  --psColorsStatusError: var(--psColorsRedBase);
-  --psColorsStatusInfo: var(--psColorsBlueBase);
-  --psColorsStatusSuccess: var(--psColorsGreenBase);
-  --psColorsStatusWarning: var(--psColorsYellowBase);
+  --psColorsStatusError: #d21c09;
+  --psColorsStatusInfo: #0084bd;
+  --psColorsStatusSuccess: #009e52;
+  --psColorsStatusWarning: #fad000;
 }


### PR DESCRIPTION
inline css vars because our build pipeline can't handle them when outputting sass files

fixes: #869

NOTE: i tried to update the build(postcss) so that i inlined css variables but couldn't figure it out....so i just did it in the src