### PR TITLE
Refactor/form controls

### DIFF
--- a/packages/checkbox/src/css/index.js
+++ b/packages/checkbox/src/css/index.js
@@ -124,7 +124,7 @@ export default {
     color: colorsTextIcon.highOnDark,
     fontSize: type.fontSizeSmall,
     lineHeight: type.lineHeightStandard,
-    fontWeight: type.fontWeightMedium
+    fontWeight: type.fontWeightBook
   },
   [`.psds-checkbox__label.psds-theme--${themeNames.light}`]: {
     color: colorsTextIcon.highOnLight

--- a/packages/checkbox/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/checkbox/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -53,7 +53,7 @@ exports[`Storyshots Checkbox checked & indeterminate 1`] = `
         value="red"
       />
       <div
-        data-css-185gc3y=""
+        data-css-ybwuvp=""
       >
         Red
       </div>
@@ -112,7 +112,7 @@ exports[`Storyshots Checkbox checked 1`] = `
         value="red"
       />
       <div
-        data-css-185gc3y=""
+        data-css-ybwuvp=""
       >
         Red
       </div>
@@ -158,7 +158,7 @@ exports[`Storyshots Checkbox default 1`] = `
         value="red"
       />
       <div
-        data-css-185gc3y=""
+        data-css-ybwuvp=""
       >
         Red
       </div>
@@ -204,7 +204,7 @@ exports[`Storyshots Checkbox disabled & errored 1`] = `
         value="red"
       />
       <div
-        data-css-185gc3y=""
+        data-css-ybwuvp=""
       >
         Red
       </div>
@@ -250,7 +250,7 @@ exports[`Storyshots Checkbox disabled 1`] = `
         value="red"
       />
       <div
-        data-css-185gc3y=""
+        data-css-ybwuvp=""
       >
         Red
       </div>
@@ -310,7 +310,7 @@ exports[`Storyshots Checkbox error 1`] = `
           value="red"
         />
         <div
-          data-css-185gc3y=""
+          data-css-ybwuvp=""
         >
           Red
         </div>
@@ -341,7 +341,7 @@ exports[`Storyshots Checkbox error 1`] = `
           value="red"
         />
         <div
-          data-css-185gc3y=""
+          data-css-ybwuvp=""
         >
           Red
         </div>
@@ -404,7 +404,7 @@ exports[`Storyshots Checkbox indeterminate 1`] = `
         value="red"
       />
       <div
-        data-css-185gc3y=""
+        data-css-ybwuvp=""
       >
         Red
       </div>
@@ -462,7 +462,7 @@ exports[`Storyshots Checkbox state demo 1`] = `
           value="red"
         />
         <div
-          data-css-185gc3y=""
+          data-css-ybwuvp=""
         >
           Red
         </div>
@@ -493,7 +493,7 @@ exports[`Storyshots Checkbox state demo 1`] = `
           value="green"
         />
         <div
-          data-css-185gc3y=""
+          data-css-ybwuvp=""
         >
           Green
         </div>
@@ -524,7 +524,7 @@ exports[`Storyshots Checkbox state demo 1`] = `
           value="blue"
         />
         <div
-          data-css-185gc3y=""
+          data-css-ybwuvp=""
         >
           Blue
         </div>

--- a/packages/datepicker/src/css/index.js
+++ b/packages/datepicker/src/css/index.js
@@ -102,10 +102,9 @@ export default {
   // __label
   '.psds-date-picker__label': {
     color: colorsTextIcon.highOnDark,
-    fontSize: type.fontSizeSmall,
-    lineHeight: '16px',
+    fontSize: type.fontSizeXSmall,
     fontWeight: type.fontWeightMedium,
-    paddingBottom: layout.spacingXSmall
+    marginBottom: layout.spacingXXSmall
   },
   [`.psds-date-picker__label.psds-theme--${themeNames.light}`]: {
     color: colorsTextIcon.highOnLight
@@ -115,9 +114,8 @@ export default {
   '.psds-date-picker__sub-label': {
     color: colorsTextIcon.lowOnDark,
     fontSize: type.fontSizeXSmall,
-    lineHeight: '16px',
-    fontWeight: type.fontWeightMedium,
-    paddingTop: layout.spacingXSmall
+    fontWeight: type.fontWeightBook,
+    marginTop: layout.spacingXXSmall
   },
   [`.psds-date-picker__sub-label.psds-theme--${themeNames.light}`]: {
     color: colorsTextIcon.lowOnLight

--- a/packages/datepicker/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/datepicker/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -116,7 +116,7 @@ exports[`Storyshots appearance default w/ error 1`] = `
       onKeyDown={[Function]}
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Problem field
       </div>
@@ -348,7 +348,7 @@ exports[`Storyshots appearance subtle w/ error 1`] = `
       onKeyDown={[Function]}
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Problem field
       </div>
@@ -477,7 +477,7 @@ exports[`Storyshots disabled compare 1`] = `
         onKeyDown={[Function]}
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Normal
         </div>
@@ -570,7 +570,7 @@ exports[`Storyshots disabled compare 1`] = `
           </div>
         </div>
         <div
-          data-css-bf7jp3=""
+          data-css-6ga4kh=""
         >
           Still normal
         </div>
@@ -580,7 +580,7 @@ exports[`Storyshots disabled compare 1`] = `
         onKeyDown={[Function]}
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           I'm not usable
         </div>
@@ -673,7 +673,7 @@ exports[`Storyshots disabled compare 1`] = `
           </div>
         </div>
         <div
-          data-css-bf7jp3=""
+          data-css-6ga4kh=""
         >
           Neither am I
         </div>
@@ -833,7 +833,7 @@ exports[`Storyshots labels label 1`] = `
       onKeyDown={[Function]}
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Some label
       </div>
@@ -942,7 +942,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
       onKeyDown={[Function]}
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Some label
       </div>
@@ -1035,7 +1035,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
         </div>
       </div>
       <div
-        data-css-bf7jp3=""
+        data-css-6ga4kh=""
       >
         Some sublabel
       </div>
@@ -1249,7 +1249,7 @@ exports[`Storyshots labels subLabel 1`] = `
         </div>
       </div>
       <div
-        data-css-bf7jp3=""
+        data-css-6ga4kh=""
       >
         Some sublabel
       </div>
@@ -1284,7 +1284,7 @@ exports[`Storyshots layouts full width 1`] = `
         }
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           First
         </div>
@@ -1388,7 +1388,7 @@ exports[`Storyshots layouts full width 1`] = `
         }
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Second
         </div>
@@ -1511,7 +1511,7 @@ exports[`Storyshots layouts full width 1`] = `
         }
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Third
         </div>
@@ -1615,7 +1615,7 @@ exports[`Storyshots layouts full width 1`] = `
         }
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Fourth
         </div>

--- a/packages/dropdown/src/css/index.js
+++ b/packages/dropdown/src/css/index.js
@@ -31,7 +31,7 @@ export default {
     background: colorsBackgroundLight[3],
     fontSize: type.fontSizeSmall,
     lineHeight: type.lineHeightStandard,
-    fontWeight: type.fontWeightMedium,
+    fontWeight: type.fontWeightBook,
     color: colorsTextIcon.highOnLight,
     textAlign: 'left',
     cursor: 'pointer',
@@ -93,10 +93,9 @@ export default {
   // __label
   '.psds-dropdown__label': {
     color: colorsTextIcon.highOnDark,
-    fontSize: type.fontSizeSmall,
-    lineHeight: '16px',
+    fontSize: type.fontSizeXSmall,
     fontWeight: type.fontWeightMedium,
-    paddingBottom: layout.spacingXSmall
+    marginBottom: layout.spacingXXSmall
   },
   [`.psds-dropdown__label.psds-theme--${themeNames.light}`]: {
     color: colorsTextIcon.highOnLight
@@ -106,9 +105,8 @@ export default {
   '.psds-dropdown__sub-label': {
     color: colorsTextIcon.lowOnDark,
     fontSize: type.fontSizeXSmall,
-    lineHeight: '16px',
-    fontWeight: type.fontWeightMedium,
-    paddingTop: layout.spacingXSmall
+    fontWeight: type.fontWeightBook,
+    marginTop: layout.spacingXXSmall
   },
   [`.psds-dropdown__sub-label.psds-theme--${themeNames.light}`]: {
     color: colorsTextIcon.lowOnLight

--- a/packages/dropdown/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/dropdown/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -13,7 +13,7 @@ exports[`Storyshots appearance default w/ error 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Problem field
     </div>
@@ -27,7 +27,7 @@ exports[`Storyshots appearance default w/ error 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -98,7 +98,7 @@ exports[`Storyshots appearance gaps 1`] = `
         onKeyDown={[Function]}
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Problem field
         </div>
@@ -112,7 +112,7 @@ exports[`Storyshots appearance gaps 1`] = `
               data-css-ne3jjf=""
             >
               <button
-                data-css-1lq4mos=""
+                data-css-i9dafq=""
                 disabled={false}
                 onClick={[Function]}
               >
@@ -153,7 +153,7 @@ exports[`Storyshots appearance gaps 1`] = `
         onKeyDown={[Function]}
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Problem field
         </div>
@@ -167,7 +167,7 @@ exports[`Storyshots appearance gaps 1`] = `
               data-css-ne3jjf=""
             >
               <button
-                data-css-1lq4mos=""
+                data-css-i9dafq=""
                 disabled={false}
                 onClick={[Function]}
               >
@@ -227,7 +227,7 @@ exports[`Storyshots appearance gaps 1`] = `
         onKeyDown={[Function]}
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Problem field
         </div>
@@ -241,7 +241,7 @@ exports[`Storyshots appearance gaps 1`] = `
               data-css-ne3jjf=""
             >
               <button
-                data-css-18uvdlm=""
+                data-css-1xu7t6b=""
                 disabled={false}
                 onClick={[Function]}
               >
@@ -282,7 +282,7 @@ exports[`Storyshots appearance gaps 1`] = `
         onKeyDown={[Function]}
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Problem field
         </div>
@@ -296,7 +296,7 @@ exports[`Storyshots appearance gaps 1`] = `
               data-css-ne3jjf=""
             >
               <button
-                data-css-18uvdlm=""
+                data-css-1xu7t6b=""
                 disabled={false}
                 onClick={[Function]}
               >
@@ -376,7 +376,7 @@ exports[`Storyshots appearance medium default 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -439,7 +439,7 @@ exports[`Storyshots appearance medium subtle 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-18uvdlm=""
+            data-css-1xu7t6b=""
             disabled={false}
             onClick={[Function]}
           >
@@ -502,7 +502,7 @@ exports[`Storyshots appearance small default 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-nypqc5=""
+            data-css-kcavkk=""
             disabled={false}
             onClick={[Function]}
           >
@@ -565,7 +565,7 @@ exports[`Storyshots appearance small subtle 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-112wuyk=""
+            data-css-uxc8uo=""
             disabled={false}
             onClick={[Function]}
           >
@@ -619,7 +619,7 @@ exports[`Storyshots appearance subtle w/ error 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Problem field
     </div>
@@ -633,7 +633,7 @@ exports[`Storyshots appearance subtle w/ error 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-18uvdlm=""
+            data-css-1xu7t6b=""
             disabled={false}
             onClick={[Function]}
           >
@@ -703,7 +703,7 @@ exports[`Storyshots disabled compare 1`] = `
       onKeyDown={[Function]}
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Normal
       </div>
@@ -717,7 +717,7 @@ exports[`Storyshots disabled compare 1`] = `
             data-css-ne3jjf=""
           >
             <button
-              data-css-1lq4mos=""
+              data-css-i9dafq=""
               disabled={false}
               onClick={[Function]}
             >
@@ -755,7 +755,7 @@ exports[`Storyshots disabled compare 1`] = `
         </div>
       </div>
       <div
-        data-css-bf7jp3=""
+        data-css-6ga4kh=""
       >
         Still normal
       </div>
@@ -765,7 +765,7 @@ exports[`Storyshots disabled compare 1`] = `
       onKeyDown={[Function]}
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         I'm not usable
       </div>
@@ -779,7 +779,7 @@ exports[`Storyshots disabled compare 1`] = `
             data-css-ne3jjf=""
           >
             <button
-              data-css-1lq4mos=""
+              data-css-i9dafq=""
               disabled={true}
               onClick={null}
             >
@@ -817,7 +817,7 @@ exports[`Storyshots disabled compare 1`] = `
         </div>
       </div>
       <div
-        data-css-bf7jp3=""
+        data-css-6ga4kh=""
       >
         Neither am I
       </div>
@@ -848,7 +848,7 @@ exports[`Storyshots focus autofocus with ref 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -907,7 +907,7 @@ exports[`Storyshots focus disabled 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={true}
             onBlur={[Function]}
             onClick={null}
@@ -968,7 +968,7 @@ exports[`Storyshots focus onBlur 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onBlur={[Function]}
             onClick={[Function]}
@@ -1028,7 +1028,7 @@ exports[`Storyshots focus onFocus 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
             onFocus={[Function]}
@@ -1079,7 +1079,7 @@ exports[`Storyshots labels all 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Some label
     </div>
@@ -1093,7 +1093,7 @@ exports[`Storyshots labels all 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -1131,7 +1131,7 @@ exports[`Storyshots labels all 1`] = `
       </div>
     </div>
     <div
-      data-css-bf7jp3=""
+      data-css-6ga4kh=""
     >
       Some sublabel
     </div>
@@ -1152,7 +1152,7 @@ exports[`Storyshots labels label 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Some label
     </div>
@@ -1166,7 +1166,7 @@ exports[`Storyshots labels label 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -1216,7 +1216,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Some label
     </div>
@@ -1230,7 +1230,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -1264,7 +1264,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
       </div>
     </div>
     <div
-      data-css-bf7jp3=""
+      data-css-6ga4kh=""
     >
       Some sublabel
     </div>
@@ -1294,7 +1294,7 @@ exports[`Storyshots labels none 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -1353,7 +1353,7 @@ exports[`Storyshots labels placeholder 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -1416,7 +1416,7 @@ exports[`Storyshots labels subLabel 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -1450,7 +1450,7 @@ exports[`Storyshots labels subLabel 1`] = `
       </div>
     </div>
     <div
-      data-css-bf7jp3=""
+      data-css-6ga4kh=""
     >
       Some sublabel
     </div>
@@ -1487,7 +1487,7 @@ exports[`Storyshots layouts custom width 1`] = `
       }
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Width 150
       </div>
@@ -1501,7 +1501,7 @@ exports[`Storyshots layouts custom width 1`] = `
             data-css-ne3jjf=""
           >
             <button
-              data-css-1lq4mos=""
+              data-css-i9dafq=""
               disabled={false}
               onChange={[Function]}
               onClick={[Function]}
@@ -1546,7 +1546,7 @@ exports[`Storyshots layouts custom width 1`] = `
       onKeyDown={[Function]}
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Width determined by longest item
       </div>
@@ -1560,7 +1560,7 @@ exports[`Storyshots layouts custom width 1`] = `
             data-css-ne3jjf=""
           >
             <button
-              data-css-1lq4mos=""
+              data-css-i9dafq=""
               disabled={false}
               onChange={[Function]}
               onClick={[Function]}
@@ -1631,7 +1631,7 @@ exports[`Storyshots layouts full width 1`] = `
       }
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         First
       </div>
@@ -1645,7 +1645,7 @@ exports[`Storyshots layouts full width 1`] = `
             data-css-ne3jjf=""
           >
             <button
-              data-css-1lq4mos=""
+              data-css-i9dafq=""
               disabled={false}
               onClick={[Function]}
             >
@@ -1690,7 +1690,7 @@ exports[`Storyshots layouts full width 1`] = `
       }
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Second
       </div>
@@ -1704,7 +1704,7 @@ exports[`Storyshots layouts full width 1`] = `
             data-css-ne3jjf=""
           >
             <button
-              data-css-1lq4mos=""
+              data-css-i9dafq=""
               disabled={false}
               onClick={[Function]}
             >
@@ -1768,7 +1768,7 @@ exports[`Storyshots layouts full width 1`] = `
       }
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Third
       </div>
@@ -1782,7 +1782,7 @@ exports[`Storyshots layouts full width 1`] = `
             data-css-ne3jjf=""
           >
             <button
-              data-css-18uvdlm=""
+              data-css-1xu7t6b=""
               disabled={false}
               onClick={[Function]}
             >
@@ -1827,7 +1827,7 @@ exports[`Storyshots layouts full width 1`] = `
       }
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Fourth
       </div>
@@ -1841,7 +1841,7 @@ exports[`Storyshots layouts full width 1`] = `
             data-css-ne3jjf=""
           >
             <button
-              data-css-18uvdlm=""
+              data-css-1xu7t6b=""
               disabled={false}
               onClick={[Function]}
             >
@@ -1935,7 +1935,7 @@ exports[`Storyshots layouts right-aligned 1`] = `
               data-css-ne3jjf=""
             >
               <button
-                data-css-18uvdlm=""
+                data-css-1xu7t6b=""
                 disabled={false}
                 onClick={[Function]}
               >
@@ -1999,7 +1999,7 @@ exports[`Storyshots menu divider 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Level
     </div>
@@ -2013,7 +2013,7 @@ exports[`Storyshots menu divider 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -2067,7 +2067,7 @@ exports[`Storyshots menu in stack 1`] = `
         onKeyDown={[Function]}
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Level
         </div>
@@ -2081,7 +2081,7 @@ exports[`Storyshots menu in stack 1`] = `
               data-css-ne3jjf=""
             >
               <button
-                data-css-1lq4mos=""
+                data-css-i9dafq=""
                 disabled={false}
                 onClick={[Function]}
               >
@@ -2126,7 +2126,7 @@ exports[`Storyshots menu in stack 1`] = `
         onKeyDown={[Function]}
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Level
         </div>
@@ -2140,7 +2140,7 @@ exports[`Storyshots menu in stack 1`] = `
               data-css-ne3jjf=""
             >
               <button
-                data-css-1lq4mos=""
+                data-css-i9dafq=""
                 disabled={false}
                 onClick={[Function]}
               >
@@ -2196,7 +2196,7 @@ exports[`Storyshots menu nested 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Level
     </div>
@@ -2210,7 +2210,7 @@ exports[`Storyshots menu nested 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -2264,7 +2264,7 @@ exports[`Storyshots menu onClicks 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Level
     </div>
@@ -2278,7 +2278,7 @@ exports[`Storyshots menu onClicks 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-18uvdlm=""
+            data-css-1xu7t6b=""
             disabled={false}
             onClick={[Function]}
           >
@@ -2351,7 +2351,7 @@ exports[`Storyshots menu single list 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Level
     </div>
@@ -2365,7 +2365,7 @@ exports[`Storyshots menu single list 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -2417,7 +2417,7 @@ exports[`Storyshots menu single list w/ icon 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Level
     </div>
@@ -2431,7 +2431,7 @@ exports[`Storyshots menu single list w/ icon 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -2485,7 +2485,7 @@ exports[`Storyshots menu super long 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Level
     </div>
@@ -2499,7 +2499,7 @@ exports[`Storyshots menu super long 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -2551,7 +2551,7 @@ exports[`Storyshots menu w/ longer nested menu item label 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Level
     </div>
@@ -2565,7 +2565,7 @@ exports[`Storyshots menu w/ longer nested menu item label 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -2617,7 +2617,7 @@ exports[`Storyshots menu w/ longer placeholder 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Level
     </div>
@@ -2631,7 +2631,7 @@ exports[`Storyshots menu w/ longer placeholder 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -2685,7 +2685,7 @@ exports[`Storyshots menu w/ subLabel 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Level
     </div>
@@ -2699,7 +2699,7 @@ exports[`Storyshots menu w/ subLabel 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -2735,7 +2735,7 @@ exports[`Storyshots menu w/ subLabel 1`] = `
       </div>
     </div>
     <div
-      data-css-bf7jp3=""
+      data-css-6ga4kh=""
     >
       The course level
     </div>
@@ -2765,7 +2765,7 @@ exports[`Storyshots placeholder as pre-selected item 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
           >
@@ -2819,7 +2819,7 @@ exports[`Storyshots props whitelist title 1`] = `
     onKeyDown={[Function]}
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Level
     </div>
@@ -2833,7 +2833,7 @@ exports[`Storyshots props whitelist title 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             onClick={[Function]}
             title="This title should be present"
@@ -2902,7 +2902,7 @@ exports[`Storyshots whitelist clear 1`] = `
       onKeyDown={[Function]}
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Thing to change
       </div>
@@ -2916,7 +2916,7 @@ exports[`Storyshots whitelist clear 1`] = `
             data-css-ne3jjf=""
           >
             <button
-              data-css-1lq4mos=""
+              data-css-i9dafq=""
               disabled={false}
               onChange={[Function]}
               onClick={[Function]}
@@ -2982,7 +2982,7 @@ exports[`Storyshots whitelist name 1`] = `
           data-css-ne3jjf=""
         >
           <button
-            data-css-1lq4mos=""
+            data-css-i9dafq=""
             disabled={false}
             name="myFieldNameOfPower"
             onClick={[Function]}
@@ -3048,7 +3048,7 @@ exports[`Storyshots whitelist onChange 1`] = `
       onKeyDown={[Function]}
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Thing to change
       </div>
@@ -3062,7 +3062,7 @@ exports[`Storyshots whitelist onChange 1`] = `
             data-css-ne3jjf=""
           >
             <button
-              data-css-1lq4mos=""
+              data-css-i9dafq=""
               disabled={false}
               onChange={[Function]}
               onClick={[Function]}

--- a/packages/form/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/form/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -262,7 +262,7 @@ exports[`Storyshots Sample Form null children 1`] = `
             }
           >
             <div
-              data-css-1ewie3k=""
+              data-css-dysqqm=""
             >
               Name
             </div>
@@ -299,7 +299,7 @@ exports[`Storyshots Sample Form null children 1`] = `
             }
           >
             <div
-              data-css-1ewie3k=""
+              data-css-dysqqm=""
             >
               Alias
             </div>
@@ -322,7 +322,7 @@ exports[`Storyshots Sample Form null children 1`] = `
               </div>
             </div>
             <div
-              data-css-bf7jp3=""
+              data-css-6ga4kh=""
             >
               *Optional
             </div>
@@ -348,7 +348,7 @@ exports[`Storyshots Sample Form null children 1`] = `
             }
           >
             <div
-              data-css-hnaccs=""
+              data-css-9kywkh=""
             >
               Comment
             </div>
@@ -468,7 +468,7 @@ exports[`Storyshots Sample Form sample 1`] = `
             }
           >
             <div
-              data-css-1ewie3k=""
+              data-css-dysqqm=""
             >
               Name
             </div>
@@ -505,7 +505,7 @@ exports[`Storyshots Sample Form sample 1`] = `
             }
           >
             <div
-              data-css-1ewie3k=""
+              data-css-dysqqm=""
             >
               Alias
             </div>
@@ -528,7 +528,7 @@ exports[`Storyshots Sample Form sample 1`] = `
               </div>
             </div>
             <div
-              data-css-bf7jp3=""
+              data-css-6ga4kh=""
             >
               *Optional
             </div>
@@ -547,7 +547,7 @@ exports[`Storyshots Sample Form sample 1`] = `
             }
           >
             <div
-              data-css-1ewie3k=""
+              data-css-dysqqm=""
             >
               Email address
             </div>
@@ -589,7 +589,7 @@ exports[`Storyshots Sample Form sample 1`] = `
               </div>
             </div>
             <div
-              data-css-bf7jp3=""
+              data-css-6ga4kh=""
             >
               Not a valid email address
             </div>
@@ -609,7 +609,7 @@ exports[`Storyshots Sample Form sample 1`] = `
             }
           >
             <div
-              data-css-1ewie3k=""
+              data-css-dysqqm=""
             >
               Occupation
             </div>
@@ -623,7 +623,7 @@ exports[`Storyshots Sample Form sample 1`] = `
                   data-css-ne3jjf=""
                 >
                   <button
-                    data-css-1lq4mos=""
+                    data-css-i9dafq=""
                     disabled={false}
                     onClick={[Function]}
                   >
@@ -746,7 +746,7 @@ exports[`Storyshots Sample Form sample 1`] = `
             }
           >
             <div
-              data-css-1ewie3k=""
+              data-css-dysqqm=""
             >
               Choose a Date
             </div>
@@ -887,7 +887,7 @@ exports[`Storyshots Sample Form sample 1`] = `
               value="someVal"
             />
             <div
-              data-css-185gc3y=""
+              data-css-ybwuvp=""
             >
               Checkbox selected
             </div>
@@ -948,7 +948,7 @@ exports[`Storyshots Sample Form sample 1`] = `
                   value="full"
                 />
                 <div
-                  data-css-wbyy03=""
+                  data-css-nrxvu5=""
                 >
                   Full-time employement
                 </div>
@@ -986,7 +986,7 @@ exports[`Storyshots Sample Form sample 1`] = `
                   value="part"
                 />
                 <div
-                  data-css-wbyy03=""
+                  data-css-nrxvu5=""
                 >
                   Part-time employement
                 </div>
@@ -1038,7 +1038,7 @@ exports[`Storyshots Sample Form sample 1`] = `
               type="checkbox"
             />
             <label
-              data-css-on3oux=""
+              data-css-1oms9gl=""
             >
               toggle
             </label>
@@ -1064,7 +1064,7 @@ exports[`Storyshots Sample Form sample 1`] = `
             }
           >
             <div
-              data-css-hnaccs=""
+              data-css-9kywkh=""
             >
               Comment
             </div>

--- a/packages/radio/src/css/index.js
+++ b/packages/radio/src/css/index.js
@@ -54,7 +54,7 @@ export default {
   },
   '.psds-radio-button__circle--checked': {
     borderColor: colorsBlue.base,
-    background: colorsBlue.base
+	background: colorsBlue.base
   },
 
   '.psds-radio-button__circle-inner': {

--- a/packages/radio/src/css/index.js
+++ b/packages/radio/src/css/index.js
@@ -54,7 +54,7 @@ export default {
   },
   '.psds-radio-button__circle--checked': {
     borderColor: colorsBlue.base,
-	background: colorsBlue.base
+    background: colorsBlue.base
   },
 
   '.psds-radio-button__circle-inner': {

--- a/packages/radio/src/css/index.js
+++ b/packages/radio/src/css/index.js
@@ -1,5 +1,6 @@
 import {
   colorsBlue,
+  colorsWhite,
   colorsBackgroundDark,
   colorsBackgroundLight,
   colorsTextIcon,
@@ -52,16 +53,17 @@ export default {
     borderColor: colorsTextIcon.lowOnLight
   },
   '.psds-radio-button__circle--checked': {
-    borderColor: colorsBlue.base
+    borderColor: colorsBlue.base,
+	background: colorsBlue.base
   },
 
   '.psds-radio-button__circle-inner': {
     display: 'block',
-    height: 'calc(100% - 4px)',
-    width: 'calc(100% - 4px)',
-    margin: '2px',
+    height: 'calc(100% - 6px)',
+    width: 'calc(100% - 6px)',
+    margin: '3px',
     borderRadius: '50%',
-    background: colorsBlue.base
+    background: colorsWhite
   },
 
   '.psds-radio-button__input': {
@@ -72,7 +74,7 @@ export default {
     color: colorsTextIcon.highOnDark,
     fontSize: type.fontSizeSmall,
     lineHeight: type.lineHeightStandard,
-    fontWeight: type.fontWeightMedium
+    fontWeight: type.fontWeightBook
   },
   [`.psds-radio-button__label.psds-theme--${themeNames.light}`]: {
     color: colorsTextIcon.highOnLight

--- a/packages/radio/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/radio/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -47,7 +47,7 @@ exports[`Storyshots Radio default 1`] = `
           value="red"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Red
         </div>
@@ -85,7 +85,7 @@ exports[`Storyshots Radio default 1`] = `
           value="green"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Green
         </div>
@@ -123,7 +123,7 @@ exports[`Storyshots Radio default 1`] = `
           value="blue"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Blue
         </div>
@@ -180,7 +180,7 @@ exports[`Storyshots Radio disabled & error 1`] = `
           value="red"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Red
         </div>
@@ -201,13 +201,13 @@ exports[`Storyshots Radio disabled & error 1`] = `
           >
             <div
               aria-checked={true}
-              data-css-12prt44=""
+              data-css-1olif27=""
               onFocus={null}
               role="radio"
               tabIndex="-1"
             >
               <div
-                data-css-1qtmg0s=""
+                data-css-ppl1jg=""
               />
             </div>
           </div>
@@ -222,7 +222,7 @@ exports[`Storyshots Radio disabled & error 1`] = `
           value="green"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Green
         </div>
@@ -260,7 +260,7 @@ exports[`Storyshots Radio disabled & error 1`] = `
           value="blue"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Blue
         </div>
@@ -317,7 +317,7 @@ exports[`Storyshots Radio disabled 1`] = `
           value="red"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Red
         </div>
@@ -338,13 +338,13 @@ exports[`Storyshots Radio disabled 1`] = `
           >
             <div
               aria-checked={true}
-              data-css-12prt44=""
+              data-css-1olif27=""
               onFocus={null}
               role="radio"
               tabIndex="-1"
             >
               <div
-                data-css-1qtmg0s=""
+                data-css-ppl1jg=""
               />
             </div>
           </div>
@@ -359,7 +359,7 @@ exports[`Storyshots Radio disabled 1`] = `
           value="green"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Green
         </div>
@@ -397,7 +397,7 @@ exports[`Storyshots Radio disabled 1`] = `
           value="blue"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Blue
         </div>
@@ -454,7 +454,7 @@ exports[`Storyshots Radio error 1`] = `
           value="red"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Red
         </div>
@@ -475,13 +475,13 @@ exports[`Storyshots Radio error 1`] = `
           >
             <div
               aria-checked={true}
-              data-css-12prt44=""
+              data-css-1olif27=""
               onFocus={[Function]}
               role="radio"
               tabIndex="-1"
             >
               <div
-                data-css-1qtmg0s=""
+                data-css-ppl1jg=""
               />
             </div>
           </div>
@@ -496,7 +496,7 @@ exports[`Storyshots Radio error 1`] = `
           value="green"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Green
         </div>
@@ -534,7 +534,7 @@ exports[`Storyshots Radio error 1`] = `
           value="blue"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Blue
         </div>
@@ -591,7 +591,7 @@ exports[`Storyshots Radio one selected 1`] = `
           value="red"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Red
         </div>
@@ -612,13 +612,13 @@ exports[`Storyshots Radio one selected 1`] = `
           >
             <div
               aria-checked={true}
-              data-css-12prt44=""
+              data-css-1olif27=""
               onFocus={[Function]}
               role="radio"
               tabIndex="-1"
             >
               <div
-                data-css-1qtmg0s=""
+                data-css-ppl1jg=""
               />
             </div>
           </div>
@@ -633,7 +633,7 @@ exports[`Storyshots Radio one selected 1`] = `
           value="green"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Green
         </div>
@@ -671,7 +671,7 @@ exports[`Storyshots Radio one selected 1`] = `
           value="blue"
         />
         <div
-          data-css-wbyy03=""
+          data-css-nrxvu5=""
         >
           Blue
         </div>
@@ -723,13 +723,13 @@ exports[`Storyshots Radio state demo 1`] = `
             >
               <div
                 aria-checked={true}
-                data-css-12prt44=""
+                data-css-1olif27=""
                 onFocus={[Function]}
                 role="radio"
                 tabIndex="-1"
               >
                 <div
-                  data-css-1qtmg0s=""
+                  data-css-ppl1jg=""
                 />
               </div>
             </div>
@@ -744,7 +744,7 @@ exports[`Storyshots Radio state demo 1`] = `
             value="red"
           />
           <div
-            data-css-wbyy03=""
+            data-css-nrxvu5=""
           >
             Red
           </div>
@@ -782,7 +782,7 @@ exports[`Storyshots Radio state demo 1`] = `
             value="green"
           />
           <div
-            data-css-wbyy03=""
+            data-css-nrxvu5=""
           >
             Green
           </div>
@@ -820,7 +820,7 @@ exports[`Storyshots Radio state demo 1`] = `
             value="blue"
           />
           <div
-            data-css-wbyy03=""
+            data-css-nrxvu5=""
           >
             Blue
           </div>

--- a/packages/searchinput/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/searchinput/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -105,7 +105,7 @@ exports[`Storyshots SearchInput with TextInput-type props 1`] = `
   data-css-w0yocm=""
 >
   <div
-    data-css-1ewie3k=""
+    data-css-dysqqm=""
   >
     Label
   </div>
@@ -198,7 +198,7 @@ exports[`Storyshots SearchInput with TextInput-type props 1`] = `
     </div>
   </div>
   <div
-    data-css-bf7jp3=""
+    data-css-6ga4kh=""
   >
     Sub label
   </div>

--- a/packages/site/pages/components/form.js
+++ b/packages/site/pages/components/form.js
@@ -395,7 +395,7 @@ class InAppExample extends React.Component {
                     Save
                   </Button>
                   <Button
-                    appearance={Button.appearances.flat}
+                    appearance={Button.appearances.secondary}
                     onClick={evt => evt.preventDefault()}
                   >
                     Cancel
@@ -538,7 +538,7 @@ class InAppExample extends React.Component {
             >
               Save
             </Button>
-            <Button appearance={Button.appearances.flat} onClick={_ => {}}>
+            <Button appearance={Button.appearances.secondary onClick={_ => {}}>
               Cancel
             </Button>
           </Form.ButtonRow>
@@ -684,7 +684,7 @@ export default _ => (
     <TextInput placeholder="Other related stuff" />
     <Form.ButtonRow>
       <Button>Primary</Button>
-      <Button appearance={Button.appearances.flat}>Secondary</Button>
+      <Button appearance={Button.appearances.secondary}>Secondary</Button>
     </Form.ButtonRow>
   </Form.VerticalLayout>
 </div>`

--- a/packages/switch/src/css/index.js
+++ b/packages/switch/src/css/index.js
@@ -94,7 +94,7 @@ export default {
   },
 
   [`.psds-switch__label`]: {
-    fontWeight: type.fontWeightMedium,
+    fontWeight: type.fontWeightBook,
     lineHeight: '1em'
   },
   [`.psds-switch__label--size-${vars.sizes.small}`]: {

--- a/packages/switch/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/switch/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -32,7 +32,7 @@ exports[`Storyshots checked false 1`] = `
       type="checkbox"
     />
     <label
-      data-css-on3oux=""
+      data-css-1oms9gl=""
     >
       Click me
     </label>
@@ -72,7 +72,7 @@ exports[`Storyshots checked true 1`] = `
       type="checkbox"
     />
     <label
-      data-css-on3oux=""
+      data-css-1oms9gl=""
     >
       Click me
     </label>
@@ -182,7 +182,7 @@ exports[`Storyshots color blue 1`] = `
       type="checkbox"
     />
     <label
-      data-css-on3oux=""
+      data-css-1oms9gl=""
     >
       Click me
     </label>
@@ -222,7 +222,7 @@ exports[`Storyshots color green 1`] = `
       type="checkbox"
     />
     <label
-      data-css-on3oux=""
+      data-css-1oms9gl=""
     >
       Click me
     </label>
@@ -262,7 +262,7 @@ exports[`Storyshots color orange 1`] = `
       type="checkbox"
     />
     <label
-      data-css-on3oux=""
+      data-css-1oms9gl=""
     >
       Click me
     </label>
@@ -407,7 +407,7 @@ exports[`Storyshots error true 1`] = `
       type="checkbox"
     />
     <label
-      data-css-on3oux=""
+      data-css-1oms9gl=""
     >
       Clickable in error state
     </label>
@@ -447,7 +447,7 @@ exports[`Storyshots error true w/ disabled 1`] = `
       type="checkbox"
     />
     <label
-      data-css-on3oux=""
+      data-css-1oms9gl=""
     >
       Such errors
     </label>
@@ -487,7 +487,7 @@ exports[`Storyshots label large left 1`] = `
       type="checkbox"
     />
     <label
-      data-css-qisca0=""
+      data-css-16fknc=""
     >
       Click me
     </label>
@@ -527,7 +527,7 @@ exports[`Storyshots label large right 1`] = `
       type="checkbox"
     />
     <label
-      data-css-on3oux=""
+      data-css-1oms9gl=""
     >
       Click me
     </label>
@@ -567,7 +567,7 @@ exports[`Storyshots label small left 1`] = `
       type="checkbox"
     />
     <label
-      data-css-kccklm=""
+      data-css-i4my9=""
     >
       Click me
     </label>
@@ -607,7 +607,7 @@ exports[`Storyshots label small right 1`] = `
       type="checkbox"
     />
     <label
-      data-css-yktx6h=""
+      data-css-y6ldsm=""
     >
       Click me
     </label>
@@ -647,7 +647,7 @@ exports[`Storyshots size large 1`] = `
       type="checkbox"
     />
     <label
-      data-css-on3oux=""
+      data-css-1oms9gl=""
     >
       Click me
     </label>
@@ -687,7 +687,7 @@ exports[`Storyshots size small 1`] = `
       type="checkbox"
     />
     <label
-      data-css-yktx6h=""
+      data-css-y6ldsm=""
     >
       Click me
     </label>

--- a/packages/textarea/src/css/index.js
+++ b/packages/textarea/src/css/index.js
@@ -53,10 +53,9 @@ export default {
   '.psds-text-area__label': {
     width: '100%',
     color: colorsTextIcon.highOnDark,
-    fontSize: type.fontSizeSmall,
-    lineHeight: '16px',
+    fontSize: type.fontSizeXSmall,
     fontWeight: type.fontWeightMedium,
-    paddingBottom: layout.spacingXSmall
+    marginBottom: layout.spacingXXSmall
   },
   [`.psds-text-area__label.psds-theme--${themeNames.light}`]: {
     color: colorsTextIcon.highOnLight
@@ -65,9 +64,8 @@ export default {
   '.psds-text-area__sub-label': {
     color: colorsTextIcon.lowOnDark,
     fontSize: type.fontSizeXSmall,
-    lineHeight: '16px',
     fontWeight: type.fontWeightMedium,
-    paddingTop: layout.spacingXSmall
+    marginTop: layout.spacingXXSmall
   },
   [`.psds-text-area__sub-label.psds-theme--${themeNames.light}`]: {
     color: colorsTextIcon.lowOnLight

--- a/packages/textarea/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/textarea/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -9,7 +9,7 @@ exports[`Storyshots disabled compare 1`] = `
       data-css-na8jqt=""
     >
       <div
-        data-css-hnaccs=""
+        data-css-9kywkh=""
       >
         Normal
       </div>
@@ -33,7 +33,7 @@ exports[`Storyshots disabled compare 1`] = `
         </div>
       </div>
       <div
-        data-css-bf7jp3=""
+        data-css-1u5arfw=""
       >
         Still normal
       </div>
@@ -42,7 +42,7 @@ exports[`Storyshots disabled compare 1`] = `
       data-css-1tctpgo=""
     >
       <div
-        data-css-hnaccs=""
+        data-css-9kywkh=""
       >
         I'm not usable
       </div>
@@ -66,7 +66,7 @@ exports[`Storyshots disabled compare 1`] = `
         </div>
       </div>
       <div
-        data-css-bf7jp3=""
+        data-css-1u5arfw=""
       >
         Neither am I
       </div>
@@ -84,7 +84,7 @@ exports[`Storyshots error compare 1`] = `
       data-css-na8jqt=""
     >
       <div
-        data-css-hnaccs=""
+        data-css-9kywkh=""
       >
         Normal
       </div>
@@ -108,7 +108,7 @@ exports[`Storyshots error compare 1`] = `
         </div>
       </div>
       <div
-        data-css-bf7jp3=""
+        data-css-1u5arfw=""
       >
         Still normal
       </div>
@@ -117,7 +117,7 @@ exports[`Storyshots error compare 1`] = `
       data-css-na8jqt=""
     >
       <div
-        data-css-hnaccs=""
+        data-css-9kywkh=""
       >
         I'm in an error state
       </div>
@@ -160,7 +160,7 @@ exports[`Storyshots error compare 1`] = `
         </div>
       </div>
       <div
-        data-css-bf7jp3=""
+        data-css-1u5arfw=""
       >
         Here
       </div>
@@ -209,7 +209,7 @@ exports[`Storyshots labels all 1`] = `
     data-css-na8jqt=""
   >
     <div
-      data-css-hnaccs=""
+      data-css-9kywkh=""
     >
       Some label
     </div>
@@ -233,7 +233,7 @@ exports[`Storyshots labels all 1`] = `
       </div>
     </div>
     <div
-      data-css-bf7jp3=""
+      data-css-1u5arfw=""
     >
       Some sublabel
     </div>
@@ -249,7 +249,7 @@ exports[`Storyshots labels label 1`] = `
     data-css-na8jqt=""
   >
     <div
-      data-css-hnaccs=""
+      data-css-9kywkh=""
     >
       Some label
     </div>
@@ -283,7 +283,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
     data-css-na8jqt=""
   >
     <div
-      data-css-hnaccs=""
+      data-css-9kywkh=""
     >
       Some label
     </div>
@@ -306,7 +306,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
       </div>
     </div>
     <div
-      data-css-bf7jp3=""
+      data-css-1u5arfw=""
     >
       Some sublabel
     </div>
@@ -399,7 +399,7 @@ exports[`Storyshots labels subLabel 1`] = `
       </div>
     </div>
     <div
-      data-css-bf7jp3=""
+      data-css-1u5arfw=""
     >
       Some sublabel
     </div>
@@ -427,7 +427,7 @@ exports[`Storyshots layouts Form.VerticalLayout 1`] = `
         }
       >
         <div
-          data-css-hnaccs=""
+          data-css-9kywkh=""
         >
           Inside Form.VerticalLayout
         </div>
@@ -477,7 +477,7 @@ exports[`Storyshots layouts full width 1`] = `
       }
     >
       <div
-        data-css-hnaccs=""
+        data-css-9kywkh=""
       >
         max-width still applies
       </div>
@@ -511,7 +511,7 @@ exports[`Storyshots layouts full width 1`] = `
       }
     >
       <div
-        data-css-hnaccs=""
+        data-css-9kywkh=""
       >
         remove max-width
       </div>
@@ -565,7 +565,7 @@ exports[`Storyshots rows less than 4 1`] = `
     data-css-na8jqt=""
   >
     <div
-      data-css-hnaccs=""
+      data-css-9kywkh=""
     >
       Min Height Engages
     </div>
@@ -599,7 +599,7 @@ exports[`Storyshots rows more than 4 1`] = `
     data-css-na8jqt=""
   >
     <div
-      data-css-hnaccs=""
+      data-css-9kywkh=""
     >
       6 Rows of Text
     </div>

--- a/packages/textinput/src/css/index.js
+++ b/packages/textinput/src/css/index.js
@@ -125,10 +125,9 @@ export default {
   // __label
   '.psds-text-input__label': {
     color: colorsTextIcon.highOnDark,
-    fontSize: type.fontSizeSmall,
-    lineHeight: '16px',
+    fontSize: type.fontSizeXSmall,
     fontWeight: type.fontWeightMedium,
-    paddingBottom: layout.spacingXSmall
+    marginBottom: layout.spacingXXSmall
   },
   [`.psds-text-input__label.psds-theme--${themeNames.light}`]: {
     color: colorsTextIcon.highOnLight
@@ -138,9 +137,8 @@ export default {
   '.psds-text-input__sub-label': {
     color: colorsTextIcon.lowOnDark,
     fontSize: type.fontSizeXSmall,
-    lineHeight: '16px',
-    fontWeight: type.fontWeightMedium,
-    paddingTop: layout.spacingXSmall
+    fontWeight: type.fontWeightBook,
+    marginTop: layout.spacingXXSmall
   },
   [`.psds-text-input__sub-label.psds-theme--${themeNames.light}`]: {
     color: colorsTextIcon.lowOnLight

--- a/packages/textinput/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/textinput/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -289,7 +289,7 @@ exports[`Storyshots appearance default w/ error 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Problem field
       </div>
@@ -610,7 +610,7 @@ exports[`Storyshots appearance subtle w/ error 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Problem field
       </div>
@@ -671,7 +671,7 @@ exports[`Storyshots disabled compare 1`] = `
         data-css-w0yocm=""
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Normal
         </div>
@@ -694,7 +694,7 @@ exports[`Storyshots disabled compare 1`] = `
           </div>
         </div>
         <div
-          data-css-bf7jp3=""
+          data-css-6ga4kh=""
         >
           Still normal
         </div>
@@ -703,7 +703,7 @@ exports[`Storyshots disabled compare 1`] = `
         data-css-1y0hkm3=""
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           I'm not usable
         </div>
@@ -726,7 +726,7 @@ exports[`Storyshots disabled compare 1`] = `
           </div>
         </div>
         <div
-          data-css-bf7jp3=""
+          data-css-6ga4kh=""
         >
           Neither am I
         </div>
@@ -735,7 +735,7 @@ exports[`Storyshots disabled compare 1`] = `
         data-css-1y0hkm3=""
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Disbled and errored
         </div>
@@ -777,7 +777,7 @@ exports[`Storyshots disabled compare 1`] = `
           </div>
         </div>
         <div
-          data-css-bf7jp3=""
+          data-css-6ga4kh=""
         >
           Neither am I
         </div>
@@ -802,7 +802,7 @@ exports[`Storyshots labels all 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Some label
       </div>
@@ -825,7 +825,7 @@ exports[`Storyshots labels all 1`] = `
         </div>
       </div>
       <div
-        data-css-bf7jp3=""
+        data-css-6ga4kh=""
       >
         Some sublabel
       </div>
@@ -849,7 +849,7 @@ exports[`Storyshots labels all w/error 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Some label
       </div>
@@ -891,7 +891,7 @@ exports[`Storyshots labels all w/error 1`] = `
         </div>
       </div>
       <div
-        data-css-bf7jp3=""
+        data-css-6ga4kh=""
       >
         Some sublabel
       </div>
@@ -915,7 +915,7 @@ exports[`Storyshots labels label 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Some label
       </div>
@@ -956,7 +956,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
       data-css-w0yocm=""
     >
       <div
-        data-css-1ewie3k=""
+        data-css-dysqqm=""
       >
         Some label
       </div>
@@ -978,7 +978,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
         </div>
       </div>
       <div
-        data-css-bf7jp3=""
+        data-css-6ga4kh=""
       >
         Some sublabel
       </div>
@@ -1134,7 +1134,7 @@ exports[`Storyshots labels subLabel 1`] = `
         </div>
       </div>
       <div
-        data-css-bf7jp3=""
+        data-css-6ga4kh=""
       >
         Some sublabel
       </div>
@@ -1172,7 +1172,7 @@ exports[`Storyshots layouts full width 1`] = `
         }
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           First
         </div>
@@ -1204,7 +1204,7 @@ exports[`Storyshots layouts full width 1`] = `
         }
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Second
         </div>
@@ -1255,7 +1255,7 @@ exports[`Storyshots layouts full width 1`] = `
         }
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Third
         </div>
@@ -1287,7 +1287,7 @@ exports[`Storyshots layouts full width 1`] = `
         }
       >
         <div
-          data-css-1ewie3k=""
+          data-css-dysqqm=""
         >
           Fourth
         </div>

--- a/packages/typeahead/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/typeahead/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -165,7 +165,7 @@ exports[`Storyshots Components | Typeahead / form props all 1`] = `
     data-css-w0yocm=""
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Some label
     </div>
@@ -208,7 +208,7 @@ exports[`Storyshots Components | Typeahead / form props all 1`] = `
       </div>
     </div>
     <div
-      data-css-bf7jp3=""
+      data-css-6ga4kh=""
     >
       Some sublabel
     </div>
@@ -229,7 +229,7 @@ exports[`Storyshots Components | Typeahead / form props all w/error 1`] = `
     data-css-w0yocm=""
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Some label
     </div>
@@ -291,7 +291,7 @@ exports[`Storyshots Components | Typeahead / form props all w/error 1`] = `
       </div>
     </div>
     <div
-      data-css-bf7jp3=""
+      data-css-6ga4kh=""
     >
       Some sublabel
     </div>
@@ -312,7 +312,7 @@ exports[`Storyshots Components | Typeahead / form props label and subLabel 1`] =
     data-css-w0yocm=""
   >
     <div
-      data-css-1ewie3k=""
+      data-css-dysqqm=""
     >
       Some label
     </div>
@@ -354,7 +354,7 @@ exports[`Storyshots Components | Typeahead / form props label and subLabel 1`] =
       </div>
     </div>
     <div
-      data-css-bf7jp3=""
+      data-css-6ga4kh=""
     >
       Some sublabel
     </div>


### PR DESCRIPTION
Refactor visual styling of the following components to match Figma styles:
- textinput
- datepicker
- textarea
- dropdown
- radio
- checkbox
- switch

Update form docs to use secondary button in Form.ButtonRow in examples instead of flat button.