### PR TITLE
Portal actionmenu overlay to direct child of body

### DIFF
--- a/packages/actionmenu/src/react/overlay.js
+++ b/packages/actionmenu/src/react/overlay.js
@@ -11,6 +11,13 @@ const styles = {
   overlay: () => css(stylesheet['.psds-actionmenu__overlay'])
 }
 
+const hasComponentRendered = () =>
+  !!(
+    typeof window !== 'undefined' &&
+    typeof window.document !== 'undefined' &&
+    typeof window.document.body !== 'undefined'
+  )
+
 const Overlay = props => {
   function handleOverlayClick(evt) {
     if (evt.target.id === MODAL_OVERLAY_ID) {
@@ -18,14 +25,17 @@ const Overlay = props => {
       if (typeof props.onClick === 'function') props.onClick(evt)
     }
   }
-  return (
-    <div
-      {...filterReactProps(props)}
-      id={MODAL_OVERLAY_ID}
-      {...styles.overlay(props)}
-      onClick={handleOverlayClick}
-    />
-  )
+  return hasComponentRendered()
+    ? ReactDOM.createPortal(
+        <div
+          {...filterReactProps(props)}
+          id={MODAL_OVERLAY_ID}
+          {...styles.overlay(props)}
+          onClick={handleOverlayClick}
+        />,
+        document.body
+      )
+    : null
 }
 Overlay.propTypes = {
   onClick: PropTypes.func,


### PR DESCRIPTION
## Instructions

- Action menu (specifically the overlay)

### What You're Solving

This is in response to: https://pluralsight.slack.com/archives/C70HPSJPP/p1582318454236600


As a side note, I wasn't able to get storybook running so I didn't actually verify that it works correctly. Can someone try it out on their machine and see if it puts the overlay just under the body? 
