### PR TITLE
fix(build): corrects postcss-css-var-selectors.js

### DIFF
--- a/packages/build/postcss/postcss-css-var-selectors.js
+++ b/packages/build/postcss/postcss-css-var-selectors.js
@@ -31,6 +31,9 @@ function createVarSelectors(decl, options) {
 
   return foundDecl.props.map((p, i, newProps) => {
     const selector = '.' + prop + (newProps.length > 1 ? `--${p}` : '')
-    return postcss.decl({ prop: selector, value: `{ ${p}: ${value} }` })
+    const decl = postcss.decl({ prop: p, value })
+    const rule = postcss.rule({ selector })
+    rule.append(decl)
+    return rule
   })
 }


### PR DESCRIPTION
resolves  #928

css was building incorrectly this resolves this by  creating a rule and appending the declaration to it. 