### PR TITLE
StarRating: added aria-hidden to stars in star rating when not editable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14590,12 +14590,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -14610,17 +14612,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -14737,7 +14742,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -14749,6 +14755,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -14763,6 +14770,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -14770,12 +14778,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -14794,6 +14804,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -14883,7 +14894,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -14895,6 +14907,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -15016,6 +15029,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/packages/starrating/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/starrating/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -2100,7 +2100,7 @@ exports[`Storyshots StarRating / not interactive 0 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2124,7 +2124,7 @@ exports[`Storyshots StarRating / not interactive 0 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2148,7 +2148,7 @@ exports[`Storyshots StarRating / not interactive 0 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2172,7 +2172,7 @@ exports[`Storyshots StarRating / not interactive 0 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2196,7 +2196,7 @@ exports[`Storyshots StarRating / not interactive 0 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2235,7 +2235,7 @@ exports[`Storyshots StarRating / not interactive 0.5 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2283,7 +2283,7 @@ exports[`Storyshots StarRating / not interactive 0.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2307,7 +2307,7 @@ exports[`Storyshots StarRating / not interactive 0.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2331,7 +2331,7 @@ exports[`Storyshots StarRating / not interactive 0.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2355,7 +2355,7 @@ exports[`Storyshots StarRating / not interactive 0.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2394,7 +2394,7 @@ exports[`Storyshots StarRating / not interactive 1 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2418,7 +2418,7 @@ exports[`Storyshots StarRating / not interactive 1 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2442,7 +2442,7 @@ exports[`Storyshots StarRating / not interactive 1 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2466,7 +2466,7 @@ exports[`Storyshots StarRating / not interactive 1 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2490,7 +2490,7 @@ exports[`Storyshots StarRating / not interactive 1 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2529,7 +2529,7 @@ exports[`Storyshots StarRating / not interactive 1.5 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2553,7 +2553,7 @@ exports[`Storyshots StarRating / not interactive 1.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2601,7 +2601,7 @@ exports[`Storyshots StarRating / not interactive 1.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2625,7 +2625,7 @@ exports[`Storyshots StarRating / not interactive 1.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2649,7 +2649,7 @@ exports[`Storyshots StarRating / not interactive 1.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2688,7 +2688,7 @@ exports[`Storyshots StarRating / not interactive 2 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2712,7 +2712,7 @@ exports[`Storyshots StarRating / not interactive 2 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2736,7 +2736,7 @@ exports[`Storyshots StarRating / not interactive 2 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2760,7 +2760,7 @@ exports[`Storyshots StarRating / not interactive 2 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2784,7 +2784,7 @@ exports[`Storyshots StarRating / not interactive 2 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2823,7 +2823,7 @@ exports[`Storyshots StarRating / not interactive 2.5 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2847,7 +2847,7 @@ exports[`Storyshots StarRating / not interactive 2.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2871,7 +2871,7 @@ exports[`Storyshots StarRating / not interactive 2.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2919,7 +2919,7 @@ exports[`Storyshots StarRating / not interactive 2.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2943,7 +2943,7 @@ exports[`Storyshots StarRating / not interactive 2.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -2982,7 +2982,7 @@ exports[`Storyshots StarRating / not interactive 3 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3006,7 +3006,7 @@ exports[`Storyshots StarRating / not interactive 3 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3030,7 +3030,7 @@ exports[`Storyshots StarRating / not interactive 3 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3054,7 +3054,7 @@ exports[`Storyshots StarRating / not interactive 3 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3078,7 +3078,7 @@ exports[`Storyshots StarRating / not interactive 3 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3117,7 +3117,7 @@ exports[`Storyshots StarRating / not interactive 3.5 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3141,7 +3141,7 @@ exports[`Storyshots StarRating / not interactive 3.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3165,7 +3165,7 @@ exports[`Storyshots StarRating / not interactive 3.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3189,7 +3189,7 @@ exports[`Storyshots StarRating / not interactive 3.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3237,7 +3237,7 @@ exports[`Storyshots StarRating / not interactive 3.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3276,7 +3276,7 @@ exports[`Storyshots StarRating / not interactive 4 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3300,7 +3300,7 @@ exports[`Storyshots StarRating / not interactive 4 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3324,7 +3324,7 @@ exports[`Storyshots StarRating / not interactive 4 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3348,7 +3348,7 @@ exports[`Storyshots StarRating / not interactive 4 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3372,7 +3372,7 @@ exports[`Storyshots StarRating / not interactive 4 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3411,7 +3411,7 @@ exports[`Storyshots StarRating / not interactive 4.5 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3435,7 +3435,7 @@ exports[`Storyshots StarRating / not interactive 4.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3459,7 +3459,7 @@ exports[`Storyshots StarRating / not interactive 4.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3483,7 +3483,7 @@ exports[`Storyshots StarRating / not interactive 4.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3507,7 +3507,7 @@ exports[`Storyshots StarRating / not interactive 4.5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3570,7 +3570,7 @@ exports[`Storyshots StarRating / not interactive 5 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3594,7 +3594,7 @@ exports[`Storyshots StarRating / not interactive 5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3618,7 +3618,7 @@ exports[`Storyshots StarRating / not interactive 5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3642,7 +3642,7 @@ exports[`Storyshots StarRating / not interactive 5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3666,7 +3666,7 @@ exports[`Storyshots StarRating / not interactive 5 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-k4u9v3=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3705,7 +3705,7 @@ exports[`Storyshots StarRating / not interactive null 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3729,7 +3729,7 @@ exports[`Storyshots StarRating / not interactive null 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3753,7 +3753,7 @@ exports[`Storyshots StarRating / not interactive null 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3777,7 +3777,7 @@ exports[`Storyshots StarRating / not interactive null 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3801,7 +3801,7 @@ exports[`Storyshots StarRating / not interactive null 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3839,7 +3839,7 @@ exports[`Storyshots StarRating / not interactive undefined 1`] = `
 >
   <div>
     <span
-      aria-label="Rate 1 Star"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3863,7 +3863,7 @@ exports[`Storyshots StarRating / not interactive undefined 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 2 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3887,7 +3887,7 @@ exports[`Storyshots StarRating / not interactive undefined 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 3 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3911,7 +3911,7 @@ exports[`Storyshots StarRating / not interactive undefined 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 4 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}
@@ -3935,7 +3935,7 @@ exports[`Storyshots StarRating / not interactive undefined 1`] = `
       </div>
     </span>
     <span
-      aria-label="Rate 5 Stars"
+      aria-hidden={true}
       data-css-11f15fs=""
       onBlur={[Function]}
       onClick={[Function]}

--- a/packages/starrating/src/react/__specs__/index.spec.js
+++ b/packages/starrating/src/react/__specs__/index.spec.js
@@ -8,7 +8,7 @@ describe('StarRating', () => {
     const nodeList = container.querySelectorAll('span, button')
 
     return [...nodeList].filter(node => {
-      const label = node.getAttribute('aria-label')
+      const label = node.getAttribute('title')
       return label && label.includes('Rate')
     })
   }
@@ -28,6 +28,15 @@ describe('StarRating', () => {
 
       stars.forEach(node => {
         expect(node.tagName.toLowerCase()).toBe('span')
+      })
+    })
+
+    it('hides the individual stars from screen readers', () => {
+      const { container } = render(<StarRating />)
+      const stars = collectStarNodes(container)
+
+      stars.forEach(node => {
+        expect(node.getAttribute('aria-hidden')).toBe('true')
       })
     })
   })

--- a/packages/starrating/src/react/star.js
+++ b/packages/starrating/src/react/star.js
@@ -88,13 +88,15 @@ function Star(props) {
     <Tag
       {...styles.star(props, themeName)}
       {...filterReactProps(props, { tagName: Tag })}
-      aria-label={label}
       title={label}
       onBlur={handleLeave}
       onClick={handleClicked}
       onFocus={handleEnter}
       onMouseEnter={handleEnter}
       onMouseLeave={handleLeave}
+      {...(props.interactive
+        ? { 'aria-label': label }
+        : { 'aria-hidden': true })}
     >
       {props.appearance === APPEARANCES.full && (
         <StarFillIcon size={iconSize} />


### PR DESCRIPTION
### What You're Solving

- Amber pointed out on the search site that interacting with the star rating through a screen reader is quite hard at the moment, because each star icon is read aloud before the label stating the actual rating is read. This change makes it so that the star icons are hidden as long as they are not interactive.

### Design Decisions

- I did not hide the stars when an `onChange` was present because in that context they are used as buttons
- Is there a reason that the individual stars should not be aria-hidden?

### How to Verify

- Running the StarRating tests validates that the stars are in fact hidden
- Screen reader experience validated with NVDA/firefox in the storybook tests
