### PR TITLE
fix(site): rm root postcss.config.js

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    'postcss-import': {},
-    'postcss-preset-env': { browsers: ['Last 2 versions', 'IE >= 11'] }
-  }
-}


### PR DESCRIPTION
### What You're Solving

Build has been broken for some time:

https://teamcity.vnerd.com/viewLog.html?buildId=777195&buildTypeId=Platform_DesignSystem_DesignSystemBuildDeploy&tab=buildLog&_focus=28812

Reporting:

Cannot find module 'postcss-import' from '/opt/teamcity/work/741c7bcb4a5d8ff4/packages/site/'


### Design Decisions

Site doesn't need postcss afaik or can remember.  Trying to figure out what the root postcss.config.js was used for, I decide it was unused.  

Core and normalize use postcss in their build

Postcss is used in core, normalize and build packages.  They seem to have independent package.json deps and postcss.config.js files or other custom postcss usage.

### How to Verify

core, normalize, a component using the build package, and site still build
