### PR TITLE
Add typeahead sugg doc

### DIFF
--- a/packages/site/pages/components/typeahead.js
+++ b/packages/site/pages/components/typeahead.js
@@ -110,7 +110,14 @@ export default () => (
               <code>string</code>,
               null,
               null,
-              <span>suggestion text</span>
+              <span>suggestion label</span>
+            ]),
+            PropTypes.row([
+              'value',
+              <code>string</code>,
+              null,
+              null,
+              <span>suggestion value (optional, falls back to label)</span>
             ])
           ]
         }}


### PR DESCRIPTION
Resolves #945


### What You're Solving

- Make it obvious that typeahead suggestion label and value are independent.

### Design Decisions

- Value prop exists.  Just wasn't documented.  
- Matches HTML native attrs quite well (eg, <select />)

### How to Verify

- Load ref site locally
