### PR TITLE
CircularProgress: fix .d.ts problem which fails build for TS users

### DIFF
--- a/packages/circularprogress/src/index.d.ts
+++ b/packages/circularprogress/src/index.d.ts
@@ -17,7 +17,10 @@ export interface CircularProgressStatics {
   sizes: typeof sizes
 }
 
-export const sizes = keyMirror('small', 'medium')
+export const sizes: {
+  small: 'small',
+  medium: 'medium'
+}
 
 // TODO: relocate to a global typings file
 export type RefForwardingComponent<
@@ -26,15 +29,3 @@ export type RefForwardingComponent<
   Statics = {}
 > = ForwardRefExoticComponent<Props & HTMLAttributes<El> & RefAttributes<El>> &
   Statics
-
-// TODO: move to global utils
-type KeyMirror<Keys extends string[]> = { readonly [K in Keys[number]]: K }
-
-declare function keyMirror<Keys extends string[]>(...inputs: Keys) {
-  const mirrored = inputs.reduce(
-    (acc, key) => ({ ...acc, [key]: key }),
-    {} as KeyMirror<Keys>
-  )
-
-  return Object.freeze(mirrored)
-}


### PR DESCRIPTION
This bug gives TypeScript users a compile error when importing `CircularProgress`
The problem is that you can't implement a function in a `.d.ts` file. In [#973](https://github.com/pluralsight/design-system/pull/973) we changed the `.d.ts` to implement and use a `keyMirror` function. This isn't valid. I should have run a typecheck locally to see this but failed to.

The fix just goes back to enumerating the sizes explicitly.

### How to Verify

- Storybook runs locally without any type errors
