### PR TITLE
explore splitting out html

### DIFF
--- a/packages/universal-nav/package.json
+++ b/packages/universal-nav/package.json
@@ -1,0 +1,29 @@
+{
+  "scripts": {
+    "build": "parcel build src/index.html src/oldschool.html src/templateliteral.html src/webcomponent.html",
+    "clean": "rm dist/bundle.js",
+    "start": "parcel src/index.html src/oldschool.html src/templateliteral.html src/webcomponent.html"
+  },
+  "dependencies": {
+    "htm": "^3.0.4",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.10.5",
+    "@babel/preset-env": "^7.10.4",
+    "@babel/preset-react": "^7.10.4",
+    "@pluralsight/ps-design-system-build": "*",
+    "@pluralsight/ps-design-system-core": "^6.2.1",
+    "@pluralsight/ps-design-system-icon": "*",
+    "@pluralsight/ps-design-system-navbrand": "*",
+    "@pluralsight/ps-design-system-navitem": "*",
+    "@pluralsight/ps-design-system-navuser": "*",
+    "@pluralsight/ps-design-system-storybook-addon-center": "*",
+    "@pluralsight/ps-design-system-storybook-addon-theme": "*",
+    "autoprefixer": "^9.8.5",
+    "parcel-bundler": "^1.12.4",
+    "postcss-modules": "^3.2.0",
+    "prop-types": "^15.7.2"
+  }
+}

--- a/packages/universal-nav/src/htm/.browserslistrc
+++ b/packages/universal-nav/src/htm/.browserslistrc
@@ -1,0 +1,1 @@
+last 2 versions

--- a/packages/universal-nav/src/htm/.postcssrc
+++ b/packages/universal-nav/src/htm/.postcssrc
@@ -1,0 +1,8 @@
+{
+  "modules": true,
+  "plugins": {
+    "autoprefixer": {
+      "grid": true
+    }
+  }
+}

--- a/packages/universal-nav/src/htm/Navbar.js
+++ b/packages/universal-nav/src/htm/Navbar.js
@@ -1,0 +1,34 @@
+import { html } from './html.js'
+import PropTypes from 'prop-types'
+import styles from './styles.css'
+console.log(styles)
+
+/**
+ * TODO: how to work with forwardRef
+ * Do all frameworks use className?
+ *  */
+
+const Slots = ({ brand, items, user, utility, onMobileMenuClick }) =>
+  html`
+    <div className="${styles['psds-navbar__mobile-menu']}">
+      ${onMobileMenuClick}
+    </div>
+    <div class="${styles['psds-navbar__brand']}">${brand}</div>
+    <div class="${styles['psds-navbar__items']}">${items}</div>
+    <div class="${styles['psds-navbar__utility']}">${utility}</div>
+    <div class="${styles['psds-navbar__user']}">${user}</div>
+  `
+
+export const Navbar = props => html`
+  <nav className="${styles['psds-navbar']}">
+    <${Slots} ...${props} />
+  </nav>
+`
+
+Slots.propTypes = {
+  brand: PropTypes.node,
+  items: PropTypes.node,
+  onMobileMenuClick: PropTypes.func,
+  utility: PropTypes.node,
+  user: PropTypes.node
+}

--- a/packages/universal-nav/src/htm/html.js
+++ b/packages/universal-nav/src/htm/html.js
@@ -1,0 +1,7 @@
+import htm from 'htm'
+import { createElement } from 'react'
+
+// We could use some enviormental variable to toggle this?
+export const html = htm.bind(createElement)
+
+export const h = createElement

--- a/packages/universal-nav/src/htm/index.js
+++ b/packages/universal-nav/src/htm/index.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import PropTypes from 'prop-types'
+import { colorsPink, layout } from '@pluralsight/ps-design-system-core'
+
+import { Navbar } from './Navbar.js'
+
+var mountNode = document.getElementById('main')
+
+function Filler(props) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: colorsPink.base,
+        height: '100%',
+        border: `2px dashed ${colorsPink.base}`,
+        padding: `0 ${layout.spacingMedium}`
+      }}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+Filler.propTypes = {
+  children: PropTypes.node
+}
+
+ReactDOM.render(
+  <Navbar
+    brand={<Filler>Brand</Filler>}
+    items={<Filler>Items</Filler>}
+    user={<Filler>User</Filler>}
+    utility={<Filler>Utility</Filler>}
+  />,
+  mountNode
+)

--- a/packages/universal-nav/src/htm/styles.css
+++ b/packages/universal-nav/src/htm/styles.css
@@ -1,0 +1,24 @@
+.psds-navbar {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 56px;
+  padding: 8px;
+  background: #181c20;
+  border-bottom: 1px solid #1e2429;
+  box-shadow: rgba(0, 0, 0, 0.5) 0 0 8px 0;
+}
+.psds-navbar__brand {
+  margin-right: 16px;
+}
+.psds-navbar__items {
+  flex: 1;
+  margin-right: 24px;
+}
+.psds-navbar__mobile-menu {
+  margin-right: 4px;
+}
+.psds-navbar__utility {
+  margin-left: auto;
+  margin-right: 4px;
+}

--- a/packages/universal-nav/src/html/Navbar.js
+++ b/packages/universal-nav/src/html/Navbar.js
@@ -1,0 +1,28 @@
+import { createPortal } from 'react-dom'
+import PropTypes from 'prop-types'
+
+export const callAll = (...fns) => fns.filter(Boolean).forEach(fn => fn && fn())
+
+export const Navbar = ({ brand, items, user, utility, onMobileMenuClick }) => {
+  return [
+    brand && createPortal(brand, document.querySelector('.psds-navbar__brand')),
+    items && createPortal(items, document.querySelector('.psds-navbar__items')),
+    user && createPortal(user, document.querySelector('.psds-navbar__user')),
+    utility &&
+      createPortal(utility, document.querySelector('.psds-navbar__utility')),
+    onMobileMenuClick &&
+      createPortal(
+        onMobileMenuClick,
+        document.querySelector('.psds-navbar__utility')
+      )
+  ].filter(Boolean)
+}
+
+Navbar.displayName = 'Navbar'
+Navbar.propTypes = {
+  brand: PropTypes.node,
+  items: PropTypes.node,
+  onMobileMenuClick: PropTypes.func,
+  utility: PropTypes.node,
+  user: PropTypes.node
+}

--- a/packages/universal-nav/src/html/index.js
+++ b/packages/universal-nav/src/html/index.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import PropTypes from 'prop-types'
+import { colorsPink, layout } from '@pluralsight/ps-design-system-core'
+
+import { Navbar } from './Navbar.js'
+
+var mountNode = document.getElementById('main')
+
+function Filler(props) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: colorsPink.base,
+        height: '100%',
+        border: `2px dashed ${colorsPink.base}`,
+        padding: `0 ${layout.spacingMedium}`
+      }}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+Filler.propTypes = {
+  children: PropTypes.node
+}
+
+/**
+ * <div id="appShell">
+ *   <nav id="topNav">
+ *   <aside id="sideNav" />
+ * </div>
+ */
+
+/**
+ * useTemplate(state)
+ * remove append
+ */
+
+ReactDOM.render(
+  <Navbar
+    brand={<Filler>Brand</Filler>}
+    items={<Filler>Items</Filler>}
+    user={<Filler>User</Filler>}
+    utility={<Filler>Utility</Filler>}
+  />,
+  mountNode
+)

--- a/packages/universal-nav/src/html/style.css
+++ b/packages/universal-nav/src/html/style.css
@@ -1,0 +1,24 @@
+.psds-navbar {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 56px;
+  padding: 8px;
+  background: #181c20;
+  border-bottom: 1px solid #1e2429;
+  box-shadow: rgba(0, 0, 0, 0.5) 0 0 8px 0;
+}
+.psds-navbar__brand {
+  margin-right: 16px;
+}
+.psds-navbar__items {
+  flex: 1;
+  margin-right: 24px;
+}
+.psds-navbar__mobile-menu {
+  margin-right: 4px;
+}
+.psds-navbar__utility {
+  margin-left: auto;
+  margin-right: 4px;
+}

--- a/packages/universal-nav/src/index.html
+++ b/packages/universal-nav/src/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Markup split exploration</title>
+        <meta charset="utf-8">
+        <style>
+          .nav {
+            display: grid;
+            grid: auto / 1fr;
+            font-size: 20px;
+            line-height: 1.5;
+            row-gap: 12px;
+          }
+          .link {
+            width: 450px;
+            padding: 8px;
+            border: 1px solid rebeccapurple;
+          }
+        </style>
+    </head>
+    <body>
+      <nav class="nav">
+        <a class="link" href="./oldschool.html">vanilla html (portals)</a>
+        <a class="link" href="./templateliteral.html">template literals (htm library)</a>
+        <a class="link" href="./webcomponent.html">web component (declarative styles and structure only)</a>
+      </nav>  
+    </body>
+</html>

--- a/packages/universal-nav/src/oldschool.html
+++ b/packages/universal-nav/src/oldschool.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Empty project</title>
+        <meta charset="utf-8">
+        <link rel="stylesheet" href="./html/style.css"/>
+    </head>
+    <body>
+        <nav class="psds-navbar">
+        <div class="psds-navbar__mobile-menu">
+        </div>
+        <div class="psds-navbar__brand"></div>
+        <div class="psds-navbar__items"></div>
+        <div class="psds-navbar__utility"></div>
+        <div class="psds-navbar__user"></div>
+        </nav>
+        <div id="main"></div>
+        <script src="./html/index.js"></script>
+    </body>
+</html>

--- a/packages/universal-nav/src/templateliteral.html
+++ b/packages/universal-nav/src/templateliteral.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Empty project</title>
+        <meta charset="utf-8">
+    </head>
+    <body>
+        <div id="main"></div>
+        <script src="./htm/index.js"></script>
+    </body>
+</html>

--- a/packages/universal-nav/src/webcomponent.html
+++ b/packages/universal-nav/src/webcomponent.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Empty project</title>
+        <meta charset="utf-8">
+        <link rel="stylesheet" href="./webcomponent/style.css"/>
+        <script type="module" src="./webcomponent/registry.js"></script>
+    </head>
+    <body>
+        <div id="main"></div>
+        <script src="./webcomponent/index.js"></script>
+    </body>
+</html>

--- a/packages/universal-nav/src/webcomponent/Nav.js
+++ b/packages/universal-nav/src/webcomponent/Nav.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { colorsPink, layout } from '@pluralsight/ps-design-system-core'
+import { Navbar } from './registry.js'
+function Filler(props) {
+  return (
+    <div
+      slot={props.slot}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: colorsPink.base,
+        height: '100%',
+        border: `2px dashed ${colorsPink.base}`,
+        padding: `0 ${layout.spacingMedium}`
+      }}
+    >
+      {props.children}
+    </div>
+  )
+}
+
+Filler.propTypes = {
+  children: PropTypes.node,
+  slot: PropTypes.string
+}
+export const Nav = () => (
+  <Navbar>
+    <Filler slot="brand">Brand</Filler>
+    <Filler slot="items">Items</Filler>
+    <Filler slot="utility">Utility</Filler>
+    <Filler slot="user">User</Filler>
+  </Navbar>
+)

--- a/packages/universal-nav/src/webcomponent/components/Navbar.js
+++ b/packages/universal-nav/src/webcomponent/components/Navbar.js
@@ -1,0 +1,22 @@
+import { element, html } from '../lib/index.js'
+
+export const Navbar = element(
+  'navbar',
+  html`
+    <div part="mobile-menu">
+      <slot name="mobile-menu"></slot>
+    </div>
+    <div part="brand">
+      <slot name="brand"></slot>
+    </div>
+    <div part="items">
+      <slot name="items"></slot>
+    </div>
+    <div part="utility">
+      <slot name="utility"></slot>
+    </div>
+    <div part="user">
+      <slot name="user"></slot>
+    </div>
+  `
+)

--- a/packages/universal-nav/src/webcomponent/components/index.js
+++ b/packages/universal-nav/src/webcomponent/components/index.js
@@ -1,0 +1,1 @@
+export { Navbar } from './Navbar.js'

--- a/packages/universal-nav/src/webcomponent/index.js
+++ b/packages/universal-nav/src/webcomponent/index.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { Nav } from './Nav.js'
+
+var mountNode = document.getElementById('main')
+ReactDOM.render(<Nav />, mountNode)

--- a/packages/universal-nav/src/webcomponent/lib/createComponent.js
+++ b/packages/universal-nav/src/webcomponent/lib/createComponent.js
@@ -1,0 +1,4 @@
+import { createElement } from 'react'
+
+export const createComponent = tag => props =>
+  createElement(tag, props, ...props.children)

--- a/packages/universal-nav/src/webcomponent/lib/createTemplate.js
+++ b/packages/universal-nav/src/webcomponent/lib/createTemplate.js
@@ -1,0 +1,6 @@
+/** @param  {...string} strings */
+export const createTemplate = (...strings) => {
+  const template = document.createElement('template')
+  template.innerHTML = strings.filter(Boolean).join('')
+  return template
+}

--- a/packages/universal-nav/src/webcomponent/lib/element.js
+++ b/packages/universal-nav/src/webcomponent/lib/element.js
@@ -1,0 +1,45 @@
+import { createTemplate } from './createTemplate.js'
+import { shadowReset } from './shadowReset.js'
+import { createComponent } from './createComponent.js'
+/**
+ * @param {String} tag
+ * @param {String} template
+ * @param {CustomElementConstructor} base
+ * @param {Object} options
+ * @param {string} [options.mode=open]
+ * @param {Boolean} [options.delegatesFocus=undefined]
+ * @param {Boolean} [options.shadow=true]
+ * @example
+ * const MyElement = element(
+ *  'component',
+ *  html`${my template}`,
+ * )
+ */
+
+export const element = (
+  tag,
+  template,
+  { mode = 'open', delegatesFocus } = {}
+) => {
+  /**
+   *
+   * @param {Object<string, string|number|boolean>} attrs
+   * @param  {...string} children
+   */
+  // eslint-disable-next-line react/prop-types
+  const prefixedTag = `psds-${tag}`
+
+  const component = createComponent(prefixedTag)
+
+  if (customElements.get(prefixedTag)) return component
+  class Element extends HTMLElement {
+    constructor() {
+      super()
+      this.attachShadow({ mode, delegatesFocus })
+      const fragment = createTemplate(`<style>${shadowReset}</style>`, template)
+      this.shadowRoot.appendChild(fragment.content.cloneNode(true))
+    }
+  }
+  customElements.define(prefixedTag, Element)
+  return component
+}

--- a/packages/universal-nav/src/webcomponent/lib/html.js
+++ b/packages/universal-nav/src/webcomponent/lib/html.js
@@ -1,0 +1,33 @@
+/**
+ * @description
+ * Tagged template function for making strings of html.
+ * Good for either server side rendering or inside web components
+ * in conjunction with or without tpl function
+ * @param {string} literalSections
+ * @param {expression}
+ * @return {string}
+ */
+const reduceWhitespace = str => str.replace(/(\s\s+|\n)/g, ' ')
+export const html = (literalSections, ...substs) => {
+  /**
+   * @constant
+   * @type {{raw:[...string]}}
+   */
+  const { raw } = literalSections
+  const result = substs.reduce((acc, cur, i) => {
+    acc.push(reduceWhitespace(raw[i]))
+    const string = Array.isArray(cur) ? cur.filter(Boolean).join('') : cur
+    acc.push(string)
+    return acc
+  }, [])
+  result.push(reduceWhitespace(raw[raw.length - 1]))
+  return result
+    .filter(val => val !== undefined)
+    .join('')
+    .trim()
+    .replace(/\s>/g, '>')
+    .replace(/>\s</g, '><')
+    .replace(/(>)(\s)(\S)/g, (match, p1, p2, p3) => [p1, p3].join(''))
+    .replace(/(\S)(\s)(<)/g, (match, p1, p2, p3) => [p1, p3].join(''))
+  // .replace(/[\t\r\n]+/g, ' ')
+}

--- a/packages/universal-nav/src/webcomponent/lib/index.js
+++ b/packages/universal-nav/src/webcomponent/lib/index.js
@@ -1,0 +1,2 @@
+export { element } from './element.js'
+export { html } from './html.js'

--- a/packages/universal-nav/src/webcomponent/lib/shadowReset.js
+++ b/packages/universal-nav/src/webcomponent/lib/shadowReset.js
@@ -1,0 +1,3 @@
+export const shadowReset =
+  // eslint-disable-next-line max-len
+  '::-webkit-scrollbar{display: none;} *,*:before,*:after{box-sizing:border-box;} :host{contain: content;} :host([hidden]),:host(:not(:defined)){display: none;}'

--- a/packages/universal-nav/src/webcomponent/registry.js
+++ b/packages/universal-nav/src/webcomponent/registry.js
@@ -1,0 +1,1 @@
+export { Navbar } from './components/index.js'

--- a/packages/universal-nav/src/webcomponent/style.css
+++ b/packages/universal-nav/src/webcomponent/style.css
@@ -1,0 +1,24 @@
+psds-navbar {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 56px;
+  padding: 8px;
+  background: #181c20;
+  border-bottom: 1px solid #1e2429;
+  box-shadow: rgba(0, 0, 0, 0.5) 0 0 8px 0;
+}
+psds-navbar::part(brand) {
+  margin-right: 16px;
+}
+psds-navbar::part(items) {
+  flex: 1;
+  margin-right: 24px;
+}
+psds-navbar::part(mobile-menu) {
+  margin-right: 4px;
+}
+psds-navbar::part(utility) {
+  margin-left: auto;
+  margin-right: 4px;
+}


### PR DESCRIPTION
# Findings

Three approaches were tried: 
1. **vanilla html** combined with the portal feature which is present in most modern ui libraries.
2. **template literals** using [htm](https://github.com/developit/htm)
3. **web components** for style and structure only, **no state or interaction. Uses tiny micro utils from previous open source work by @EdwardIrby.

## Vanilla HTML

In this approach we acknowledge the Nav and app shell are static and thus can be built into the index.html in a given PXT's Webpack/parcel/next/CRA setup. Then dynamic content can be rendered to the Nav using the portal like features available in modern UI libraries.  

### Pro's
Old school and simple

### Con's
- So old school most us might have forgot how to do this. 
- Varied project configs means lots of troubleshooting at onset of usage.

## Template literals

In this approach we use template literals native to javascript in combination with htm a library that allows UI libraries supporting the hyperscript pattern to share the same component code.

### Pro's
- At the atomic level is great for things like react, vue, preact, and hyperapp.

### Con's
- Can't figure out how to account for forwardRef as it changes the function signature
- Must put keys on fragment direct children and linter does not catch this or proptype errors.
- class and className are not universal across UI libraries

### Web component

In this approach we acknowledge that while we still use React non-scalar data and imperative apis on web components can not be used with react. (See https://custom-elements-everywhere.com/) We'd have to result to using useEffect and DOM API's to get expected behavior for interactivity. (See https://stenciljs.com/docs/react)  However if it's just structure and styling then we can split this out atomically using web components. 

## Pro's
- future proof
- Framework/Library agnostic

## Con's
- Needs polyfills for ie11
- may require rethinking our styling practices such as using css files again, a mix of css and glamour, or a build step that auto-injects styles and generates a root stylesheet for variables.

# Run
Navigate to `packages/universal-nav`
run `npm start`


---
resolves #1037


