### PR TITLE
NavItem MarginTop

### DIFF
--- a/packages/navitem/src/css/index.js
+++ b/packages/navitem/src/css/index.js
@@ -150,7 +150,13 @@ export default {
 
   // vert
   '.psds-navitem__vert-container': {
-    display: 'inline-block'
+    display: 'inline-block',
+    marginTop: layout.spacingXXSmall,
+
+    '& a, & button': {
+      paddingTop: '6px',
+      paddingBottom: '6px'
+    }
   },
   '.psds-navitem__vert-caret': {
     position: 'absolute',

--- a/packages/navitem/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
+++ b/packages/navitem/src/react/__specs__/__snapshots__/storyshots.spec.js.snap
@@ -561,7 +561,7 @@ exports[`Storyshots NavItem vertical 1`] = `
   <span
     className={
       Object {
-        "data-css-w0yocm": "",
+        "data-css-1kfj35d": "",
       }
     }
   >
@@ -625,7 +625,7 @@ exports[`Storyshots NavItem vertical 1`] = `
   <span
     className={
       Object {
-        "data-css-w0yocm": "",
+        "data-css-1kfj35d": "",
       }
     }
   >
@@ -690,7 +690,7 @@ exports[`Storyshots NavItem vertical 1`] = `
   <span
     className={
       Object {
-        "data-css-w0yocm": "",
+        "data-css-1kfj35d": "",
       }
     }
   >
@@ -775,7 +775,7 @@ exports[`Storyshots NavItem vertical 1`] = `
   <span
     className={
       Object {
-        "data-css-w0yocm": "",
+        "data-css-1kfj35d": "",
       }
     }
   >
@@ -839,7 +839,7 @@ exports[`Storyshots NavItem vertical 1`] = `
   <span
     className={
       Object {
-        "data-css-w0yocm": "",
+        "data-css-1kfj35d": "",
       }
     }
   >
@@ -903,7 +903,7 @@ exports[`Storyshots NavItem vertical 1`] = `
   <span
     className={
       Object {
-        "data-css-w0yocm": "",
+        "data-css-1kfj35d": "",
       }
     }
   >
@@ -967,7 +967,7 @@ exports[`Storyshots NavItem vertical 1`] = `
   <span
     className={
       Object {
-        "data-css-w0yocm": "",
+        "data-css-1kfj35d": "",
       }
     }
   >


### PR DESCRIPTION
Dunno if this changed in figma after the initial implementation or if it was mistranslated originally.  Anyway, now figma is showing navitem with marginTop 4px. This intros that. Should help with vertical centering w/in a navbar.
