### PR TITLE
fix(actionmenu): proptype on menu loosened

### DIFF
--- a/packages/actionmenu/package.json
+++ b/packages/actionmenu/package.json
@@ -24,7 +24,6 @@
     "@pluralsight/ps-design-system-core": "^6.4.0",
     "@pluralsight/ps-design-system-filter-react-props": "^1.1.18",
     "@pluralsight/ps-design-system-icon": "^18.1.8",
-    "@pluralsight/ps-design-system-prop-types": "^2.0.18",
     "@pluralsight/ps-design-system-util": "^4.0.1",
     "exenv": "^1.2.2",
     "glamorous": "^5.0.0",

--- a/packages/actionmenu/src/react/index.js
+++ b/packages/actionmenu/src/react/index.js
@@ -1,5 +1,3 @@
-import { elementOfType } from '@pluralsight/ps-design-system-prop-types'
-
 import PropTypes from 'prop-types'
 
 import { ActionMenu } from './menu.js'
@@ -18,11 +16,8 @@ ActionMenu.origins = vars.origins
 ActionMenu.tagName = vars.tagName
 ActionMenu.propTypes = {
   children: PropTypes.oneOfType([
-    elementOfType(Item),
-    elementOfType(Divider),
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([elementOfType(Item), elementOfType(Divider)])
-    )
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node)
   ]),
   onClose: PropTypes.func,
   origin: PropTypes.string,


### PR DESCRIPTION
Fix the following proptype warning``Failed prop type: Invalid prop `children` supplied to `ActionMenu.Menu`.``