### PR TITLE
dialog: allow users to change styling of content div

### DIFF
--- a/packages/dialog/src/react/index.js
+++ b/packages/dialog/src/react/index.js
@@ -27,7 +27,8 @@ const styles = {
           stylesheet[`.psds-dialog--tailPosition-${tailPosition}`]
         )
     ),
-  content: () => css(stylesheet['.psds-dialog__content']),
+  content: contentStyles =>
+    css(compose(stylesheet['.psds-dialog__content'], contentStyles)),
   close: _ => css(stylesheet['.psds-dialog__close']),
   overlay: _ => css(stylesheet['.psds-dialog__overlay'])
 }
@@ -56,7 +57,7 @@ const Dialog = React.forwardRef((props, ref) => {
       ref={ref}
     >
       <Theme name={Theme.names.light}>
-        <div {...styles.content()}>
+        <div {...styles.content(props.contentStyles)}>
           {!props.disableCloseButton && isFunction(props.onClose) && (
             <CloseButton onClick={props.onClose} />
           )}
@@ -95,7 +96,8 @@ Dialog.propTypes = {
   modal: PropTypes.bool,
   onClose: PropTypes.func,
   tailPosition: PropTypes.oneOf(Object.values(Dialog.tailPositions)),
-  returnFocus: PropTypes.bool
+  returnFocus: PropTypes.bool,
+  contentStyles: PropTypes.object
 }
 
 Dialog.defaultProps = {


### PR DESCRIPTION
## Instructions

- fill in title: format of "<package name>: short description"
- label: attach bug or enhancement request label

### What You're Solving

- Flow designers are requesting the usage of different margins and paddings on dialog boxes. This will allow us to change styling of the inner content div created by the dialog component.

### Design Decisions

This seems like a pretty straightforward change, but am definitely open to suggestions.

### How to Verify

- Steps needed to independently verify additions

1. Create a dialog component with some content
2. Observe that margins are something like 24px.
3. Add a prop, `contentStyles={{ margin: 0 }}`
4. The inner content div rendered by the component should compose a new CSS class and assign it to the dialog contents div. 