### PR TITLE
Example switcher

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1330,6 +1330,16 @@
         }
       }
     },
+    "@github-docs/frontmatter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@github-docs/frontmatter/-/frontmatter-1.3.1.tgz",
+      "integrity": "sha512-1BFouSuheb7GelUDlLmv/Qrpi8Ybtyfch91grZbqx+aGzDEh7CAna+mAHIYaaN3HppNB8JnppGvX2DXM4v0pzQ==",
+      "requires": {
+        "gray-matter": "^4.0.2",
+        "lodash": "^4.17.15",
+        "revalidator": "^0.3.1"
+      }
+    },
     "@graphql-tools/schema": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-6.2.0.tgz",
@@ -11987,7 +11997,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.2.tgz",
       "integrity": "sha512-7hB/+LxrOjq/dd8APlK0r24uL/67w7SkYnfwhNFwg/VDIGWGmduTDYf3WNstLW2fbbmRwrDGCVSJ2isuf2+4Hw==",
-      "dev": true,
       "requires": {
         "js-yaml": "^3.11.0",
         "kind-of": "^6.0.2",
@@ -13615,8 +13624,7 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -14212,8 +14220,7 @@
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "kleur": {
       "version": "3.0.3",
@@ -20491,6 +20498,11 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
+    "revalidator": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.3.1.tgz",
+      "integrity": "sha1-/yzEz3zHxjhaxxAXgnbm280Ddi8="
+    },
     "rgb-regex": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -20629,7 +20641,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
       "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "kind-of": "^6.0.0"
@@ -20639,7 +20650,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -21957,8 +21967,7 @@
     "strip-bom-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
-      "dev": true
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
     },
     "strip-eof": {
       "version": "1.0.0",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1769,6 +1769,20 @@
         }
       }
     },
+    "@pluralsight/ps-design-system-actionmenu": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@pluralsight/ps-design-system-actionmenu/-/ps-design-system-actionmenu-15.0.1.tgz",
+      "integrity": "sha512-fqe3sOrFyY4vwweByKQP3GeUJdX26ewiOkEMhMA16K4cThWVQykQUgPahqqeYKGvC+/C/aeUkWWWqjBXynX7dQ==",
+      "requires": {
+        "@pluralsight/ps-design-system-core": "^6.4.0",
+        "@pluralsight/ps-design-system-filter-react-props": "^1.1.18",
+        "@pluralsight/ps-design-system-icon": "^18.2.1",
+        "@pluralsight/ps-design-system-util": "^5.0.1",
+        "exenv": "^1.2.2",
+        "glamorous": "^5.0.0",
+        "prop-types": "^15.7.2"
+      }
+    },
     "@pluralsight/ps-design-system-badge": {
       "version": "10.0.18",
       "resolved": "https://registry.npmjs.org/@pluralsight/ps-design-system-badge/-/ps-design-system-badge-10.0.18.tgz",
@@ -1858,6 +1872,21 @@
         }
       }
     },
+    "@pluralsight/ps-design-system-dropdown": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@pluralsight/ps-design-system-dropdown/-/ps-design-system-dropdown-9.0.1.tgz",
+      "integrity": "sha512-gf289neVgxaCkncaW2w9J75QQazpE8ZwVeP7SAD7wcYxWs1/BCbWj4HsWD1dinEYwRvvHuGcmytqpndRd9SfUA==",
+      "requires": {
+        "@pluralsight/ps-design-system-actionmenu": "^15.0.1",
+        "@pluralsight/ps-design-system-core": "^6.4.0",
+        "@pluralsight/ps-design-system-filter-react-props": "^1.1.18",
+        "@pluralsight/ps-design-system-halo": "^7.0.11",
+        "@pluralsight/ps-design-system-icon": "^18.2.1",
+        "@pluralsight/ps-design-system-util": "^5.0.1",
+        "exenv": "^1.2.2",
+        "prop-types": "^15.7.2"
+      }
+    },
     "@pluralsight/ps-design-system-emptystate": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/@pluralsight/ps-design-system-emptystate/-/ps-design-system-emptystate-8.1.3.tgz",
@@ -1889,11 +1918,22 @@
         "react-html-attributes": "^1.4.6"
       }
     },
+    "@pluralsight/ps-design-system-halo": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@pluralsight/ps-design-system-halo/-/ps-design-system-halo-7.0.11.tgz",
+      "integrity": "sha512-nhKk2whGwK0S8P5+2naxm0dzfKoTJ7pbyQ5M/TUhQWXP6HjomoMl1+ilzZsUGsJfh6EYaUZEiQl0Yu2QYAgkmg==",
+      "requires": {
+        "@pluralsight/ps-design-system-core": "^6.4.0",
+        "@pluralsight/ps-design-system-filter-react-props": "^1.1.18",
+        "focus-within": "^3.0.2",
+        "hoist-non-react-statics": "^3.3.0",
+        "prop-types": "^15.7.2"
+      }
+    },
     "@pluralsight/ps-design-system-icon": {
       "version": "18.2.1",
       "resolved": "https://registry.npmjs.org/@pluralsight/ps-design-system-icon/-/ps-design-system-icon-18.2.1.tgz",
       "integrity": "sha512-A8ntydcci0fTYDPGKBtotL0HK3qZD4Qq40DEECIYOoW2J1IeKs4IrMzncdlXtb58wsn1rY06eUYp9WLTtVAXJw==",
-      "dev": true,
       "requires": {
         "@pluralsight/ps-design-system-core": "^6.4.0",
         "@pluralsight/ps-design-system-filter-react-props": "^1.1.18",
@@ -2019,7 +2059,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@pluralsight/ps-design-system-util/-/ps-design-system-util-5.0.1.tgz",
       "integrity": "sha512-yxDJZuK0sH1ep2EM3y+8aJZvjYufOvY2DC3lN/oZkK9Wh0Q2BNl2bObU+9/kydrRa7cCEtUdFjsWs3sNWOZ5rQ==",
-      "dev": true,
       "requires": {
         "exenv": "^1.2.2",
         "prop-types": "^15.7.2",
@@ -4460,6 +4499,11 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "brcast": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.2.tgz",
+      "integrity": "sha512-f5XwwFCCuvgqP2nMH/hJ74FqnGmb4X3D+NC//HphxJzzhsZvSZa+Hk/syB7j3ZHpPDLMoYU8oBgviRWfNvEfKA=="
     },
     "brorand": {
       "version": "1.1.0",
@@ -7164,8 +7208,7 @@
     "csstype": {
       "version": "2.6.13",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-      "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==",
-      "dev": true
+      "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -9547,6 +9590,14 @@
       "integrity": "sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw==",
       "dev": true
     },
+    "focus-within": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/focus-within/-/focus-within-3.0.2.tgz",
+      "integrity": "sha512-TMn2sLUwi02dSPElXFPyzBkiQN+Xo1oYta5Jd2zC54MQoBOCMht6xar7gJgw5a9+GtFxkG9c2k4ptI6cU37soA==",
+      "requires": {
+        "postcss": "^7.0.6"
+      }
+    },
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
@@ -11573,6 +11624,28 @@
         "through": "^2.3.8"
       }
     },
+    "glamorous": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/glamorous/-/glamorous-5.0.0.tgz",
+      "integrity": "sha512-ayP4ldvNHJNKSfJEERKNAvOmTKkQZliVK5AKUJwUU7YruhaCnlPrPsBUp6BBJgHQdI63Nda9Hn7HISlj+qiPkA==",
+      "requires": {
+        "brcast": "^3.0.0",
+        "csstype": "^2.2.0",
+        "fast-memoize": "^2.2.7",
+        "html-tag-names": "^1.1.1",
+        "is-function": "^1.0.1",
+        "is-plain-object": "^2.0.4",
+        "react-html-attributes": "^1.4.2",
+        "svg-tag-names": "^1.1.0"
+      },
+      "dependencies": {
+        "svg-tag-names": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/svg-tag-names/-/svg-tag-names-1.1.2.tgz",
+          "integrity": "sha512-LIDOy8NRLGfJegTEnpizWA/ofg3Gyx58JgPEEjvATFciUJW9dHZ2aPTYY0Mn2rQYCeUGZElpHfu91OcWK0IMIw=="
+        }
+      }
+    },
     "glob": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
@@ -12279,7 +12352,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -12375,8 +12447,7 @@
     "html-tag-names": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.5.tgz",
-      "integrity": "sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A==",
-      "dev": true
+      "integrity": "sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A=="
     },
     "html-void-elements": {
       "version": "1.0.5",
@@ -13558,6 +13629,11 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
+    "is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -13694,7 +13770,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -13872,8 +13947,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -17276,7 +17350,6 @@
       "version": "7.0.32",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
       "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-      "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -17286,14 +17359,12 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,6 +21,7 @@
     "start:dev": "npm run dev:gatsby"
   },
   "dependencies": {
+    "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
     "@pluralsight/ps-design-system-badge": "^10.0.18",

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,6 +24,7 @@
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
     "@pluralsight/ps-design-system-badge": "^10.0.18",
+    "@pluralsight/ps-design-system-dropdown": "^9.0.1",
     "@pluralsight/ps-design-system-layout": "^7.0.15",
     "@pluralsight/ps-design-system-table": "^9.0.11",
     "body-parser": "^1.19.0",

--- a/docs/src/components/mdx/code-block.module.css
+++ b/docs/src/components/mdx/code-block.module.css
@@ -1,14 +1,21 @@
 @import url('https://fonts.googleapis.com/css?family=Source+Code+Pro:500');
 
+.title {
+  display: flex;
+  align-items: center;
+
+  & > h2:first-child {
+    margin-right: var(--psLayoutSpacingLarge);
+  }
+}
+
 .codeBlock {
   border-radius: 0.2em;
   margin: 0 0 var(--psLayoutSpacingLarge) 0;
 }
-
 .dark {
   border: 1px solid var(--psColorsBorderLowOnDark);
 }
-
 .light {
   border: 1px solid var(--psColorsBorderLowOnLight);
 }
@@ -19,15 +26,12 @@
   height: 40px;
   padding: 0 var(--psLayoutSpacingXSmall);
 }
-
 .light .actions {
   background-color: var(--psColorsBackgroundLight1);
 }
-
 .dark .actions {
   background-color: var(--psColorsBackgroundDark1);
 }
-
 .actionsAlignRight {
   margin-left: auto;
 }

--- a/docs/src/components/mdx/code-block.tsx
+++ b/docs/src/components/mdx/code-block.tsx
@@ -1,4 +1,5 @@
 import Button from '@pluralsight/ps-design-system-button'
+import Dropdown from '@pluralsight/ps-design-system-dropdown'
 import Theme, { useTheme } from '@pluralsight/ps-design-system-theme'
 import cx from 'classnames'
 import Prism from 'prismjs/components/prism-core'
@@ -6,38 +7,65 @@ import Highlight, { PrismTheme, defaultProps } from 'prism-react-renderer'
 import React, { HTMLAttributes, useEffect, useState } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 
+import { H2 } from '../mdx'
 import styles from './code-block.module.css'
 import { darkTheme, lightTheme } from './code-block-theme'
 
 interface CodeBlockProps extends HTMLAttributes<HTMLDivElement> {
+  metastring?: null
   live?: boolean
 }
 
 export const CodeBlock: React.FC<CodeBlockProps> = (props) => {
-  const { children: code } = props
   const isSwitcher = /switcher/.test(props.metastring)
   const language = props.className.replace(/language-/, '')
 
+  const codes = props.children.split('\n\n---\n\n')
+  const options = isSwitcher
+    ? Array.from(Array(codes.length)).map((_, i) => ({
+        value: i,
+        label: 'Example #' + i,
+      }))
+    : [{ value: 0, label: 'Single example' }]
+
+  const [selectedOption, setSelectedOption] = React.useState(options[0].value)
+
   if (isSwitcher) {
-    const codes = props.children.split('\n\n---\n\n')
     return (
       <div>
-        All the codes
+        <div className={styles.title}>
+          <H2>Examples</H2>
+          <Dropdown
+            onChange={(evt, value, label) => setSelectedOption(value)}
+            menu={options.map((opt) => (
+              <Dropdown.Item key={opt.value} value={opt.value}>
+                {opt.label}
+              </Dropdown.Item>
+            ))}
+            value={selectedOption}
+          />
+        </div>
         <div>
-          {codes.map((code, i) => (
-            <Example
-              key={i}
-              language={language}
-              code={code}
-              className={props.className}
-            />
-          ))}
+          {codes.map((code, i) =>
+            i === selectedOption ? (
+              <Example
+                key={i}
+                language={language}
+                code={code}
+                className={props.className}
+              />
+            ) : null
+          )}
         </div>
       </div>
     )
   } else {
     return (
-      <Example language={language} className={props.className} code={code} />
+      <Example
+        language={language}
+        className={props.className}
+        code={codes[0]}
+      />
     )
   }
 }

--- a/docs/src/components/mdx/code-block.tsx
+++ b/docs/src/components/mdx/code-block.tsx
@@ -15,8 +15,38 @@ interface CodeBlockProps extends HTMLAttributes<HTMLDivElement> {
 
 export const CodeBlock: React.FC<CodeBlockProps> = (props) => {
   const { children: code } = props
+  const isSwitcher = /switcher/.test(props.metastring)
   const language = props.className.replace(/language-/, '')
 
+  if (isSwitcher) {
+    const codes = props.children.split('\n\n---\n\n')
+    return (
+      <div>
+        All the codes
+        <div>
+          {codes.map((code, i) => (
+            <Example
+              key={i}
+              language={language}
+              code={code}
+              className={props.className}
+            />
+          ))}
+        </div>
+      </div>
+    )
+  } else {
+    return (
+      <Example language={language} className={props.className} code={code} />
+    )
+  }
+}
+
+interface ExampleProps {
+  code: string
+  language: string
+}
+const Example: React.FC<ExampleProps> = (props) => {
   const theme = useTheme()
   const isDarkTheme = theme === Theme.names.dark
   const codeTheme = isDarkTheme ? darkTheme : lightTheme
@@ -61,7 +91,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = (props) => {
           )}
 
           {!copied && (
-            <CopyToClipboard text={code} onCopy={handleCopy}>
+            <CopyToClipboard text={props.code} onCopy={handleCopy}>
               <Button
                 appearance={Button.appearances.flat}
                 size={Button.sizes.xSmall}
@@ -73,8 +103,8 @@ export const CodeBlock: React.FC<CodeBlockProps> = (props) => {
         </div>
       </Actions>
 
-      <Editor language={language} theme={codeTheme}>
-        {code}
+      <Editor language={props.language} theme={codeTheme}>
+        {props.code}
       </Editor>
     </div>
   )
@@ -93,16 +123,13 @@ interface EditorProps extends HTMLAttributes<HTMLPreElement> {
   language: string
   theme: PrismTheme
 }
-
 const Editor: React.FC<EditorProps> = (props) => {
-  const { language, theme } = props
-
   return (
     <Highlight
       {...defaultProps}
       code={props.children}
-      language={language}
-      theme={theme}
+      language={props.language}
+      theme={props.theme}
     >
       {(highlight) => {
         const { tokens, getLineProps, getTokenProps } = highlight

--- a/docs/src/components/mdx/code-block.tsx
+++ b/docs/src/components/mdx/code-block.tsx
@@ -31,7 +31,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = (props) => {
   })
 
   const [selectedOption, setSelectedOption] = React.useState(
-    'value' + examples[1].i
+    'value' + examples[0].i
   )
 
   if (isSwitcher) {

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -31,6 +31,13 @@ export default Example
 
 ---
 
+/*
+ * For now, the description can live in a code block.
+ * 
+ * If we don't put this in markdown, we will be authoring in .tsx instead of .mdx.
+ * 
+ * Later, we can update code-block.tsx to extract these, parse markdown and display as html
+ */
 import React from 'react'
 
 // comment here

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -15,6 +15,10 @@ Hello, I'm a mdx file!
 This is `inlineCode`.
 
 ```typescript switcher
+---
+title: First Vanilla
+description: Some good descriptionaires here
+---
 import React from 'react'
 
 // comment here
@@ -31,13 +35,10 @@ export default Example
 
 ---
 
-/*
- * For now, the description can live in a code block.
- * 
- * If we don't put this in markdown, we will be authoring in .tsx instead of .mdx.
- * 
- * Later, we can update code-block.tsx to extract these, parse markdown and display as html
- */
+---
+title: Title of Num 2, Yo
+description: You want this, you really do.  Take care of it. Make sure that it's there.
+---
 import React from 'react'
 
 // comment here
@@ -53,10 +54,4 @@ const Example: React.FC = () => {
 export default Example
 ```
 
-
-```typescript
-const asdf = 'I am alone'
-
-export asdf
-````
 

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -14,35 +14,7 @@ Hello, I'm a mdx file!
 
 This is `inlineCode`.
 
-```
-Code block vanilla for now.
-```
-
-<Guideline
-  do={
-    <div>do this</div>
-  }
-  dont={
-    <div>don't do this</div>
-  }
-/>
-
-## Types
-
-<Types.Table>
-  <Types.Prop name="Jake" required type="string" default="awesome" desc="That one guy">
-  </Types.Prop>
-</Types.Table>
-
-### Subheading
-
-<Types.Table>
-  <Types.Prop name="Jake" require type="string" default="awesome" desc="That one guy">
-  </Types.Prop>
-</Types.Table>
-
-
-```typescript
+```typescript switcher
 import React from 'react'
 
 // comment here
@@ -56,18 +28,28 @@ const Example: React.FC = () => {
 }
 
 export default Example
-```
 
-```typescript codesandbox=default
+---
+
 import React from 'react'
+
+// comment here
 
 const Example: React.FC = () => {
   return (
     <div>
-      <p>hello world from typescript</p>
+      <p>222 hello world</p>
     </div>
   )
 }
 
 export default Example
 ```
+
+
+```typescript
+const asdf = 'I am alone'
+
+export asdf
+````
+


### PR DESCRIPTION
- Wanted to author in markdown since this is the common case for code authoring in docs
- Chose code block in markdown because it allows an opening and closing symbol
-  Chose a --- / hr symbol to split examples
- Downside to markdown is lack of rich data structure. Best idea so far: in a following PR, parse jsdocs for each example to parse out title and description