### PR TITLE
Docs/badge

### DIFF
--- a/docs/src/components/mdx/code-block.module.css
+++ b/docs/src/components/mdx/code-block.module.css
@@ -53,6 +53,7 @@
   height: auto;
   max-height: var(--psLayoutSpacingXXLarge);
   transition: max-height var(--psMotionSpeedSlow) ease-out;
+  overflow-y: hidden;
 }
 .editorExpanded {
   /* large number so we have something to animate to */

--- a/docs/src/components/mdx/code-block.tsx
+++ b/docs/src/components/mdx/code-block.tsx
@@ -1,6 +1,7 @@
 import Avatar from '@pluralsight/ps-design-system-avatar'
 import Carousel from '@pluralsight/ps-design-system-carousel'
 import Card from '@pluralsight/ps-design-system-card'
+import Badge from '@pluralsight/ps-design-system-badge'
 import Button from '@pluralsight/ps-design-system-button'
 import {
   CheckIcon,
@@ -369,6 +370,7 @@ export function formatPreview(code: string): PreviewData {
       '@pluralsight/ps-design-system-avatar': { Avatar },
       '@pluralsight/ps-design-system-carousel': { Carousel },
       '@pluralsight/ps-design-system-card': { Card },
+      '@pluralsight/ps-design-system-badge': { Badge },
       '@pluralsight/ps-design-system-button': { Button },
       '@pluralsight/ps-design-system-icon': {
         CheckIcon,

--- a/docs/src/components/side-nav/index.tsx
+++ b/docs/src/components/side-nav/index.tsx
@@ -77,6 +77,17 @@ const items = [
     ]
   },
   {
+      header: {
+        title: 'Navigation'
+      },
+      items: [
+        {
+          href: '/components/breadcrumb',
+          title: 'Breadcrumb'
+        }
+      ]
+    },
+      {
     header: {
       title: 'Actions'
     },
@@ -97,7 +108,18 @@ const items = [
         title: 'Avatar'
       }
     ]
-  }
+  },
+  {
+    header: {
+      title: 'Feedback'
+    },
+    items: [
+      {
+        href: '/components/badge',
+        title: 'Badge'
+      }
+    ]
+  },
 ]
 
 function Logo() {

--- a/docs/src/components/usage.module.css
+++ b/docs/src/components/usage.module.css
@@ -1,7 +1,7 @@
 .usage {
-  margin: var(--psLayoutSpacingLarge) 0;
+  margin: var(--psLayoutSpacingXLarge) 0;
   list-style: none;
-  font-size: var(--psTypeFontSizeXSmall);
+  font-size: var(--psTypeFontSizeSmall);
   line-height: 16px;
 }
 .item {
@@ -9,9 +9,24 @@
   margin-bottom: var(--psLayoutSpacingMedium);
 }
 .label {
-  width: 96px;
-  color: var(--psColorsTextIconLowOnLight);
+  font-size: var(--psTypeFontSizeXSmall);
+  width: 80px;
+
+  &.light {
+    color: var(--psColorsTextIconLowOnLight);
+  }
+  &.dark {
+    color: var(--psColorsTextIconLowOnDark);
+  }
 }
 .value {
   font-family: var(--psTypeFontFamilyCode);
+
+  &.light {
+    color: var(--psColorsTextIconHighOnLight);
+  }
+  &.dark {
+    color: var(--psColorsTextIconHighOnDark);
+  }
 }
+

--- a/docs/src/components/usage.tsx
+++ b/docs/src/components/usage.tsx
@@ -1,4 +1,6 @@
 import Link from '@pluralsight/ps-design-system-link'
+import Theme, { useTheme } from '@pluralsight/ps-design-system-theme'
+import cx from 'classnames'
 import React from 'react'
 
 import * as styles from './usage.module.css'
@@ -30,10 +32,25 @@ interface LabelProps {
   label: string
 }
 const Item: React.FC<LabelProps> = props => {
+  const themeName = useTheme()
   return (
     <li className={styles.item}>
-      <div className={styles.label}>{props.label}</div>
-      <div className={styles.value}>
+      <div
+        className={cx({
+          [styles.label]: true,
+          [styles.dark]: themeName === Theme.names.dark,
+          [styles.light]: themeName === Theme.names.light
+        })}
+      >
+        {props.label}
+      </div>
+      <div
+        className={cx({
+          [styles.value]: true,
+          [styles.dark]: themeName === Theme.names.dark,
+          [styles.light]: themeName === Theme.names.light
+        })}
+      >
         <code>{props.children}</code>
       </div>
     </li>

--- a/docs/src/global/style.css
+++ b/docs/src/global/style.css
@@ -6,12 +6,18 @@
 .example-grid {
   display: inline-grid;
   grid-template-columns: repeat(4, minmax(0, auto));
-  gap: var(--psLayoutSpacingLarge);
+  gap: var(--psLayoutSpacingMedium);
+  justify-items: start;
+}
+.example-grid--col-2 {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, auto));
+  gap: var(--psLayoutSpacingMedium);
   justify-items: start;
 }
 .example-grid--col-5 {
   display: inline-grid;
   grid-template-columns: repeat(5, minmax(0, auto));
-  gap: var(--psLayoutSpacingLarge);
+  gap: var(--psLayoutSpacingMedium);
   justify-items: start;
 }

--- a/docs/src/pages/components/badge.mdx
+++ b/docs/src/pages/components/badge.mdx
@@ -1,0 +1,54 @@
+---
+name: badge
+route: /components/badge
+---
+
+import Badge from '@pluralsight/ps-design-system-badge'
+
+import { Types, Usage } from '../../components/component'
+
+# Badge
+
+## Examples
+
+### Color
+
+Badges come in 5 colors and 2 appearances.
+
+```typescript
+import Badge from '@pluralsight/ps-design-system-badge'
+import React from 'react'
+
+function Example() {
+  return (
+    <div className="example-grid--col-2">
+      <Badge color={Badge.colors.gray}>Gray Badge</Badge>
+      <Badge color={Badge.colors.gray} appearance={Badge.appearances.subtle}>Gray Badge (Subtle)</Badge>
+      <Badge color={Badge.colors.green}>Green Badge</Badge>
+      <Badge color={Badge.colors.green} appearance={Badge.appearances.subtle}>Green Badge (Subtle)</Badge>
+      <Badge color={Badge.colors.yellow}>Yellow Badge</Badge>
+      <Badge color={Badge.colors.yellow} appearance={Badge.appearances.subtle}>Yellow Badge Subtle</Badge>
+      <Badge color={Badge.colors.red}>Red Badge</Badge>
+      <Badge color={Badge.colors.red} appearance={Badge.appearances.subtle}>Red Badge (Subtle)</Badge>
+      <Badge color={Badge.colors.blue}>Blue Badge</Badge>
+      <Badge color={Badge.colors.blue} appearance={Badge.appearances.subtle}>Blue Badge (Subtle)</Badge>
+    </div>
+  )
+}
+
+export default Example
+```
+
+## Usage & Types
+
+<Usage
+  install="npm install @pluralsight/ps-design-system-badge"
+  import="import Badge from '@pluralsight/ps-design-system-badge'"
+  packageName="badge"
+/>
+
+<Types.Table>
+  <Types.Prop name="appearance" type={<Types.Enum enum={Badge.appearances} />} desc="badge appearance (from Badge.appearances)" default="blue" />
+  <Types.Prop name="color" type={<Types.Enum enum={Badge.colors} />} desc="badge color (from Badge.colors)" default="blue" />
+</Types.Table>
+


### PR DESCRIPTION
- Add badge page
- Add dark theme support for usage text
- Add a 2 column example grid
- Prevent scroll on code editor (so you don't get hung up in collapsed editors)