### PR TITLE
feat(docs): change switcher delimiter

### DIFF
--- a/docs/src/components/code-block/examples.tsx
+++ b/docs/src/components/code-block/examples.tsx
@@ -123,7 +123,7 @@ export const Example: React.FC<ExampleProps> = props => {
 
 export function parceCode(
   code: string,
-  delimiter = '\n\n---\n\n'
+  delimiter = '\n\n===\n\n'
 ): ExampleData[] {
   return code.split(delimiter).map((str: string, index) => {
     const { content: code, data = {} } = frontmatter(str)

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -14,7 +14,7 @@ const Comp = React.FC = () => <p>example 1</p>
 
 export default Comp
 
----
+===
 
 ---
 title: some title 2


### PR DESCRIPTION
proposal: change the delimiter for segmenting examples in the code example switcher to be easy to read

`---` is used for frontmatter...so i'm thinking that `===` is different enough to make the codeblocks easier to understand

