### PR TITLE
strip example whitespace

### DIFF
--- a/docs/src/components/code-block/examples.tsx
+++ b/docs/src/components/code-block/examples.tsx
@@ -121,7 +121,7 @@ export const Example: React.FC<ExampleProps> = props => {
   )
 }
 
-export function parceCode(
+export function parseCode(
   code: string,
   delimiter = '\n\n---\n\n'
 ): ExampleData[] {

--- a/docs/src/components/code-block/examples.tsx
+++ b/docs/src/components/code-block/examples.tsx
@@ -126,7 +126,8 @@ export function parseCode(
   delimiter = '\n\n---\n\n'
 ): ExampleData[] {
   return code.split(delimiter).map((str: string, index) => {
-    const { content: code, data = {} } = frontmatter(str)
+    const { content = '', data = {} } = frontmatter(str)
+    const code = content.trim()
 
     const description = data.description || ''
     const title = data.title || `Example #${index}`

--- a/docs/src/components/code-block/index.tsx
+++ b/docs/src/components/code-block/index.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames'
 import React, { HTMLAttributes } from 'react'
 import { Language } from 'prism-react-renderer'
 
-import { ExamplesSwitcher, Example, parceCode } from './examples'
+import { ExamplesSwitcher, Example, parseCode } from './examples'
 import styles from './styles.module.css'
 
 interface CodeBlockProps extends HTMLAttributes<HTMLDivElement> {
@@ -26,7 +26,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = props => {
     props.className
   )
 
-  const examples = parceCode(children)
+  const examples = parseCode(children)
   const firstExample = examples[0]
 
   return (


### PR DESCRIPTION
just a small glow up that removes the trailing line in code examples

before:
![Screen Shot 2020-09-18 at 8 51 40 AM](https://user-images.githubusercontent.com/226356/93612373-a8be4180-f98c-11ea-8318-b200624f8220.png)

after:
![Screen Shot 2020-09-18 at 8 54 07 AM](https://user-images.githubusercontent.com/226356/93612379-a9ef6e80-f98c-11ea-9f23-6321ef72660e.png)




