### PR TITLE
fix heading alignment in example switcher

### DIFF
--- a/docs/src/components/code-block/examples.tsx
+++ b/docs/src/components/code-block/examples.tsx
@@ -8,10 +8,6 @@ import React, { HTMLAttributes, useState } from 'react'
 
 import { H2 } from '../mdx'
 
-import styles from './styles.module.css'
-import { Editor } from './editor'
-import { Preview } from './preview'
-
 import {
   Actions,
   ActionsLeft,
@@ -20,6 +16,9 @@ import {
   CodeSandboxAction,
   ExpandAction
 } from './actions'
+import { Editor } from './editor'
+import { Preview } from './preview'
+import styles from './styles.module.css'
 
 export interface ExampleData {
   code: string
@@ -45,8 +44,8 @@ export const ExamplesSwitcher: React.FC<ExamplesSwitcherProps> = props => {
 
   return (
     <div {...rest}>
-      <div className={styles.title}>
-        <H2>Examples</H2>
+      <header className={styles.header}>
+        <H2 className={styles.title}>Examples</H2>
 
         <Dropdown
           menu={examples.map(example => {
@@ -59,7 +58,7 @@ export const ExamplesSwitcher: React.FC<ExamplesSwitcherProps> = props => {
           onChange={handleDropdownChange}
           value={selectedOption}
         />
-      </div>
+      </header>
 
       <div>
         {examples

--- a/docs/src/components/code-block/styles.module.css
+++ b/docs/src/components/code-block/styles.module.css
@@ -1,10 +1,12 @@
 @import url('https://fonts.googleapis.com/css?family=Source+Code+Pro:500');
 
-.title {
+.header {
   display: flex;
   align-items: center;
-
-  & > h2:first-child {
+}
+.title {
+  &:not(.hack-to-make-more-specific) {
+    margin: 0;
     margin-right: var(--psLayoutSpacingLarge);
   }
 }

--- a/docs/src/components/mdx/index.module.css
+++ b/docs/src/components/mdx/index.module.css
@@ -1,3 +1,6 @@
+.h1 {
+  margin-top: 0;
+}
 .h2 {
   margin-top: 80px;
 }

--- a/docs/src/components/mdx/index.tsx
+++ b/docs/src/components/mdx/index.tsx
@@ -1,6 +1,7 @@
 import { MDXProvider as BaseProvider } from '@mdx-js/react'
 import Link from '@pluralsight/ps-design-system-link'
 import * as Text from '@pluralsight/ps-design-system-text'
+import cx from 'classnames'
 import React, { HTMLAttributes } from 'react'
 
 import { CodeBlock } from '../code-block'
@@ -13,23 +14,35 @@ export const A: React.FC<HTMLAttributes<HTMLAnchorElement>> = props => (
   </Link>
 )
 
-export const H1: React.FC<HTMLAttributes<HTMLHeadingElement>> = props => (
-  <Text.Heading size={Text.Heading.sizes.xLarge}>
-    <h1 {...props}>{props.children}</h1>
-  </Text.Heading>
-)
+export const H1: React.FC<HTMLAttributes<HTMLHeadingElement>> = props => {
+  const className = cx(styles.h1, props.className)
 
-export const H2: React.FC<HTMLAttributes<HTMLHeadingElement>> = props => (
-  <Text.Heading size={Text.Heading.sizes.large} className={styles.h2}>
-    <h2 {...props}>{props.children}</h2>
-  </Text.Heading>
-)
+  return (
+    <Text.Heading size={className}>
+      <h1 {...props}>{props.children}</h1>
+    </Text.Heading>
+  )
+}
 
-export const H3: React.FC<HTMLAttributes<HTMLHeadingElement>> = props => (
-  <Text.Heading size={Text.Heading.sizes.medium} className={styles.h3}>
-    <h3 {...props}>{props.children}</h3>
-  </Text.Heading>
-)
+export const H2: React.FC<HTMLAttributes<HTMLHeadingElement>> = props => {
+  const className = cx(styles.h2, props.className)
+
+  return (
+    <Text.Heading size={Text.Heading.sizes.large} className={className}>
+      <h2 {...props}>{props.children}</h2>
+    </Text.Heading>
+  )
+}
+
+export const H3: React.FC<HTMLAttributes<HTMLHeadingElement>> = props => {
+  const className = cx(styles.h3, props.className)
+
+  return (
+    <Text.Heading size={Text.Heading.sizes.medium} className={className}>
+      <h3 {...props}>{props.children}</h3>
+    </Text.Heading>
+  )
+}
 
 export const Ol: React.FC<HTMLAttributes<HTMLOListElement>> = props => (
   <Text.List type={Text.List.types.numbered} {...props} />


### PR DESCRIPTION
before:
![Screen Shot 2020-09-18 at 9 09 59 AM](https://user-images.githubusercontent.com/226356/93614452-64807080-f98f-11ea-9774-30643ab31f86.png)


after:
![Screen Shot 2020-09-18 at 9 12 35 AM](https://user-images.githubusercontent.com/226356/93614456-664a3400-f98f-11ea-9934-976812d3431d.png)
