### PR TITLE
verticaltabs: allow custom onClick on tier1 header

### DIFF
--- a/packages/verticaltabs/src/react/item.js
+++ b/packages/verticaltabs/src/react/item.js
@@ -87,7 +87,10 @@ const Item = forwardRef((props, ref) => {
 
   const [collapsed, setCollapsed] = React.useState(_collapsed)
 
-  const handleToggle = () => setCollapsed(!collapsed)
+  const handleHeaderClick = evt => {
+    setCollapsed(!collapsed)
+    if (typeof header.props.onClick === 'function') header.props.onClick(evt)
+  }
   const ListComp = collapsible ? CollapsibleList : List
 
   return (
@@ -101,7 +104,7 @@ const Item = forwardRef((props, ref) => {
           active,
           collapsed,
           collapsible,
-          ...(collapsible && { onClick: handleToggle })
+          ...(collapsible && { onClick: handleHeaderClick })
         })}
       </div>
 


### PR DESCRIPTION
### What You're Solving

- `onClick` functions set on `<VerticalTabs.Tier1.Header />` components are overridden if the tier is collapsible. This change calls the custom `onClick` if provided after toggling the tier.
- To get around this problem I'm currently using an `onClick` on the tier1 component itself but that gets called when the child nav items are clicked too. I only want it to be called when the tier is expanded/collapsed.

### How to Verify

- Add an onClick function to a collapsible tier1's header. Verify the fn gets called when clicking on the header.