### PR TITLE
Alternative approach to examples template selection

### DIFF
--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -49,7 +49,7 @@ exports.createPages = async ({ graphql, actions }) => {
   result.data.allMdx.edges.forEach(({ node }) => {
     createPage({
       path: node.fields.slug,
-      component: path.resolve(`./src/templates/page.tsx`),
+      component: chooseTemplate(node.fields.slug),
       context: {
         // NOTE: Data passed to context is available
         // in page queries as GraphQL variables.
@@ -57,4 +57,10 @@ exports.createPages = async ({ graphql, actions }) => {
       }
     })
   })
+}
+
+function chooseTemplate(slug) {
+  return slug.includes('examples')
+    ? path.resolve(`./src/templates/example-frame.tsx`)
+    : path.resolve(`./src/templates/page.tsx`)
 }

--- a/docs/src/components/frame/frame.tsx
+++ b/docs/src/components/frame/frame.tsx
@@ -53,9 +53,6 @@ export const Frame: React.FC<Props> = props => {
     [styles.light]: themeName === Theme.names.light
   })
 
-  /* const isExamplePage = window.location.pathname.includes('examples') */
-  /* if (isExamplePage) return <ExamplePage>{children}</ExamplePage> */
-
   return (
     <>
       <Helmet>

--- a/docs/src/components/frame/frame.tsx
+++ b/docs/src/components/frame/frame.tsx
@@ -53,8 +53,8 @@ export const Frame: React.FC<Props> = props => {
     [styles.light]: themeName === Theme.names.light
   })
 
-  const isExamplePage = window.location.pathname.includes('examples')
-  if (isExamplePage) return <ExamplePage>{children}</ExamplePage>
+  /* const isExamplePage = window.location.pathname.includes('examples') */
+  /* if (isExamplePage) return <ExamplePage>{children}</ExamplePage> */
 
   return (
     <>
@@ -108,19 +108,3 @@ const Main: React.FC = props => {
     />
   )
 }
-
-const ExamplePage: React.FC = props => (
-  <>
-    <Helmet>
-      <link
-        rel="stylesheet"
-        href="https://cloud.typography.com/6966154/6397212/css/fonts.css"
-      />
-      <script src="https://unpkg.com/iframe-resizer@4.2.11/js/iframeResizer.contentWindow.min.js" />
-    </Helmet>
-
-    <Theme name={Theme.names.light}>
-      <div className={styles.example} {...props} />
-    </Theme>
-  </>
-)

--- a/docs/src/templates/example-frame.module.css
+++ b/docs/src/templates/example-frame.module.css
@@ -1,0 +1,5 @@
+.example {
+  border-radius: 0.2em;
+  margin: var(--psLayoutSpacingMedium);
+  background: var(--psColorsWhite);
+}

--- a/docs/src/templates/example-frame.tsx
+++ b/docs/src/templates/example-frame.tsx
@@ -1,0 +1,46 @@
+import Theme from '@pluralsight/ps-design-system-theme'
+import { graphql } from 'gatsby'
+import { MDXRenderer } from 'gatsby-plugin-mdx'
+import React from 'react'
+import { Helmet } from 'react-helmet'
+
+import { MDXProvider } from '../components/mdx'
+import * as styles from './example-frame.module.css'
+
+export const query = graphql`
+  query($slug: String!) {
+    mdx(fields: { slug: { eq: $slug } }) {
+      body
+    }
+  }
+`
+
+interface ExampleFrameProps {
+  data: {
+    mdx: {
+      body: string
+    }
+  }
+}
+
+const ExampleFrame: React.FC<ExampleFrameProps> = props => {
+  return (
+    <MDXProvider>
+      <Helmet>
+        <link
+          rel="stylesheet"
+          href="https://cloud.typography.com/6966154/6397212/css/fonts.css"
+        />
+        <script src="https://unpkg.com/iframe-resizer@4.2.11/js/iframeResizer.contentWindow.min.js" />
+      </Helmet>
+
+      <Theme name={Theme.names.light}>
+        <div className={styles.example}>
+          <MDXRenderer>{props.data.mdx.body}</MDXRenderer>
+        </div>
+      </Theme>
+    </MDXProvider>
+  )
+}
+
+export default ExampleFrame


### PR DESCRIPTION
Just an idea. I like it better because it's not wrapped up in frame and doesn't use the window.location. And the *template* switching is where templates are first chosen, in createPage().