### PR TITLE
build: fix secvulns by forcing package resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
     "react-dom": "^16.8.6",
     "react-transition-group": "^4.4.1"
   },
+  "resolutions": {
+    "node-fetch": "^2.6.1",
+    "prismjs": "^1.21.0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.11.6",
     "@babel/core": "^7.11.6",


### PR DESCRIPTION
Seems to work.

`yarn audit` before is loud. After doesn't mention these two issues.

Not sure why GH mentions these two but not the others in yarn audit.
