### PR TITLE
refactor(docs): adjust max-width of main

### DIFF
--- a/docs/src/components/frame/frame.module.css
+++ b/docs/src/components/frame/frame.module.css
@@ -58,7 +58,7 @@
   overflow: auto;
   flex: 0 1 auto;
   margin: 0 auto;
-  max-width: 800px;
+  max-width: 1000px;
   padding: var(--psLayoutSpacingMedium) var(--psLayoutSpacingXLarge);
 }
 


### PR DESCRIPTION
Like Goldilocks, 1200 was too wide, 800 was too narrow, hoping 1000 is just right.