### PR TITLE
refactor(prop-types): change method of determining NODE_ENV to be compat with webpack5

### DIFF
--- a/packages/prop-types/index.js
+++ b/packages/prop-types/index.js
@@ -1,4 +1,4 @@
-const isProd = process && process.env && process.env.NODE_ENV === 'production'
-module.exports = isProd
-  ? require('./dist/stubs/index.js')
-  : require('./dist/index.js')
+module.exports =
+  process.env.NODE_ENV === 'production'
+    ? require('./dist/stubs/index.js')
+    : require('./dist/index.js')


### PR DESCRIPTION
refactor(prop-types): change method of determining NODE_ENV to be compat with webpack5

resolves #1327