### PR TITLE
build(errors): revert to using babel so we can use the import-all macro

### DIFF
--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -10,9 +10,9 @@
   "module": "dist/esm/index.js",
   "scripts": {
     "build": "run-s build:svg build:esm build:cjs build:css",
-    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
+    "build:cjs": "babel --extensions \".js,.ts,.tsx\" --root-mode upward src --out-dir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
-    "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
+    "build:esm": "cross-env ESM=true babel --extensions \".js,.ts,.tsx\" --root-mode upward src --out-dir dist/esm",
     "build:svg": "svgr --filename-case kebab --ext \"dist.js\" -d src/react/icons src/svg",
     "build:watch": "yarn build:js -- --watch",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
using babel is kind of a hack so we can fix the error and get a working package out. i'd like to double back soonish to convert this component to a ts only solution

resolves #1361