### PR TITLE
fix(docs): increase heading specificity

### DIFF
--- a/docs/src/components/mdx/index.module.css
+++ b/docs/src/components/mdx/index.module.css
@@ -16,7 +16,8 @@ main > .h3 {
   padding: var(--psLayoutSpacingXXSmall) 0 var(--psLayoutSpacingXXSmall)
     var(--psLayoutSpacingMedium);
 }
-.headingLink {
+
+:not(#fakeid-to-make-more-specific-than-glamor-styles) .headingLink {
   position: relative;
   color: inherit;
 


### PR DESCRIPTION
During the build, glamor and postcss are compiled and added to the initial html render in two different ways. postcss is reference through link in a css file. glamor includes it's styles in a style blob that is part of the initial render and they hydrated. because the heading style specificity is the same from the glamor heading style and postcss heading style override - the last style on the page wins. which happens to be the glamor style - which is incorrect.

there are a couple options to fix this:
- dump the gatsby plugins and build up our own ssr+babel+webpack configs for gatsby and babel
- create a postcss plugin that prepends a specifity increase hack to each postcss style
  - https://github.com/MadLittleMods/postcss-increase-specificity
- add a specifity hack to styles as needed.

i choose the third option for it's simplicity and because it has little unknown risks

fix #1381
