### PR TITLE
fix(docs): rm main body scrollbar

### DIFF
--- a/docs/src/components/frame/frame.module.css
+++ b/docs/src/components/frame/frame.module.css
@@ -55,6 +55,7 @@
 }
 
 .main {
+  overflow-x: auto;
   flex: 0 1 auto;
   margin: 0 auto;
   max-width: 1000px;

--- a/docs/src/components/frame/frame.module.css
+++ b/docs/src/components/frame/frame.module.css
@@ -55,10 +55,8 @@
 }
 
 .main {
-  overflow: auto;
   flex: 0 1 auto;
   margin: 0 auto;
   max-width: 1000px;
   padding: var(--psLayoutSpacingMedium) var(--psLayoutSpacingXLarge);
 }
-


### PR DESCRIPTION
Resolves #1399

Not sure why the overflow: auto was there.  Since I couldn't think of a good reason doesn't mean that there isn't one.  Anyone have some more context on this?
