### PR TITLE
render modal dialog in portal always

### DIFF
--- a/docs/src/content/components/dialog.mdx
+++ b/docs/src/content/components/dialog.mdx
@@ -168,7 +168,7 @@ When a modal Dialog (or non-modal Dialog) are shown on the screen, it will take 
 
 ```typescript
 import Button from '@pluralsight/ps-design-system-button'
-import { colorsBackgroundLight } from '@pluralsight/ps-design-system-core'
+import { colorsBackgroundLight, layout } from '@pluralsight/ps-design-system-core'
 import Dialog from '@pluralsight/ps-design-system-dialog'
 import { Heading } from '@pluralsight/ps-design-system-text'
 import React from 'react'
@@ -202,6 +202,17 @@ function Example() {
           </div>
         </Dialog>
       )}
+
+      <style jsx>{`
+        .buttons {
+          display: flex;
+          justify-content: flex-end;
+          margin-top: ${layout.spacingLarge};
+        }
+        .buttons > button:not(:last-child) {
+          margin-right: ${layout.spacingMedium};
+        }
+      `}</style>
     </>
   )
 }

--- a/packages/dialog/src/react/index.tsx
+++ b/packages/dialog/src/react/index.tsx
@@ -1,14 +1,15 @@
-import { StyleAttribute, compose, css, keyframes } from 'glamor'
-import React, { HTMLAttributes } from 'react'
-
 import FocusManager from '@pluralsight/ps-design-system-focusmanager'
 import Theme from '@pluralsight/ps-design-system-theme'
 import {
-  ValueOf,
   RefForwardingComponent,
+  ValueOf,
+  createUniversalPortal,
   isFunction,
-  stylesFor
+  stylesFor,
+  usePortal
 } from '@pluralsight/ps-design-system-util'
+import { StyleAttribute, compose, css, keyframes } from 'glamor'
+import React, { HTMLAttributes, MutableRefObject } from 'react'
 
 import stylesheet from '../css'
 import * as vars from '../vars'
@@ -119,6 +120,8 @@ const Dialog = React.forwardRef((props, ref) => {
   const trapped = !!modal || !!onClose
   const closeOnEscape = isFunction(onClose) && !disableCloseOnEscape
 
+  const portal = usePortal() as MutableRefObject<HTMLDivElement>
+
   // TODO: combine fns
   function handleKeyUp(evt: React.KeyboardEvent) {
     if (!isEscape(evt)) return
@@ -149,16 +152,21 @@ const Dialog = React.forwardRef((props, ref) => {
     </FocusManager>
   )
 
-  return modal ? (
-    <Overlay
-      aria-label={rest['aria-label']}
-      disableCloseOnOverlayClick={disableCloseOnOverlayClick}
-      onClose={onClose}
-    >
-      {content}
-    </Overlay>
-  ) : (
-    content
+  return (
+    <>
+      {modal
+        ? createUniversalPortal(
+            <Overlay
+              aria-label={rest['aria-label']}
+              disableCloseOnOverlayClick={disableCloseOnOverlayClick}
+              onClose={onClose}
+            >
+              {content}
+            </Overlay>,
+            portal.current
+          )
+        : content}
+    </>
   )
 }) as DialogComponent
 


### PR DESCRIPTION
Portal seems to makes sense for a modal always, right?

Fixes the problems of

- Modal overlay in docs (and hopefully everywhere else; seems like we've had reports of this being problematic due to avoiding z-index and style overriding being generally hard)
- Docs button row alignment

BREAKING CHANGE: Modal always renders in a portal. Made breaking change
since it's uncertain whether this change in layout will affect users
visually.

^ overkill?

Reported here:
https://pluralsight.slack.com/archives/C70HPSJPP/p1605227641202600
