### PR TITLE
fix(typeahead): allow selection with tab, enter and space keys

### DIFF
--- a/packages/typeahead/src/react/index.tsx
+++ b/packages/typeahead/src/react/index.tsx
@@ -40,7 +40,8 @@ interface TypeaheadProps
   onChange?: (
     evt:
       | React.FormEvent<HTMLInputElement>
-      | React.MouseEvent<HTMLButtonElement>,
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLDivElement>,
     value: string
   ) => void
 
@@ -145,7 +146,8 @@ const Typeahead = React.forwardRef<HTMLDivElement, TypeaheadProps>(
     const handleChange = (
       evt:
         | React.FormEvent<HTMLInputElement>
-        | React.MouseEvent<HTMLButtonElement>,
+        | React.MouseEvent<HTMLButtonElement>
+        | React.KeyboardEvent<HTMLDivElement>,
       nextValue: string
     ) => {
       setSearchTerm(nextValue)
@@ -166,7 +168,9 @@ const Typeahead = React.forwardRef<HTMLDivElement, TypeaheadProps>(
     }
 
     const handleSuggestionMenuChange = (
-      evt: React.MouseEvent<HTMLButtonElement>,
+      evt:
+        | React.MouseEvent<HTMLButtonElement>
+        | React.KeyboardEvent<HTMLDivElement>,
       nextValue: string
     ) => {
       setOpen(false)

--- a/packages/typeahead/src/react/menu.tsx
+++ b/packages/typeahead/src/react/menu.tsx
@@ -20,7 +20,12 @@ const styles = {
 
 interface SuggestionsMenuProps extends Omit<HTMLPropsFor<'div'>, 'onChange'> {
   activeValue?: string
-  onChange: (evt: React.MouseEvent<HTMLButtonElement>, value: string) => void
+  onChange: (
+    evt:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLDivElement>,
+    value: string
+  ) => void
   onFocus?: React.FocusEventHandler<HTMLDivElement>
   onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>
   suggestions: SuggestionOption[]
@@ -87,13 +92,17 @@ const SuggestionsMenu = forwardRef<HTMLDivElement, SuggestionsMenuProps>(
     }, props.onFocus)
 
     const handleKeyDown = combineFns(evt => {
-      const tab = evt.key === 'Tab'
-      if (tab) return
-
-      if (evt.key === 'ArrowDown') next()
+      console.log({ key: evt.key })
+      if (evt.shiftKey && evt.key === 'Tab') prev()
+      else if (evt.key === 'Tab') next()
+      else if (evt.key === 'ArrowDown') next()
       else if (evt.key === 'ArrowUp') prev()
       else if (evt.key === 'Home') first()
       else if (evt.key === 'End') last()
+      else if (evt.key === 'Enter' || evt.key === ' ') {
+        if (typeof cursor === 'number' && cursor > 0 && cursor < itemCount)
+          onChange(evt, suggestions[cursor].value)
+      }
 
       evt.preventDefault()
     }, props.onKeyDown)

--- a/packages/typeahead/src/react/menu.tsx
+++ b/packages/typeahead/src/react/menu.tsx
@@ -92,7 +92,7 @@ const SuggestionsMenu = forwardRef<HTMLDivElement, SuggestionsMenuProps>(
     }, props.onFocus)
 
     const handleKeyDown = combineFns(evt => {
-      console.log({ key: evt.key })
+    
       if (evt.shiftKey && evt.key === 'Tab') prev()
       else if (evt.key === 'Tab') next()
       else if (evt.key === 'ArrowDown') next()


### PR DESCRIPTION
I wanted to drive with a test something like this, but I never got it working.  I couldn't figure out why input's value was never updated on Enter.  All the elements were found, just seemed like that final step didn't show up for some reason.  Kind of funny there are no other keyboarding tests in the suite either.  My current best guess is there's some sort of timing problem with the Position wrapper. 

``` 
  import { logDOM } from '@testing-library/dom'
  import userEvent from '@testing-library/user-event'
  it('selects the focused element upon pressing enter', async () => {
    const { getByLabelText } = render(
      <Typeahead label="inputlabel">
        <Typeahead.Suggestion>primo</Typeahead.Suggestion>
        <Typeahead.Suggestion>second</Typeahead.Suggestion>
        <Typeahead.Suggestion>secondino</Typeahead.Suggestion>
      </Typeahead>
    )
    const input = getByLabelText('inputlabel')

    input.focus()
    fireEvent.change(input, { target: { value: 'sec' } })

    logDOM(document.body)
    userEvent.tab()
    fireEvent.keyDown(document.activeElement, { key: 'Enter', code: 13 })

    expect(input).toHaveValue('second')
  })
```