### PR TITLE
cuttin the cruft

### DIFF
--- a/packages/actionmenu/package.json
+++ b/packages/actionmenu/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/appframe/package.json
+++ b/packages/appframe/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "gitHead": "7418883d96a76c59a99f86c2b16516ec752bf913",
   "style": "dist/index.css",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:js -- --watch",
+    "build:watch": "yarn build:js --watch",
     "storybook": "start-storybook -p 6006",
     "test": "jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/css/index.css",
   "dependencies": {

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:js -- --watch",
+    "build:watch": "yarn build:js --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -12,7 +12,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "dependencies": {
     "chalk": "^2.4.2",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "types": "dist/esm/index.d.ts",
   "dependencies": {

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "gitHead": "7418883d96a76c59a99f86c2b16516ec752bf913",
   "style": "dist/index.css",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/circularprogress/package.json
+++ b/packages/circularprogress/package.json
@@ -13,7 +13,7 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:js -- --watch",
+    "build:watch": "yarn build:js --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
     "test:watch": "yarn test --watchAll"

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -13,9 +13,9 @@
     "build": "run-s build:cjs build:esm",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "types": "dist/esm/index.d.ts",
   "peerDependencies": {

--- a/packages/datawell/package.json
+++ b/packages/datawell/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^6.5.1",

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "gitHead": "7418883d96a76c59a99f86c2b16516ec752bf913",
   "dependencies": {

--- a/packages/emptystate/package.json
+++ b/packages/emptystate/package.json
@@ -15,11 +15,11 @@
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
     "build:svg": "svgr --typescript --filename-case kebab --ext \"dist.tsx\" -d src/react/illustrations src/svg",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "copy:svg": "node copy-svgs.js",
     "storybook": "start-storybook -p 6006",
     "test": "jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -14,10 +14,10 @@
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "cross-env ESM=true babel --extensions \".js,.ts,.tsx\" --root-mode upward src --out-dir dist/esm",
     "build:svg": "svgr --filename-case kebab --ext \"dist.js\" -d src/react/icons src/svg",
-    "build:watch": "yarn build:cjs -- --watch",
+    "build:watch": "yarn build:cjs --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/featureflags/package.json
+++ b/packages/featureflags/package.json
@@ -13,9 +13,9 @@
     "build": "run-s build:cjs build:esm",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "types": "dist/esm/index.d.ts",
   "peerDependencies": {

--- a/packages/focusmanager/package.json
+++ b/packages/focusmanager/package.json
@@ -13,10 +13,10 @@
     "build": "run-s build:esm build:cjs",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "types": "dist/esm/index.d.ts",
   "peerDependencies": {

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -17,10 +17,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/halo/package.json
+++ b/packages/halo/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -18,12 +18,12 @@
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
     "prebuild:svg": "yarn clean:svg",
     "build:svg": "node bin/icon -s src/svg -d src/react/icons core",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "clean:svg": "node bin/icon -s src/svg --clean",
     "copy:svg": "node cli/copy-svgs.js",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/linearprogress/package.json
+++ b/packages/linearprogress/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^6.5.1",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006 -s ./dist",
     "test": "jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "typings": "./react.d.ts",
   "dependencies": {

--- a/packages/navbar/package.json
+++ b/packages/navbar/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "gitHead": "7418883d96a76c59a99f86c2b16516ec752bf913",
   "style": "dist/index.css",

--- a/packages/navbrand/package.json
+++ b/packages/navbrand/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/navcookiebanner/package.json
+++ b/packages/navcookiebanner/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/navitem/package.json
+++ b/packages/navitem/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/navuser/package.json
+++ b/packages/navuser/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/note/package.json
+++ b/packages/note/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/position/package.json
+++ b/packages/position/package.json
@@ -13,10 +13,10 @@
     "build": "run-s build:cjs build:esm",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^6.5.1",

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/screenreaderonly/package.json
+++ b/packages/screenreaderonly/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/scrollable/package.json
+++ b/packages/scrollable/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/searchinput/package.json
+++ b/packages/searchinput/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/starrating/package.json
+++ b/packages/starrating/package.json
@@ -16,10 +16,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/storybook-addon-center/package.json
+++ b/packages/storybook-addon-center/package.json
@@ -11,7 +11,7 @@
   "module": "dist/index.js",
   "scripts": {
     "build": "tsc --project tsconfig.build.json --module commonjs --target es5",
-    "build:watch": "yarn build -- --watch"
+    "build:watch": "yarn build --watch"
   },
   "types": "dist/index.d.ts",
   "dependencies": {

--- a/packages/storybook-addon-theme/package.json
+++ b/packages/storybook-addon-theme/package.json
@@ -12,7 +12,7 @@
   "module": "dist/index.js",
   "scripts": {
     "build": "tsc --project tsconfig.build.json --module commonjs --target es5",
-    "build:watch": "yarn build -- --watch"
+    "build:watch": "yarn build --watch"
   },
   "types": "dist/index.d.ts",
   "dependencies": {

--- a/packages/storybook-preset/package.json
+++ b/packages/storybook-preset/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json --module commonjs --target es5",
-    "build:watch": "yarn build -- --watch"
+    "build:watch": "yarn build --watch"
   },
   "types": "dist/index.d.ts",
   "dependencies": {

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "dependencies": {
     "@pluralsight/ps-design-system-core": "^6.5.1",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/textinput/package.json
+++ b/packages/textinput/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -12,9 +12,9 @@
     "build": "run-s build:cjs build:esm",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "test": "jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "types": "dist/esm/index.d.ts",
   "dependencies": {

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/typeahead/package.json
+++ b/packages/typeahead/package.json
@@ -14,10 +14,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "gitHead": "ea4595a4bff6a08255102a0321bb641dc4d25913",
   "style": "dist/index.css",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -12,10 +12,10 @@
     "build": "run-s build:cjs build:esm",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "tsc --noEmit --project ./tsconfig.json && jest",
-    "test:watch": "yarn test -- --watch"
+    "test:watch": "yarn test --watch"
   },
   "types": "dist/esm/index.d.ts",
   "dependencies": {

--- a/packages/verticaltabs/package.json
+++ b/packages/verticaltabs/package.json
@@ -11,10 +11,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:cjs -- --watch",
+    "build:watch": "yarn build:cjs --watch",
     "storybook": "start-storybook -p 6006",
     "test": "jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/viewtoggle/package.json
+++ b/packages/viewtoggle/package.json
@@ -13,10 +13,10 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",
-    "build:watch": "yarn build:esm -- --watch",
+    "build:watch": "yarn build:esm --watch",
     "storybook": "start-storybook -p 6006",
     "test": "jest",
-    "test:watch": "yarn test -- --watchAll"
+    "test:watch": "yarn test --watchAll"
   },
   "style": "dist/index.css",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
Removes a yarn warning that these aren't needed and will eventually be... wrong.


warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.