### PR TITLE
refactor(datepicker): make subfields available to accessibility tree

### DIFF
--- a/packages/datepicker/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/datepicker/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots appearance default 1`] = `
-<label
+<div
   data-css-w0yocm=""
   onKeyDown={[Function]}
 >
@@ -12,6 +12,7 @@ exports[`Storyshots appearance default 1`] = `
       data-css-1gfowhv=""
     >
       <input
+        aria-label="month"
         data-css-1ynlp2p=""
         name="mm"
         onBlur={[Function]}
@@ -29,6 +30,7 @@ exports[`Storyshots appearance default 1`] = `
         /
       </span>
       <input
+        aria-label="day"
         data-css-1ynlp2p=""
         name="dd"
         onBlur={[Function]}
@@ -46,6 +48,7 @@ exports[`Storyshots appearance default 1`] = `
         /
       </span>
       <input
+        aria-label="year"
         data-css-1ynlp2p=""
         name="yyyy"
         onBlur={[Function]}
@@ -82,11 +85,11 @@ exports[`Storyshots appearance default 1`] = `
       </button>
     </div>
   </div>
-</label>
+</div>
 `;
 
 exports[`Storyshots appearance default w/ error 1`] = `
-<label
+<div
   data-css-w0yocm=""
   onKeyDown={[Function]}
 >
@@ -102,6 +105,7 @@ exports[`Storyshots appearance default w/ error 1`] = `
       data-css-1gfowhv=""
     >
       <input
+        aria-label="month"
         data-css-1ynlp2p=""
         name="mm"
         onBlur={[Function]}
@@ -119,6 +123,7 @@ exports[`Storyshots appearance default w/ error 1`] = `
         /
       </span>
       <input
+        aria-label="day"
         data-css-1ynlp2p=""
         name="dd"
         onBlur={[Function]}
@@ -136,6 +141,7 @@ exports[`Storyshots appearance default w/ error 1`] = `
         /
       </span>
       <input
+        aria-label="year"
         data-css-1ynlp2p=""
         name="yyyy"
         onBlur={[Function]}
@@ -191,11 +197,11 @@ exports[`Storyshots appearance default w/ error 1`] = `
       </div>
     </div>
   </div>
-</label>
+</div>
 `;
 
 exports[`Storyshots appearance subtle 1`] = `
-<label
+<div
   data-css-w0yocm=""
   onKeyDown={[Function]}
 >
@@ -206,6 +212,7 @@ exports[`Storyshots appearance subtle 1`] = `
       data-css-1usw9cb=""
     >
       <input
+        aria-label="month"
         data-css-18at7l7=""
         name="mm"
         onBlur={[Function]}
@@ -223,6 +230,7 @@ exports[`Storyshots appearance subtle 1`] = `
         /
       </span>
       <input
+        aria-label="day"
         data-css-18at7l7=""
         name="dd"
         onBlur={[Function]}
@@ -240,6 +248,7 @@ exports[`Storyshots appearance subtle 1`] = `
         /
       </span>
       <input
+        aria-label="year"
         data-css-18at7l7=""
         name="yyyy"
         onBlur={[Function]}
@@ -276,11 +285,11 @@ exports[`Storyshots appearance subtle 1`] = `
       </button>
     </div>
   </div>
-</label>
+</div>
 `;
 
 exports[`Storyshots appearance subtle w/ error 1`] = `
-<label
+<div
   data-css-w0yocm=""
   onKeyDown={[Function]}
 >
@@ -296,6 +305,7 @@ exports[`Storyshots appearance subtle w/ error 1`] = `
       data-css-1usw9cb=""
     >
       <input
+        aria-label="month"
         data-css-18at7l7=""
         name="mm"
         onBlur={[Function]}
@@ -313,6 +323,7 @@ exports[`Storyshots appearance subtle w/ error 1`] = `
         /
       </span>
       <input
+        aria-label="day"
         data-css-18at7l7=""
         name="dd"
         onBlur={[Function]}
@@ -330,6 +341,7 @@ exports[`Storyshots appearance subtle w/ error 1`] = `
         /
       </span>
       <input
+        aria-label="year"
         data-css-18at7l7=""
         name="yyyy"
         onBlur={[Function]}
@@ -385,12 +397,12 @@ exports[`Storyshots appearance subtle w/ error 1`] = `
       </div>
     </div>
   </div>
-</label>
+</div>
 `;
 
 exports[`Storyshots disabled compare 1`] = `
 <div>
-  <label
+  <div
     data-css-w0yocm=""
     onKeyDown={[Function]}
   >
@@ -406,6 +418,7 @@ exports[`Storyshots disabled compare 1`] = `
         data-css-1gfowhv=""
       >
         <input
+          aria-label="month"
           data-css-1ynlp2p=""
           name="mm"
           onBlur={[Function]}
@@ -423,6 +436,7 @@ exports[`Storyshots disabled compare 1`] = `
           /
         </span>
         <input
+          aria-label="day"
           data-css-1ynlp2p=""
           name="dd"
           onBlur={[Function]}
@@ -440,6 +454,7 @@ exports[`Storyshots disabled compare 1`] = `
           /
         </span>
         <input
+          aria-label="year"
           data-css-1ynlp2p=""
           name="yyyy"
           onBlur={[Function]}
@@ -481,8 +496,8 @@ exports[`Storyshots disabled compare 1`] = `
     >
       Still normal
     </div>
-  </label>
-  <label
+  </div>
+  <div
     data-css-1y0hkm3=""
     onKeyDown={[Function]}
   >
@@ -498,6 +513,7 @@ exports[`Storyshots disabled compare 1`] = `
         data-css-1gfowhv=""
       >
         <input
+          aria-label="month"
           data-css-1ynlp2p=""
           defaultValue={12}
           disabled={true}
@@ -517,6 +533,7 @@ exports[`Storyshots disabled compare 1`] = `
           /
         </span>
         <input
+          aria-label="day"
           data-css-1ynlp2p=""
           defaultValue={7}
           disabled={true}
@@ -536,6 +553,7 @@ exports[`Storyshots disabled compare 1`] = `
           /
         </span>
         <input
+          aria-label="year"
           data-css-1ynlp2p=""
           defaultValue={1941}
           disabled={true}
@@ -582,7 +600,7 @@ exports[`Storyshots disabled compare 1`] = `
     >
       Neither am I
     </div>
-  </label>
+  </div>
 </div>
 `;
 
@@ -595,7 +613,7 @@ exports[`Storyshots labels compare w/ textinput 1`] = `
       }
     }
   >
-    <label
+    <div
       data-css-w0yocm=""
       onKeyDown={[Function]}
     >
@@ -606,6 +624,7 @@ exports[`Storyshots labels compare w/ textinput 1`] = `
           data-css-1gfowhv=""
         >
           <input
+            aria-label="month"
             data-css-1ynlp2p=""
             name="mm"
             onBlur={[Function]}
@@ -623,6 +642,7 @@ exports[`Storyshots labels compare w/ textinput 1`] = `
             /
           </span>
           <input
+            aria-label="day"
             data-css-1ynlp2p=""
             name="dd"
             onBlur={[Function]}
@@ -640,6 +660,7 @@ exports[`Storyshots labels compare w/ textinput 1`] = `
             /
           </span>
           <input
+            aria-label="year"
             data-css-1ynlp2p=""
             name="yyyy"
             onBlur={[Function]}
@@ -676,7 +697,7 @@ exports[`Storyshots labels compare w/ textinput 1`] = `
           </button>
         </div>
       </div>
-    </label>
+    </div>
   </div>
   <div>
     <label
@@ -705,7 +726,7 @@ exports[`Storyshots labels compare w/ textinput 1`] = `
 `;
 
 exports[`Storyshots labels label 1`] = `
-<label
+<div
   data-css-w0yocm=""
   onKeyDown={[Function]}
 >
@@ -721,6 +742,7 @@ exports[`Storyshots labels label 1`] = `
       data-css-1gfowhv=""
     >
       <input
+        aria-label="month"
         data-css-1ynlp2p=""
         name="mm"
         onBlur={[Function]}
@@ -738,6 +760,7 @@ exports[`Storyshots labels label 1`] = `
         /
       </span>
       <input
+        aria-label="day"
         data-css-1ynlp2p=""
         name="dd"
         onBlur={[Function]}
@@ -755,6 +778,7 @@ exports[`Storyshots labels label 1`] = `
         /
       </span>
       <input
+        aria-label="year"
         data-css-1ynlp2p=""
         name="yyyy"
         onBlur={[Function]}
@@ -791,11 +815,11 @@ exports[`Storyshots labels label 1`] = `
       </button>
     </div>
   </div>
-</label>
+</div>
 `;
 
 exports[`Storyshots labels label and subLabel 1`] = `
-<label
+<div
   data-css-w0yocm=""
   onKeyDown={[Function]}
 >
@@ -811,6 +835,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
       data-css-1gfowhv=""
     >
       <input
+        aria-label="month"
         data-css-1ynlp2p=""
         name="mm"
         onBlur={[Function]}
@@ -828,6 +853,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
         /
       </span>
       <input
+        aria-label="day"
         data-css-1ynlp2p=""
         name="dd"
         onBlur={[Function]}
@@ -845,6 +871,7 @@ exports[`Storyshots labels label and subLabel 1`] = `
         /
       </span>
       <input
+        aria-label="year"
         data-css-1ynlp2p=""
         name="yyyy"
         onBlur={[Function]}
@@ -886,11 +913,11 @@ exports[`Storyshots labels label and subLabel 1`] = `
   >
     Some sublabel
   </div>
-</label>
+</div>
 `;
 
 exports[`Storyshots labels none 1`] = `
-<label
+<div
   data-css-w0yocm=""
   onKeyDown={[Function]}
 >
@@ -901,6 +928,7 @@ exports[`Storyshots labels none 1`] = `
       data-css-1gfowhv=""
     >
       <input
+        aria-label="month"
         data-css-1ynlp2p=""
         name="mm"
         onBlur={[Function]}
@@ -918,6 +946,7 @@ exports[`Storyshots labels none 1`] = `
         /
       </span>
       <input
+        aria-label="day"
         data-css-1ynlp2p=""
         name="dd"
         onBlur={[Function]}
@@ -935,6 +964,7 @@ exports[`Storyshots labels none 1`] = `
         /
       </span>
       <input
+        aria-label="year"
         data-css-1ynlp2p=""
         name="yyyy"
         onBlur={[Function]}
@@ -971,11 +1001,11 @@ exports[`Storyshots labels none 1`] = `
       </button>
     </div>
   </div>
-</label>
+</div>
 `;
 
 exports[`Storyshots labels subLabel 1`] = `
-<label
+<div
   data-css-w0yocm=""
   onKeyDown={[Function]}
 >
@@ -986,6 +1016,7 @@ exports[`Storyshots labels subLabel 1`] = `
       data-css-1gfowhv=""
     >
       <input
+        aria-label="month"
         data-css-1ynlp2p=""
         name="mm"
         onBlur={[Function]}
@@ -1003,6 +1034,7 @@ exports[`Storyshots labels subLabel 1`] = `
         /
       </span>
       <input
+        aria-label="day"
         data-css-1ynlp2p=""
         name="dd"
         onBlur={[Function]}
@@ -1020,6 +1052,7 @@ exports[`Storyshots labels subLabel 1`] = `
         /
       </span>
       <input
+        aria-label="year"
         data-css-1ynlp2p=""
         name="yyyy"
         onBlur={[Function]}
@@ -1061,7 +1094,7 @@ exports[`Storyshots labels subLabel 1`] = `
   >
     Some sublabel
   </div>
-</label>
+</div>
 `;
 
 exports[`Storyshots layouts full width 1`] = `
@@ -1073,7 +1106,7 @@ exports[`Storyshots layouts full width 1`] = `
     }
   }
 >
-  <label
+  <div
     data-css-w0yocm=""
     onKeyDown={[Function]}
     style={
@@ -1095,6 +1128,7 @@ exports[`Storyshots layouts full width 1`] = `
         data-css-1gfowhv=""
       >
         <input
+          aria-label="month"
           data-css-1ynlp2p=""
           name="mm"
           onBlur={[Function]}
@@ -1112,6 +1146,7 @@ exports[`Storyshots layouts full width 1`] = `
           /
         </span>
         <input
+          aria-label="day"
           data-css-1ynlp2p=""
           name="dd"
           onBlur={[Function]}
@@ -1129,6 +1164,7 @@ exports[`Storyshots layouts full width 1`] = `
           /
         </span>
         <input
+          aria-label="year"
           data-css-1ynlp2p=""
           name="yyyy"
           onBlur={[Function]}
@@ -1165,8 +1201,8 @@ exports[`Storyshots layouts full width 1`] = `
         </button>
       </div>
     </div>
-  </label>
-  <label
+  </div>
+  <div
     data-css-w0yocm=""
     onKeyDown={[Function]}
     style={
@@ -1188,6 +1224,7 @@ exports[`Storyshots layouts full width 1`] = `
         data-css-1gfowhv=""
       >
         <input
+          aria-label="month"
           data-css-1ynlp2p=""
           name="mm"
           onBlur={[Function]}
@@ -1205,6 +1242,7 @@ exports[`Storyshots layouts full width 1`] = `
           /
         </span>
         <input
+          aria-label="day"
           data-css-1ynlp2p=""
           name="dd"
           onBlur={[Function]}
@@ -1222,6 +1260,7 @@ exports[`Storyshots layouts full width 1`] = `
           /
         </span>
         <input
+          aria-label="year"
           data-css-1ynlp2p=""
           name="yyyy"
           onBlur={[Function]}
@@ -1277,8 +1316,8 @@ exports[`Storyshots layouts full width 1`] = `
         </div>
       </div>
     </div>
-  </label>
-  <label
+  </div>
+  <div
     data-css-w0yocm=""
     onKeyDown={[Function]}
     style={
@@ -1300,6 +1339,7 @@ exports[`Storyshots layouts full width 1`] = `
         data-css-1usw9cb=""
       >
         <input
+          aria-label="month"
           data-css-18at7l7=""
           name="mm"
           onBlur={[Function]}
@@ -1317,6 +1357,7 @@ exports[`Storyshots layouts full width 1`] = `
           /
         </span>
         <input
+          aria-label="day"
           data-css-18at7l7=""
           name="dd"
           onBlur={[Function]}
@@ -1334,6 +1375,7 @@ exports[`Storyshots layouts full width 1`] = `
           /
         </span>
         <input
+          aria-label="year"
           data-css-18at7l7=""
           name="yyyy"
           onBlur={[Function]}
@@ -1370,8 +1412,8 @@ exports[`Storyshots layouts full width 1`] = `
         </button>
       </div>
     </div>
-  </label>
-  <label
+  </div>
+  <div
     data-css-w0yocm=""
     onKeyDown={[Function]}
     style={
@@ -1393,6 +1435,7 @@ exports[`Storyshots layouts full width 1`] = `
         data-css-1usw9cb=""
       >
         <input
+          aria-label="month"
           data-css-18at7l7=""
           name="mm"
           onBlur={[Function]}
@@ -1410,6 +1453,7 @@ exports[`Storyshots layouts full width 1`] = `
           /
         </span>
         <input
+          aria-label="day"
           data-css-18at7l7=""
           name="dd"
           onBlur={[Function]}
@@ -1427,6 +1471,7 @@ exports[`Storyshots layouts full width 1`] = `
           /
         </span>
         <input
+          aria-label="year"
           data-css-18at7l7=""
           name="yyyy"
           onBlur={[Function]}
@@ -1482,7 +1527,7 @@ exports[`Storyshots layouts full width 1`] = `
         </div>
       </div>
     </div>
-  </label>
+  </div>
 </div>
 `;
 
@@ -1502,7 +1547,7 @@ exports[`Storyshots layouts right-aligned 1`] = `
       }
     }
   >
-    <label
+    <div
       data-css-w0yocm=""
       onKeyDown={[Function]}
     >
@@ -1513,6 +1558,7 @@ exports[`Storyshots layouts right-aligned 1`] = `
           data-css-1usw9cb=""
         >
           <input
+            aria-label="month"
             data-css-18at7l7=""
             name="mm"
             onBlur={[Function]}
@@ -1530,6 +1576,7 @@ exports[`Storyshots layouts right-aligned 1`] = `
             /
           </span>
           <input
+            aria-label="day"
             data-css-18at7l7=""
             name="dd"
             onBlur={[Function]}
@@ -1547,6 +1594,7 @@ exports[`Storyshots layouts right-aligned 1`] = `
             /
           </span>
           <input
+            aria-label="year"
             data-css-18at7l7=""
             name="yyyy"
             onBlur={[Function]}
@@ -1583,7 +1631,7 @@ exports[`Storyshots layouts right-aligned 1`] = `
           </button>
         </div>
       </div>
-    </label>
+    </div>
   </div>
   <div
     style={
@@ -1608,7 +1656,7 @@ exports[`Storyshots value controlled value changes 1`] = `
     Sending in: 
     1941-12-7
   </div>
-  <label
+  <div
     data-css-w0yocm=""
     onKeyDown={[Function]}
   >
@@ -1619,6 +1667,7 @@ exports[`Storyshots value controlled value changes 1`] = `
         data-css-1gfowhv=""
       >
         <input
+          aria-label="month"
           data-css-1ynlp2p=""
           defaultValue={12}
           name="mm"
@@ -1637,6 +1686,7 @@ exports[`Storyshots value controlled value changes 1`] = `
           /
         </span>
         <input
+          aria-label="day"
           data-css-1ynlp2p=""
           defaultValue={7}
           name="dd"
@@ -1655,6 +1705,7 @@ exports[`Storyshots value controlled value changes 1`] = `
           /
         </span>
         <input
+          aria-label="year"
           data-css-1ynlp2p=""
           defaultValue={1941}
           name="yyyy"
@@ -1693,12 +1744,12 @@ exports[`Storyshots value controlled value changes 1`] = `
         </button>
       </div>
     </div>
-  </label>
+  </div>
 </div>
 `;
 
 exports[`Storyshots value date 1`] = `
-<label
+<div
   data-css-w0yocm=""
   onKeyDown={[Function]}
 >
@@ -1709,6 +1760,7 @@ exports[`Storyshots value date 1`] = `
       data-css-1gfowhv=""
     >
       <input
+        aria-label="month"
         data-css-1ynlp2p=""
         defaultValue={12}
         name="mm"
@@ -1727,6 +1779,7 @@ exports[`Storyshots value date 1`] = `
         /
       </span>
       <input
+        aria-label="day"
         data-css-1ynlp2p=""
         defaultValue={7}
         name="dd"
@@ -1745,6 +1798,7 @@ exports[`Storyshots value date 1`] = `
         /
       </span>
       <input
+        aria-label="year"
         data-css-1ynlp2p=""
         defaultValue={1941}
         name="yyyy"
@@ -1783,7 +1837,7 @@ exports[`Storyshots value date 1`] = `
       </button>
     </div>
   </div>
-</label>
+</div>
 `;
 
 exports[`Storyshots value updated value, no initial 1`] = `
@@ -1798,7 +1852,7 @@ exports[`Storyshots value updated value, no initial 1`] = `
     Selected: 
     &lt;none&gt;
   </div>
-  <label
+  <div
     data-css-w0yocm=""
     onKeyDown={[Function]}
   >
@@ -1809,6 +1863,7 @@ exports[`Storyshots value updated value, no initial 1`] = `
         data-css-1gfowhv=""
       >
         <input
+          aria-label="month"
           data-css-1ynlp2p=""
           name="mm"
           onBlur={[Function]}
@@ -1826,6 +1881,7 @@ exports[`Storyshots value updated value, no initial 1`] = `
           /
         </span>
         <input
+          aria-label="day"
           data-css-1ynlp2p=""
           name="dd"
           onBlur={[Function]}
@@ -1843,6 +1899,7 @@ exports[`Storyshots value updated value, no initial 1`] = `
           /
         </span>
         <input
+          aria-label="year"
           data-css-1ynlp2p=""
           name="yyyy"
           onBlur={[Function]}
@@ -1879,7 +1936,7 @@ exports[`Storyshots value updated value, no initial 1`] = `
         </button>
       </div>
     </div>
-  </label>
+  </div>
 </div>
 `;
 
@@ -1895,7 +1952,7 @@ exports[`Storyshots value updated value, w/ initial 1`] = `
     Selected: 
     1995-3-15
   </div>
-  <label
+  <div
     data-css-w0yocm=""
     onKeyDown={[Function]}
   >
@@ -1906,6 +1963,7 @@ exports[`Storyshots value updated value, w/ initial 1`] = `
         data-css-1gfowhv=""
       >
         <input
+          aria-label="month"
           data-css-1ynlp2p=""
           defaultValue={3}
           name="mm"
@@ -1924,6 +1982,7 @@ exports[`Storyshots value updated value, w/ initial 1`] = `
           /
         </span>
         <input
+          aria-label="day"
           data-css-1ynlp2p=""
           defaultValue={15}
           name="dd"
@@ -1942,6 +2001,7 @@ exports[`Storyshots value updated value, w/ initial 1`] = `
           /
         </span>
         <input
+          aria-label="year"
           data-css-1ynlp2p=""
           defaultValue={1995}
           name="yyyy"
@@ -1980,12 +2040,12 @@ exports[`Storyshots value updated value, w/ initial 1`] = `
         </button>
       </div>
     </div>
-  </label>
+  </div>
 </div>
 `;
 
 exports[`Storyshots whitelist name 1`] = `
-<label
+<div
   data-css-w0yocm=""
   onKeyDown={[Function]}
 >
@@ -1996,6 +2056,7 @@ exports[`Storyshots whitelist name 1`] = `
       data-css-1gfowhv=""
     >
       <input
+        aria-label="month"
         data-css-1ynlp2p=""
         defaultValue={4}
         name="mm"
@@ -2014,6 +2075,7 @@ exports[`Storyshots whitelist name 1`] = `
         /
       </span>
       <input
+        aria-label="day"
         data-css-1ynlp2p=""
         defaultValue={2}
         name="dd"
@@ -2032,6 +2094,7 @@ exports[`Storyshots whitelist name 1`] = `
         /
       </span>
       <input
+        aria-label="year"
         data-css-1ynlp2p=""
         defaultValue={1944}
         name="yyyy"
@@ -2072,11 +2135,11 @@ exports[`Storyshots whitelist name 1`] = `
       </button>
     </div>
   </div>
-</label>
+</div>
 `;
 
 exports[`Storyshots whitelist onChange 1`] = `
-<label
+<div
   data-css-w0yocm=""
   onKeyDown={[Function]}
 >
@@ -2087,6 +2150,7 @@ exports[`Storyshots whitelist onChange 1`] = `
       data-css-1gfowhv=""
     >
       <input
+        aria-label="month"
         data-css-1ynlp2p=""
         name="mm"
         onBlur={[Function]}
@@ -2104,6 +2168,7 @@ exports[`Storyshots whitelist onChange 1`] = `
         /
       </span>
       <input
+        aria-label="day"
         data-css-1ynlp2p=""
         name="dd"
         onBlur={[Function]}
@@ -2121,6 +2186,7 @@ exports[`Storyshots whitelist onChange 1`] = `
         /
       </span>
       <input
+        aria-label="year"
         data-css-1ynlp2p=""
         name="yyyy"
         onBlur={[Function]}
@@ -2158,5 +2224,5 @@ exports[`Storyshots whitelist onChange 1`] = `
       </button>
     </div>
   </div>
-</label>
+</div>
 `;

--- a/packages/datepicker/src/react/__specs__/index.spec.tsx
+++ b/packages/datepicker/src/react/__specs__/index.spec.tsx
@@ -27,7 +27,7 @@ describe('DatePicker', () => {
   })
 
   it('opens calendar on icon click', () => {
-    const { getByText, getByLabelText, container, rerender } = render(
+    const { getByText, getByLabelText, rerender } = render(
       <DatePicker value={new Date(1993, 0, 20)} />
     )
     const icon = getByLabelText('calendar icon', { selector: 'svg' })
@@ -65,46 +65,43 @@ describe('DatePicker', () => {
     })
   })
 
-  it('derives initial value from prop', () => {
+  it('derives initial value from prop', async () => {
     const date = new Date(1993, 0, 20)
-    const { container } = render(<DatePicker value={date} />)
+    const { findByRole } = render(<DatePicker value={date} />)
 
-    const fields: { [key: string]: HTMLInputElement } = {
-      day: container.querySelector<HTMLInputElement>(
-        '[name="dd"]'
-      ) as HTMLInputElement,
-      month: container.querySelector<HTMLInputElement>(
-        '[name="mm"]'
-      ) as HTMLInputElement,
-      year: container.querySelector<HTMLInputElement>(
-        '[name="yyyy"]'
-      ) as HTMLInputElement
-    }
-    expect(parseInt(fields.day.value, 10)).toEqual(date.getDate())
-    expect(parseInt(fields.month.value, 10)).toEqual(date.getMonth() + 1)
-    expect(parseInt(fields.year.value, 10)).toEqual(date.getFullYear())
+    const dd = (await findByRole('textbox', {
+      name: 'day'
+    })) as HTMLInputElement
+    const mm = (await findByRole('textbox', {
+      name: 'month'
+    })) as HTMLInputElement
+    const yyyy = (await findByRole('textbox', {
+      name: 'year'
+    })) as HTMLInputElement
+
+    expect(parseInt(dd.value, 10)).toEqual(date.getDate())
+    expect(parseInt(mm.value, 10)).toEqual(date.getMonth() + 1)
+    expect(parseInt(yyyy.value, 10)).toEqual(date.getFullYear())
   })
 
-  it('updates render state on prop change', () => {
+  it('updates render state on prop change', async () => {
     const date = new Date(1993, 0, 20)
-    const { container, rerender } = render(<DatePicker value={date} />)
+    const { findByRole, rerender } = render(<DatePicker value={date} />)
 
     const newDate = new Date(2001, 7, 14)
     rerender(<DatePicker value={newDate} />)
-    const fields: { [key: string]: HTMLInputElement } = {
-      day: container.querySelector<HTMLInputElement>(
-        '[name="dd"]'
-      ) as HTMLInputElement,
-      month: container.querySelector<HTMLInputElement>(
-        '[name="mm"]'
-      ) as HTMLInputElement,
-      year: container.querySelector<HTMLInputElement>(
-        '[name="yyyy"]'
-      ) as HTMLInputElement
-    }
+    const dd = (await findByRole('textbox', {
+      name: 'day'
+    })) as HTMLInputElement
+    const mm = (await findByRole('textbox', {
+      name: 'month'
+    })) as HTMLInputElement
+    const yyyy = (await findByRole('textbox', {
+      name: 'year'
+    })) as HTMLInputElement
 
-    expect(parseInt(fields.day.value, 10)).toEqual(newDate.getDate())
-    expect(parseInt(fields.month.value, 10)).toEqual(newDate.getMonth() + 1)
-    expect(parseInt(fields.year.value, 10)).toEqual(newDate.getFullYear())
+    expect(parseInt(dd.value, 10)).toEqual(newDate.getDate())
+    expect(parseInt(mm.value, 10)).toEqual(newDate.getMonth() + 1)
+    expect(parseInt(yyyy.value, 10)).toEqual(newDate.getFullYear())
   })
 })

--- a/packages/datepicker/src/react/index.tsx
+++ b/packages/datepicker/src/react/index.tsx
@@ -194,7 +194,7 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
     }
 
     return (
-      <label
+      <div
         {...styles.datePicker(disabled, themeName)}
         className={className}
         onKeyDown={handleKeyDown}
@@ -213,6 +213,7 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
               onBlur={handleSubFieldBlur}
               value={value ? value.getMonth() + 1 : undefined}
               name="mm"
+              aria-label="month"
               disabled={disabled}
               style={{ width: '32px' }}
             />
@@ -225,6 +226,7 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
               onBlur={handleSubFieldBlur}
               value={value ? value.getDate() : undefined}
               name="dd"
+              aria-label="day"
               disabled={disabled}
               style={{ width: '24px' }}
             />
@@ -237,6 +239,7 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
               onBlur={handleSubFieldBlur}
               value={value ? value.getFullYear() : undefined}
               name="yyyy"
+              aria-label="year"
               disabled={disabled}
               style={{ width: '48px' }}
             />
@@ -278,7 +281,7 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
         )}
 
         {subLabel && <div {...styles.subLabel(themeName)}>{subLabel}</div>}
-      </label>
+      </div>
     )
   }
 ) as DatePickerComponent

--- a/packages/form/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/form/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -742,7 +742,7 @@ exports[`Storyshots Sample Form sample 1`] = `
       <div
         data-css-4l6uky=""
       >
-        <label
+        <div
           data-css-w0yocm=""
           onKeyDown={[Function]}
           style={
@@ -764,6 +764,7 @@ exports[`Storyshots Sample Form sample 1`] = `
               data-css-1gfowhv=""
             >
               <input
+                aria-label="month"
                 data-css-1ynlp2p=""
                 name="mm"
                 onBlur={[Function]}
@@ -781,6 +782,7 @@ exports[`Storyshots Sample Form sample 1`] = `
                 /
               </span>
               <input
+                aria-label="day"
                 data-css-1ynlp2p=""
                 name="dd"
                 onBlur={[Function]}
@@ -798,6 +800,7 @@ exports[`Storyshots Sample Form sample 1`] = `
                 /
               </span>
               <input
+                aria-label="year"
                 data-css-1ynlp2p=""
                 name="yyyy"
                 onBlur={[Function]}
@@ -834,7 +837,7 @@ exports[`Storyshots Sample Form sample 1`] = `
               </button>
             </div>
           </div>
-        </label>
+        </div>
       </div>
       <div
         data-css-4l6uky=""


### PR DESCRIPTION
- Inputs already textbox in accessibility tree
  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role
- But needed better, now individual labelling
- Following WAI subfield labelling suggestion
  https://www.w3.org/TR/WCAG20-TECHS/ARIA14.html
- Using getByRole prioritized testing-library query
  https://testing-library.com/docs/guide-which-query/
- getByRole(roleName, { name }) is non-intuitive: name is a label, not
  an html attr
  https://testing-library.com/docs/dom-testing-library/api-queries/#byrole

