### PR TITLE
add page heading patterns to docs

### DIFF
--- a/docs/src/components/code-block/package-map.ts
+++ b/docs/src/components/code-block/package-map.ts
@@ -48,7 +48,7 @@ import Tag from '@pluralsight/ps-design-system-tag'
 import * as Text from '@pluralsight/ps-design-system-text'
 import TextArea from '@pluralsight/ps-design-system-textarea'
 import TextInput from '@pluralsight/ps-design-system-textinput'
-import Theme from '@pluralsight/ps-design-system-theme'
+import Theme, { useTheme } from '@pluralsight/ps-design-system-theme'
 import Tooltip from '@pluralsight/ps-design-system-tooltip'
 import Typeahead from '@pluralsight/ps-design-system-typeahead'
 import VerticalTabs from '@pluralsight/ps-design-system-verticaltabs'
@@ -121,7 +121,7 @@ export const PACKAGE_MAP: PackageMap = {
   '@pluralsight/ps-design-system-text': { ...omit(Text, ['default']) },
   '@pluralsight/ps-design-system-textarea': { TextArea },
   '@pluralsight/ps-design-system-textinput': { TextInput },
-  '@pluralsight/ps-design-system-theme': { Theme },
+  '@pluralsight/ps-design-system-theme': { Theme, useTheme },
   '@pluralsight/ps-design-system-tooltip': { Tooltip },
   '@pluralsight/ps-design-system-typeahead': { Typeahead },
   '@pluralsight/ps-design-system-util': { ...util },

--- a/docs/src/components/side-nav/index.tsx
+++ b/docs/src/components/side-nav/index.tsx
@@ -428,6 +428,17 @@ const groups = [
         title: 'Feature flags'
       }
     ]
+  },
+  {
+    header: {
+      title: 'Patterns'
+    },
+    items: [
+      {
+        href: '/patterns/page-headings',
+        title: 'Page headings'
+      }
+    ]
   }
 ]
 

--- a/docs/src/components/side-nav/index.tsx
+++ b/docs/src/components/side-nav/index.tsx
@@ -435,8 +435,8 @@ const groups = [
     },
     items: [
       {
-        href: '/patterns/page-headings',
-        title: 'Page headings'
+        href: '/patterns/page-headers',
+        title: 'Page headers'
       }
     ]
   }

--- a/docs/src/content/patterns/page-headers.mdx
+++ b/docs/src/content/patterns/page-headers.mdx
@@ -1,13 +1,13 @@
 ---
-name: Page headings
-route: /patterns/page-headings
+name: Page headers
+route: /patterns/page-headers
 ---
 
-# Page heading patterns
+# Page header patterns
 
 <TableOfContents {...props} />
 
-### "Basic" heading
+### "Basic" header
 
 ```typescript
 import { layout } from '@pluralsight/ps-design-system-core'
@@ -70,7 +70,7 @@ function Example() {
 export default Example
 ```
 
-### "Basic alt 2" heading
+### "Basic alt 2" header
 
 ```typescript
 import { layout } from '@pluralsight/ps-design-system-core'
@@ -139,7 +139,7 @@ function Example() {
 export default Example
 ```
 
-### "Robust" heading
+### "Robust" header
 
 ```typescript
 import { colorsTextIcon, layout } from '@pluralsight/ps-design-system-core'
@@ -226,7 +226,7 @@ function Example() {
 export default Example
 ```
 
-### "Power" heading
+### "Power" header
 
 ```typescript
 import { colorsTextIcon, layout } from '@pluralsight/ps-design-system-core'

--- a/docs/src/content/patterns/page-headings.mdx
+++ b/docs/src/content/patterns/page-headings.mdx
@@ -16,12 +16,11 @@ import SearchInput from '@pluralsight/ps-design-system-searchinput'
 import { Heading } from '@pluralsight/ps-design-system-text'
 import React from 'react'
 
-// TODO: right-align button-bar on desktop size
 function Example() {
   return (
     <div className="basic-heading">
       <div className="title">
-        <Heading>
+        <Heading size="xLarge">
           <h1>Heading</h1>
         </Heading>
       </div>
@@ -57,9 +56,79 @@ function Example() {
         @media (min-width: 1024px) {
           .basic-heading {
             display: flex;
+            justify-content: space-between;
             align-items: center;
           }
           .title {
+            margin-right: ${layout.spacingLarge};
+          }
+        }
+      `}</style>
+    </div>
+  )
+}
+export default Example
+```
+
+### "Basic alt 2" heading
+
+```typescript
+import { layout } from '@pluralsight/ps-design-system-core'
+import Button from '@pluralsight/ps-design-system-button'
+import { PlaceholderIcon } from '@pluralsight/ps-design-system-icon'
+import SearchInput from '@pluralsight/ps-design-system-searchinput'
+import { Heading } from '@pluralsight/ps-design-system-text'
+import React from 'react'
+
+function Example() {
+  return (
+    <div className="basic-heading2">
+      <div className="basic-heading2__title">
+        <Heading>
+          <h1>Heading</h1>
+        </Heading>
+        <PlaceholderIcon />
+      </div>
+      <div className="basic-heading2__button-bar">
+        <Button>Label</Button>
+        <SearchInput placeholder="Placeholder" />
+      </div>
+      <style jsx>{`
+        .basic-heading2__title {
+          display: flex;
+          align-items: center;
+        }
+        .basic-heading2__title > *:last-child {
+          margin-left: ${layout.spacingSmall};
+        }
+        .basic-heading2__button-bar > * {
+          margin-bottom: ${layout.spacingXSmall};
+        }
+        @media (max-width: 767px) {
+          .basic-heading2__button-bar > * {
+            display: block;
+            width: 100%;
+          }
+        }
+        @media (min-width: 768px) {
+          .basic-heading2__button-bar {
+            display: flex;
+            flex-wrap: wrap;
+          }
+          .basic-heading2__button-bar > * {
+            margin-right: ${layout.spacingXSmall};
+          }
+          .basic-heading2__button-bar > *:last-child {
+            margin-right: 0;
+          }
+        }
+        @media (min-width: 1024px) {
+          .basic-heading2 {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+          }
+          .basic-heading2__title {
             margin-right: ${layout.spacingLarge};
           }
         }

--- a/docs/src/content/patterns/page-headings.mdx
+++ b/docs/src/content/patterns/page-headings.mdx
@@ -84,9 +84,7 @@ import React from 'react'
 function Example() {
   return (
     <div className="robust-heading">
-      <Badge>
-        Course
-      </Badge>
+      <Badge>Course</Badge>
       <Heading>
         <h1>Heading</h1>
       </Heading>
@@ -151,6 +149,83 @@ function Example() {
         .button-bar > * {
           margin-right: ${layout.spacingXSmall};
           margin-bottom: ${layout.spacingXSmall};
+        }
+      `}</style>
+    </div>
+  )
+}
+export default Example
+```
+
+### "Power" heading
+
+```typescript
+import { colorsTextIcon, layout } from '@pluralsight/ps-design-system-core'
+import Breadcrumb from '@pluralsight/ps-design-system-breadcrumb'
+import Button from '@pluralsight/ps-design-system-button'
+import { Label, Heading } from '@pluralsight/ps-design-system-text'
+import Tab from '@pluralsight/ps-design-system-tab'
+import React from 'react'
+
+function Example() {
+  return (
+    <div className="power-heading">
+      <div className="title">
+        <div>
+          <Breadcrumb>Label</Breadcrumb>
+          <Heading>
+            <h1>Page Title</h1>
+          </Heading>
+        </div>
+        <div className="main-action-group">
+          <div>
+            <div>
+              <Label strong size="medium">
+                Label: Status
+              </Label>
+            </div>
+            <div>
+              <Label color="secondary" size="small">
+                Sublabel: September 20, 2018
+              </Label>
+            </div>
+          </div>
+          <Button>Label</Button>
+        </div>
+      </div>
+      <Tab.List>
+        <Tab.ListItem active>Label</Tab.ListItem>
+        <Tab.ListItem>Label</Tab.ListItem>
+        <Tab.ListItem>Label</Tab.ListItem>
+        <Tab.ListItem>Label</Tab.ListItem>
+        <Tab.ListItem>Label</Tab.ListItem>
+        <Tab.ListItem>Label</Tab.ListItem>
+        <Tab.ListItem>Label</Tab.ListItem>
+      </Tab.List>
+      <style jsx>{`
+        @media (max-width: 767px) {
+          .main-action-group > * {
+            display: block;
+            width: 100%;
+          }
+          .title {
+            margin-bottom: ${layout.spacingLarge};
+          }
+        }
+        @media (min-width: 768px) {
+          .title {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+          }
+          .main-action-group {
+            display: flex;
+            align-items: center;
+          }
+          .main-action-group > div:first-child {
+            text-align: right;
+            margin-right: ${layout.spacingSmall};
+          }
         }
       `}</style>
     </div>

--- a/docs/src/content/patterns/page-headings.mdx
+++ b/docs/src/content/patterns/page-headings.mdx
@@ -16,9 +16,10 @@ import SearchInput from '@pluralsight/ps-design-system-searchinput'
 import { Heading } from '@pluralsight/ps-design-system-text'
 import React from 'react'
 
+// TODO: right-align button-bar on desktop size
 function Example() {
   return (
-    <div className="heading">
+    <div className="basic-heading">
       <div className="title">
         <Heading>
           <h1>Heading</h1>
@@ -54,13 +55,102 @@ function Example() {
           }
         }
         @media (min-width: 1024px) {
-          .heading {
+          .basic-heading {
             display: flex;
             align-items: center;
           }
           .title {
             margin-right: ${layout.spacingLarge};
           }
+        }
+      `}</style>
+    </div>
+  )
+}
+export default Example
+```
+
+### "Robust" heading
+
+```typescript
+import { colorsTextIcon, layout } from '@pluralsight/ps-design-system-core'
+import Badge from '@pluralsight/ps-design-system-badge'
+import Button from '@pluralsight/ps-design-system-button'
+import StarRating from '@pluralsight/ps-design-system-starrating'
+import Tag from '@pluralsight/ps-design-system-tag'
+import { Heading } from '@pluralsight/ps-design-system-text'
+import React from 'react'
+
+function Example() {
+  return (
+    <div className="robust-heading">
+      <Badge>
+        Course
+      </Badge>
+      <Heading>
+        <h1>Heading</h1>
+      </Heading>
+      <P>
+        I'm baby chambray cronut vegan cray banjo man bun organic biodiesel
+        readymade tumblr la croix pug blog microdosing. Cred squid man bun
+        iPhone, ethical banh mi post-ironic palo santo 90's vexillologist. 8-bit
+        viral.
+      </P>
+      <div className="tags">
+        <Tag>Tag label</Tag>
+        <Tag>Tag label</Tag>
+        <Tag>Tag label</Tag>
+        <Tag>Tag label</Tag>
+        <Tag>Tag label</Tag>
+        <Tag>Tag label</Tag>
+      </div>
+      <ul className="metadata">
+        <li>Meta data</li>
+        <li>Meta data</li>
+        <li>Meta data</li>
+        <li>
+          <StarRating value={3} />
+        </li>
+      </ul>
+      <div className="button-bar">
+        <Button>Label</Button>
+        <Button appearance="secondary">Label</Button>
+        <Button appearance="secondary">Label</Button>
+        <Button appearance="secondary">Label</Button>
+      </div>
+      <style jsx>{`
+        .tags {
+          display: flex;
+          flex-wrap: wrap;
+        }
+        .tags > * {
+          margin-right: ${layout.spacingXSmall};
+          margin-bottom: ${layout.spacingXSmall};
+        }
+        .metadata {
+          display: flex;
+          align-items: center;
+          flex-wrap: wrap;
+          list-style: none;
+          margin: ${layout.spacingXSmall} 0;
+        }
+        .metadata > * {
+          margin-bottom: ${layout.spacingXSmall};
+        }
+        .metadata > *:not(:last-child):after {
+          content: '\\00b7';
+          display: inline-block;
+          height: 1em;
+          width: ${layout.spacingLarge};
+          text-align: center;
+        }
+        .button-bar {
+          display: flex;
+          flex-wrap: wrap;
+        }
+        .button-bar > * {
+          margin-right: ${layout.spacingXSmall};
+          margin-bottom: ${layout.spacingXSmall};
         }
       `}</style>
     </div>

--- a/docs/src/content/patterns/page-headings.mdx
+++ b/docs/src/content/patterns/page-headings.mdx
@@ -32,14 +32,20 @@ function Example() {
         <Button>Label</Button>
       </div>
       <style jsx>{`
+        .button-bar > * {
+          margin-bottom: ${layout.spacingXSmall};
+        }
         @media (max-width: 767px) {
           .button-bar > * {
             display: block;
-            margin-bottom: ${layout.spacingXSmall};
             width: 100%;
           }
         }
         @media (min-width: 768px) {
+          .button-bar {
+            display: flex;
+            flex-wrap: wrap;
+          }
           .button-bar > * {
             margin-right: ${layout.spacingXSmall};
           }

--- a/docs/src/content/patterns/page-headings.mdx
+++ b/docs/src/content/patterns/page-headings.mdx
@@ -19,12 +19,12 @@ import React from 'react'
 function Example() {
   return (
     <div className="basic-heading">
-      <div className="title">
+      <div className="basic-heading__title">
         <Heading size="xLarge">
           <h1>Heading</h1>
         </Heading>
       </div>
-      <div className="button-bar">
+      <div className="basic-heading__button-bar">
         <SearchInput placeholder="Placeholder" />
         <Button appearance="secondary">Label</Button>
         <Button appearance="secondary">Label</Button>
@@ -32,24 +32,24 @@ function Example() {
         <Button>Label</Button>
       </div>
       <style jsx>{`
-        .button-bar > * {
+        .basic-heading__button-bar > * {
           margin-bottom: ${layout.spacingXSmall};
         }
         @media (max-width: 767px) {
-          .button-bar > * {
+          .basic-heading__button-bar > * {
             display: block;
             width: 100%;
           }
         }
         @media (min-width: 768px) {
-          .button-bar {
+          .basic-heading__button-bar {
             display: flex;
             flex-wrap: wrap;
           }
-          .button-bar > * {
+          .basic-heading__button-bar > * {
             margin-right: ${layout.spacingXSmall};
           }
-          .button-bar > *:last-child {
+          .basic-heading__button-bar > *:last-child {
             margin-right: 0;
           }
         }
@@ -59,7 +59,7 @@ function Example() {
             justify-content: space-between;
             align-items: center;
           }
-          .title {
+          .basic-heading__title {
             margin-right: ${layout.spacingLarge};
           }
         }
@@ -163,7 +163,7 @@ function Example() {
         iPhone, ethical banh mi post-ironic palo santo 90's vexillologist. 8-bit
         viral.
       </P>
-      <div className="tags">
+      <div className="robust-heading__tags">
         <Tag>Tag label</Tag>
         <Tag>Tag label</Tag>
         <Tag>Tag label</Tag>
@@ -171,7 +171,7 @@ function Example() {
         <Tag>Tag label</Tag>
         <Tag>Tag label</Tag>
       </div>
-      <ul className="metadata">
+      <ul className="robust-heading__metadata">
         <li>Meta data</li>
         <li>Meta data</li>
         <li>Meta data</li>
@@ -179,43 +179,43 @@ function Example() {
           <StarRating value={3} />
         </li>
       </ul>
-      <div className="button-bar">
+      <div className="robust-heading__button-bar">
         <Button>Label</Button>
         <Button appearance="secondary">Label</Button>
         <Button appearance="secondary">Label</Button>
         <Button appearance="secondary">Label</Button>
       </div>
       <style jsx>{`
-        .tags {
+        .robust-heading__tags {
           display: flex;
           flex-wrap: wrap;
         }
-        .tags > * {
+        .robust-heading__tags > * {
           margin-right: ${layout.spacingXSmall};
           margin-bottom: ${layout.spacingXSmall};
         }
-        .metadata {
+        .robust-heading__metadata {
           display: flex;
           align-items: center;
           flex-wrap: wrap;
           list-style: none;
           margin: ${layout.spacingXSmall} 0;
         }
-        .metadata > * {
+        .robust-heading__metadata > * {
           margin-bottom: ${layout.spacingXSmall};
         }
-        .metadata > *:not(:last-child):after {
+        .robust-heading__metadata > *:not(:last-child):after {
           content: '\\00b7';
           display: inline-block;
           height: 1em;
           width: ${layout.spacingLarge};
           text-align: center;
         }
-        .button-bar {
+        .robust-heading__button-bar {
           display: flex;
           flex-wrap: wrap;
         }
-        .button-bar > * {
+        .robust-heading__button-bar > * {
           margin-right: ${layout.spacingXSmall};
           margin-bottom: ${layout.spacingXSmall};
         }
@@ -239,14 +239,14 @@ import React from 'react'
 function Example() {
   return (
     <div className="power-heading">
-      <div className="title">
+      <div className="power-heading__title">
         <div>
           <Breadcrumb>Label</Breadcrumb>
           <Heading>
             <h1>Page Title</h1>
           </Heading>
         </div>
-        <div className="main-action-group">
+        <div className="power-heading__main-action-group">
           <div>
             <div>
               <Label strong size="medium">
@@ -273,25 +273,25 @@ function Example() {
       </Tab.List>
       <style jsx>{`
         @media (max-width: 767px) {
-          .main-action-group > * {
+          .power-heading__main-action-group > * {
             display: block;
             width: 100%;
           }
-          .title {
+          .power-heading__title {
             margin-bottom: ${layout.spacingLarge};
           }
         }
         @media (min-width: 768px) {
-          .title {
+          .power-heading__title {
             display: flex;
             justify-content: space-between;
             align-items: flex-end;
           }
-          .main-action-group {
+          .power-heading__main-action-group {
             display: flex;
             align-items: center;
           }
-          .main-action-group > div:first-child {
+          .power-heading__main-action-group > div:first-child {
             text-align: right;
             margin-right: ${layout.spacingSmall};
           }

--- a/docs/src/content/patterns/page-headings.mdx
+++ b/docs/src/content/patterns/page-headings.mdx
@@ -1,0 +1,64 @@
+---
+name: Page headings
+route: /patterns/page-headings
+---
+
+# Page heading patterns
+
+<TableOfContents {...props} />
+
+### "Basic" heading
+
+```typescript
+import { layout } from '@pluralsight/ps-design-system-core'
+import Button from '@pluralsight/ps-design-system-button'
+import SearchInput from '@pluralsight/ps-design-system-searchinput'
+import { Heading } from '@pluralsight/ps-design-system-text'
+import React from 'react'
+
+function Example() {
+  return (
+    <div className="heading">
+      <div className="title">
+        <Heading>
+          <h1>Heading</h1>
+        </Heading>
+      </div>
+      <div className="button-bar">
+        <SearchInput placeholder="Placeholder" />
+        <Button appearance="secondary">Label</Button>
+        <Button appearance="secondary">Label</Button>
+        <Button appearance="secondary">Label</Button>
+        <Button>Label</Button>
+      </div>
+      <style jsx>{`
+        @media (max-width: 767px) {
+          .button-bar > * {
+            display: block;
+            margin-bottom: ${layout.spacingXSmall};
+            width: 100%;
+          }
+        }
+        @media (min-width: 768px) {
+          .button-bar > * {
+            margin-right: ${layout.spacingXSmall};
+          }
+          .button-bar > *:last-child {
+            margin-right: 0;
+          }
+        }
+        @media (min-width: 1024px) {
+          .heading {
+            display: flex;
+            align-items: center;
+          }
+          .title {
+            margin-right: ${layout.spacingLarge};
+          }
+        }
+      `}</style>
+    </div>
+  )
+}
+export default Example
+```


### PR DESCRIPTION
- Used frame labels in figma so that designers and developers are hopefully talking the same language.
- Called the last pattern in figma "Basic alternative". It was unlabeled in figma.
- Seems like some explanatory text would be useful. I see patterns without context. Oooh, I like this one, it has all the widgets I need. For instance, how would one decide which of the "basic" patterns he should use? One has an icon and fewer buttons, but that doesn't seem to indicate enough to be educated about the existence of 2 similar choices.
