### PR TITLE
expose dropdown's uniqueId function for test

### DIFF
--- a/docs/src/content/components/dropdown.mdx
+++ b/docs/src/content/components/dropdown.mdx
@@ -411,6 +411,11 @@ export default Example
     type="string"
     desc="supporting text or error messaging"
   />
+  <TypesProp
+    name="uniqueId"
+    type="(prefix: string) => string"
+    desc="override internal id generation for test stability"
+  />
 </TypesTable>
 
 ### Dropdown.Item

--- a/packages/dropdown/src/js/index.ts
+++ b/packages/dropdown/src/js/index.ts
@@ -13,7 +13,7 @@ import {
 } from 'react'
 import {
   canUseDOM,
-  uniqueId,
+  uniqueId as defaultUniqueId,
   ValueOf,
   HTMLPropsFor
 } from '@pluralsight/ps-design-system-util'
@@ -50,6 +50,7 @@ interface UseDropdownProps extends Omit<HTMLPropsFor<'button'>, 'onChange'> {
   size?: ValueOf<typeof vars.sizes>
   style?: React.CSSProperties
   subLabel?: ReactNode
+  uniqueId?: (prefix: string) => string
   value?: number | string
 }
 
@@ -66,6 +67,7 @@ const sortDropdownProps = ({
   size,
   subLabel,
   style,
+  uniqueId,
   value,
   ...rest
 }: UseDropdownProps) => ({
@@ -114,6 +116,7 @@ export const useDropdown = (
 ) => {
   const { hook, ...rest } = sortDropdownProps(props)
   const [isOpen, setOpen] = useState(false)
+  const uniqueId = props.uniqueId || defaultUniqueId
   const inputId = useMemo(() => uniqueId('dropdown-input-'), [])
   const menuId = useMemo(() => uniqueId('dropdown-menu-'), [])
 

--- a/packages/dropdown/src/react/__specs__/storyshots.spec.ts
+++ b/packages/dropdown/src/react/__specs__/storyshots.spec.ts
@@ -3,11 +3,6 @@ import initStoryshots, {
   snapshotWithOptions
 } from '@storybook/addon-storyshots'
 
-jest.mock('@pluralsight/ps-design-system-util', () => ({
-  ...jest.requireActual('@pluralsight/ps-design-system-util'),
-  uniqueId: jest.fn().mockImplementation(prefix => prefix + 'unique-id')
-}))
-
 const createNodeMock = () => document.createElement('div')
 
 initStoryshots({

--- a/packages/dropdown/src/react/__stories__/index.story.tsx
+++ b/packages/dropdown/src/react/__stories__/index.story.tsx
@@ -16,16 +16,22 @@ import Dropdown from '../'
 import { DropdownContext, useDropdown } from '../../js'
 import { HTMLPropsFor } from '@pluralsight/ps-design-system-util'
 
+const stableId = (prefix = '') => prefix + 'unique-id'
+
+const DefaultDropdown = (props: React.ComponentProps<typeof Dropdown>) => (
+  <Dropdown uniqueId={stableId} {...props} />
+)
+
 storiesOf('labels', module)
-  .add('none', () => <Dropdown />)
-  .add('placeholder', () => <Dropdown placeholder="some placeholder" />)
-  .add('label', () => <Dropdown label="Some label" />)
-  .add('subLabel', () => <Dropdown subLabel="Some sublabel" />)
+  .add('none', () => <DefaultDropdown />)
+  .add('placeholder', () => <DefaultDropdown placeholder="some placeholder" />)
+  .add('label', () => <DefaultDropdown label="Some label" />)
+  .add('subLabel', () => <DefaultDropdown subLabel="Some sublabel" />)
   .add('label and subLabel', () => (
-    <Dropdown label="Some label" subLabel="Some sublabel" />
+    <DefaultDropdown label="Some label" subLabel="Some sublabel" />
   ))
   .add('all', () => (
-    <Dropdown
+    <DefaultDropdown
       label="Some label"
       subLabel="Some sublabel"
       placeholder="Some placeholder"
@@ -37,7 +43,7 @@ const appearanceStory = storiesOf('appearance', module)
 Object.keys(Dropdown.sizes).forEach(size =>
   Object.keys(Dropdown.appearances).forEach(appearance =>
     appearanceStory.add(`${size} ${appearance}`, () => (
-      <Dropdown
+      <DefaultDropdown
         size={size as 'medium' | 'small'}
         appearance={appearance as 'default' | 'subtle'}
         placeholder="The placeholder "
@@ -47,7 +53,7 @@ Object.keys(Dropdown.sizes).forEach(size =>
 )
 Object.keys(Dropdown.appearances).forEach(appearance =>
   appearanceStory.add(`${appearance} w/ error`, () => (
-    <Dropdown
+    <DefaultDropdown
       appearance={appearance as 'default' | 'subtle'}
       error
       label="Problem field"
@@ -57,19 +63,19 @@ Object.keys(Dropdown.appearances).forEach(appearance =>
 appearanceStory.add('gaps', () => (
   <div>
     <div>
-      <Dropdown label="Problem field" />
+      <DefaultDropdown label="Problem field" />
     </div>
     <div>
-      <Dropdown error label="Problem field" />
+      <DefaultDropdown error label="Problem field" />
     </div>
     <div>
-      <Dropdown
+      <DefaultDropdown
         appearance={Dropdown.appearances.subtle}
         label="Problem field"
       />
     </div>
     <div>
-      <Dropdown
+      <DefaultDropdown
         appearance={Dropdown.appearances.subtle}
         error
         label="Problem field"
@@ -81,12 +87,12 @@ appearanceStory.add('gaps', () => (
 storiesOf('disabled', module)
   .add('compare dropdown', () => (
     <div>
-      <Dropdown
+      <DefaultDropdown
         label="Normal"
         subLabel="Still normal"
         placeholder="I'm normal, see"
       />
-      <Dropdown
+      <DefaultDropdown
         label="I'm not usable"
         subLabel="Neither am I"
         disabled
@@ -96,7 +102,7 @@ storiesOf('disabled', module)
   ))
   .add('compare items', () => (
     <div>
-      <Dropdown
+      <DefaultDropdown
         label="Normal"
         placeholder="Has mixed labels"
         menu={
@@ -125,7 +131,7 @@ storiesOf('whitelist', module)
       return (
         <div>
           <div style={{ color: '#ababab' }}>Value: {value}</div>
-          <Dropdown
+          <DefaultDropdown
             placeholder="Change me"
             label="Thing to change"
             menu={
@@ -162,7 +168,7 @@ storiesOf('whitelist', module)
         <div>
           <div style={{ color: '#ababab' }}>Value: {value}</div>
           <button onClick={handleClear}>Clear</button>
-          <Dropdown
+          <DefaultDropdown
             placeholder="Change me"
             label="Thing to change"
             menu={
@@ -185,18 +191,21 @@ storiesOf('whitelist', module)
 storiesOf('layouts', module)
   .add('full width', () => (
     <div style={{ border: '1px solid blue', width: '500px' }}>
-      <Dropdown label="First" style={{ display: 'block', width: '100%' }} />
-      <Dropdown
+      <DefaultDropdown
+        label="First"
+        style={{ display: 'block', width: '100%' }}
+      />
+      <DefaultDropdown
         error
         label="Second"
         style={{ display: 'block', width: '100%' }}
       />
-      <Dropdown
+      <DefaultDropdown
         appearance={Dropdown.appearances.subtle}
         label="Third"
         style={{ display: 'block', width: '100%' }}
       />
-      <Dropdown
+      <DefaultDropdown
         appearance={Dropdown.appearances.subtle}
         error
         label="Fourth"
@@ -207,7 +216,7 @@ storiesOf('layouts', module)
   .add('right-aligned', () => (
     <div style={{ border: '1px solid blue' }}>
       <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-        <Dropdown
+        <DefaultDropdown
           placeholder="Filter"
           appearance={Dropdown.appearances.subtle}
         />
@@ -228,7 +237,7 @@ storiesOf('layouts', module)
       return (
         <div>
           <div style={{ color: '#ababab' }}>Value: {value}</div>
-          <Dropdown
+          <DefaultDropdown
             placeholder="Change me"
             label="Width 150"
             style={{ width: 150 }}
@@ -244,7 +253,7 @@ storiesOf('layouts', module)
             onChange={handleChange}
             value={value}
           />
-          <Dropdown
+          <DefaultDropdown
             placeholder="Change me"
             label="Width determined by longest item"
             menu={
@@ -269,7 +278,7 @@ storiesOf('value', module)
   .add('no preselection', () => (
     <>
       <h2>With values</h2>
-      <Dropdown
+      <DefaultDropdown
         placeholder="Shown until selection made"
         menu={
           <>
@@ -280,7 +289,7 @@ storiesOf('value', module)
         }
       />
       <h2>Just labels</h2>
-      <Dropdown
+      <DefaultDropdown
         placeholder="Shown until selection made"
         menu={
           <>
@@ -293,7 +302,7 @@ storiesOf('value', module)
     </>
   ))
   .add('shows pre-selected item by label', () => (
-    <Dropdown
+    <DefaultDropdown
       placeholder="Shown because can't find option"
       value="Preselected three item"
       menu={
@@ -306,7 +315,7 @@ storiesOf('value', module)
     />
   ))
   .add('shows pre-selected item by value', () => (
-    <Dropdown
+    <DefaultDropdown
       placeholder="Not shown until empty"
       value="h"
       menu={
@@ -319,7 +328,7 @@ storiesOf('value', module)
     />
   ))
   .add('value is not an item in the list', () => (
-    <Dropdown
+    <DefaultDropdown
       placeholder="Shown because can't find option"
       value="unknown"
       menu={
@@ -345,7 +354,7 @@ storiesOf('value', module)
       })
 
       return (
-        <Dropdown
+        <DefaultDropdown
           placeholder="Not shown until empty"
           value={value}
           menu={
@@ -362,7 +371,7 @@ storiesOf('value', module)
   })
 
   .add('test the spec', () => (
-    <Dropdown
+    <DefaultDropdown
       placeholder="Select"
       value="w"
       menu={[
@@ -381,7 +390,7 @@ storiesOf('value', module)
 
 storiesOf('menu', module)
   .add('single list', () => (
-    <Dropdown
+    <DefaultDropdown
       label="Level"
       menu={
         <>
@@ -394,7 +403,7 @@ storiesOf('menu', module)
     />
   ))
   .add('max height', () => (
-    <Dropdown
+    <DefaultDropdown
       label="Level"
       menu={
         <>
@@ -418,7 +427,7 @@ storiesOf('menu', module)
     />
   ))
   .add('w/ value', () => (
-    <Dropdown
+    <DefaultDropdown
       label="Level"
       value="three-1"
       menu={
@@ -434,7 +443,7 @@ storiesOf('menu', module)
     />
   ))
   .add('w/ subLabel', () => (
-    <Dropdown
+    <DefaultDropdown
       label="Level"
       subLabel="The course level"
       menu={
@@ -448,7 +457,7 @@ storiesOf('menu', module)
     />
   ))
   .add('single list w/ icon', () => (
-    <Dropdown
+    <DefaultDropdown
       label="Level"
       placeholder="Select one"
       menu={
@@ -464,7 +473,7 @@ storiesOf('menu', module)
     />
   ))
   .add('divider', () => (
-    <Dropdown
+    <DefaultDropdown
       label="Level"
       menu={
         <>
@@ -480,7 +489,7 @@ storiesOf('menu', module)
   .add('in stack', () => (
     <div>
       <div>
-        <Dropdown
+        <DefaultDropdown
           label="Level"
           placeholder="Select one"
           menu={
@@ -494,7 +503,7 @@ storiesOf('menu', module)
         />
       </div>
       <div>
-        <Dropdown
+        <DefaultDropdown
           label="Level"
           placeholder="Select another one"
           menu={
@@ -512,7 +521,7 @@ storiesOf('menu', module)
     </div>
   ))
   .add('super long', () => (
-    <Dropdown
+    <DefaultDropdown
       label="Level"
       menu={
         <>
@@ -525,7 +534,7 @@ storiesOf('menu', module)
     />
   ))
   .add('onClicks', () => (
-    <Dropdown
+    <DefaultDropdown
       label="Level"
       appearance={Dropdown.appearances.subtle}
       placeholder="Select another one"
@@ -540,7 +549,7 @@ storiesOf('menu', module)
     />
   ))
   .add('w/ longer placeholder', () => (
-    <Dropdown
+    <DefaultDropdown
       label="Level"
       placeholder="This one is longer than any menu item"
       menu={
@@ -553,7 +562,7 @@ storiesOf('menu', module)
   ))
 
 storiesOf('props whitelist', module).add('title', () => (
-  <Dropdown
+  <DefaultDropdown
     title="This title should be present"
     label="Level"
     menu={
@@ -571,14 +580,18 @@ const AutofocusStory: React.FC = props => {
     ref.current?.focus()
   })
 
-  return <Dropdown {...props} ref={ref} />
+  return <DefaultDropdown {...props} ref={ref} />
 }
 
 storiesOf('focus', module)
-  .add('onFocus', () => <Dropdown onFocus={action('focused')} />)
-  .add('onBlur', () => <Dropdown onBlur={action('blurred')} />)
+  .add('onFocus', () => <DefaultDropdown onFocus={action('focused')} />)
+  .add('onBlur', () => <DefaultDropdown onBlur={action('blurred')} />)
   .add('disabled', () => (
-    <Dropdown disabled onBlur={action('blurred')} onFocus={action('focused')} />
+    <DefaultDropdown
+      disabled
+      onBlur={action('blurred')}
+      onFocus={action('focused')}
+    />
   ))
   .add('autofocus with ref', () => <AutofocusStory />)
 storiesOf('portal', module).add('position', () => (
@@ -611,7 +624,7 @@ storiesOf('portal', module).add('position', () => (
     aliquet sagittis. Elit pellentesque habitant morbi tristique. Sit amet
     consectetur adipiscing elit. Id volutpat lacus laoreet non curabitur gravida
     arcu ac. Enim neque volutpat ac tincidunt. Lorem ipsum dolor sit amet.
-    <Dropdown
+    <DefaultDropdown
       label="Level"
       menu={
         <>
@@ -672,7 +685,7 @@ interface DropdownWithIconProps extends React.ComponentProps<typeof Dropdown> {
 
 const DropdownWithIcon = forwardRef<HTMLButtonElement, DropdownWithIconProps>(
   ({ icon, ...props }, forwardedRef) => {
-    const allProps = useDropdown(props, forwardedRef)
+    const allProps = useDropdown({ uniqueId: stableId, ...props }, forwardedRef)
 
     return (
       <Dropdown.Layout

--- a/packages/dropdown/src/react/index.tsx
+++ b/packages/dropdown/src/react/index.tsx
@@ -46,6 +46,7 @@ interface DropdownProps extends Omit<HTMLPropsFor<'button'>, 'onChange'> {
   placeholder?: string
   size?: ValueOf<typeof vars.sizes>
   subLabel?: ReactNode
+  uniqueId?: (prefix: string) => string
   value?: React.ReactText
 }
 interface DropdownComponent


### PR DESCRIPTION
Search team is trying to mock uniqueId's for snapshot stability, similar to what we have done.  The problem is that jest.mock requires a package name to mock a dependency. By the time we build, this package name information is not available for consumers to reach down into our code and identify the uniqueId function. This exposes uniqueId on Dropdown directly.

Could have done this through a static. The override method then would have been similar, using jest.mock.  Chose instead to simply use a prop. This is simpler and doesn't require mocking.
