### PR TITLE
fix sandbox dependencies

### DIFF
--- a/docs/src/components/code-block/actions.tsx
+++ b/docs/src/components/code-block/actions.tsx
@@ -81,7 +81,8 @@ export const CodeSandboxAction: React.FC<CodeSandboxActionProps> = props => {
         '@pluralsight/ps-design-system-normalize': 'latest',
         '@pluralsight/ps-design-system-theme': 'latest',
         '@babel/runtime': 'latest',
-        glamor: 'latest'
+        glamor: 'latest',
+        invariant: 'latest'
       }}
       gitInfo={gitInfo}
       pkgJSON={pkg}


### PR DESCRIPTION
- I'm assuming that `invariant` must come from the `devDependencies` present. It might not be. We could just list it as a new dependencies, as that seems to solve the problem manually within codesandbox.  Waddya think?
- I think the problem is that devDependencies don't show up in the sandbox. https://github.com/codesandbox/codesandbox-client/issues/2794
