### PR TITLE
refactor(core): indicate deprecated vars in comments

### DIFF
--- a/packages/core/css/type.module.css
+++ b/packages/core/css/type.module.css
@@ -3,7 +3,7 @@
   --psTypeFontFamily: 'PS TT Commons Roman', 'Gotham SSm A', 'Gotham SSm B', Arial, sans-serif;
   --psTypeFontFamilyCode: 'DM Mono', 'Source Code Pro', monospace;
 
-  /* font size */
+  /* font size (deprecated) */
   --psTypeFontSizeGigantic: 60px;
   --psTypeFontSizeJumbo: 48px;
   --psTypeFontSizeXXLarge: 36px;
@@ -13,6 +13,7 @@
   --psTypeFontSizeSmall: 14px;
   --psTypeFontSizeXSmall: 12px;
 
+  /* font size */
   --psTypeFontSizeBase: 16px;
   --psTypeFontSize1200: 88px;
   --psTypeFontSize1100: 72px;
@@ -27,7 +28,7 @@
   --psTypeFontSize200: 14px;
   --psTypeFontSize100: 12px;
 
-  /* letter spacing */
+  /* letter spacing (deprecated) */
   --psTypeLetterSpacingGigantic: -1px;
   --psTypeLetterSpacingJumbo: -0.72px;
   --psTypeLetterSpacingXXLarge: -0.54px;
@@ -37,6 +38,7 @@
   --psTypeLetterSpacingSmall: 0;
   --psTypeLetterSpacingXSmall: 0;
 
+  /* letter spacing */
   --psTypeLetterSpacingTighter: -0.025em;
   --psTypeLetterSpacingTight: -0.01em;
   --psTypeLetterSpacingNone: 0;
@@ -44,7 +46,7 @@
   --psTypeLetterSpacingLooser: 0.025em;
   --psTypeLetterSpacingAllCaps: 0.08em;
 
-  /* font weight */
+  /* font weight (deprecated) */
   --psTypeFontWeightBlack: 900;
   --psTypeFontWeightXBold: 800;
   --psTypeFontWeightBold: 700;
@@ -56,6 +58,7 @@
   --psTypeFontWeightXLight: 200;
   --psTypeFontWeightThin: 100;
 
+  /* font weight */
   --psTypeFontWeightDefault: 400;
   --psTypeFontWeightStrong: 600;
   --psTypeFontWeight900: 900;

--- a/packages/core/js/type.ts
+++ b/packages/core/js/type.ts
@@ -3,7 +3,7 @@ export default {
     '"PS TT Commons Roman", "Gotham SSm A", "Gotham SSm B", Arial, sans-serif',
   fontFamilyCode: '"DM Mono", "Source Code Pro", monospace',
 
-  /* font size */
+  /* font size (deprecated) */
   fontSizeGigantic: '60px',
   fontSizeJumbo: '48px',
   fontSizeXXLarge: '36px',
@@ -13,6 +13,7 @@ export default {
   fontSizeSmall: '14px',
   fontSizeXSmall: '12px',
 
+  /* font size */
   fontSizeBase: '16px',
   fontSize1200: '88px',
   fontSize1100: '72px',
@@ -27,7 +28,7 @@ export default {
   fontSize200: '14px',
   fontSize100: '12px',
 
-  /* letter spacing */
+  /* letter spacing (deprecated) */
   letterSpacingGigantic: '-1px',
   letterSpacingJumbo: '-0.72px',
   letterSpacingXXLarge: '-0.72px',
@@ -37,6 +38,7 @@ export default {
   letterSpacingSmall: 0,
   letterSpacingXSmall: 0,
 
+  /* letter spacing */
   letterSpacingTighter: '-0.025em',
   letterSpacingTight: '-0.01em',
   letterSpacingNone: 0,
@@ -44,7 +46,7 @@ export default {
   letterSpacingLooser: '0.025em',
   letterSpacingAllCaps: '0.08em',
 
-  /* font weight */
+  /* font weight (deprecated) */
   fontWeightBlack: 900,
   fontWeightXBold: 800,
   fontWeightBold: 700,
@@ -56,6 +58,7 @@ export default {
   fontWeightXLight: 200,
   fontWeightThin: 100,
 
+  /* font weight */
   fontWeightDefault: 400,
   fontWeightStrong: 600,
   fontWeight900: 900,


### PR DESCRIPTION
We'll eventually want remove the old vars, but until then, I used the comments to indicate which sets are deprecated.