### PR TITLE
feat(carousel): add custom uniqueId prop for testing

### DIFF
--- a/packages/carousel/src/react/__specs__/storyshots.spec.tsx
+++ b/packages/carousel/src/react/__specs__/storyshots.spec.tsx
@@ -3,15 +3,6 @@ import initStoryshots, {
   snapshotWithOptions
 } from '@storybook/addon-storyshots'
 
-jest.mock('../../js/utils', () => {
-  const original = jest.requireActual('../../js/utils.ts')
-  const uniqueId = jest
-    .fn()
-    .mockImplementation((prefix = '') => `${prefix}mock_unique_id`)
-
-  return { ...original, uniqueId }
-})
-
 const createNodeMock = () => document.createElement('div')
 
 initStoryshots({

--- a/packages/carousel/src/react/__specs__/use-unique-id.spec.ts
+++ b/packages/carousel/src/react/__specs__/use-unique-id.spec.ts
@@ -2,11 +2,11 @@ import { renderHook } from '@testing-library/react-hooks'
 
 import useUniqueId from '../use-unique-id'
 
-
-const uniqueId = jest.fn().mockImplementation(prefix => prefix + '12345')
+const uniqueId = jest
+  .fn()
+  .mockImplementation((prefix: string) => prefix + '12345')
 
 describe('useUniqueId', () => {
-
   beforeEach(() => {
     uniqueId.mockClear()
   })
@@ -32,7 +32,9 @@ describe('useUniqueId', () => {
   })
 
   it('supports prefixing', () => {
-    const { rerender, result } = renderHook(() => useUniqueId('the_prefix_', uniqueId))
+    const { rerender, result } = renderHook(() =>
+      useUniqueId('the_prefix_', uniqueId)
+    )
 
     expect(result.current).toEqual('the_prefix_12345')
 

--- a/packages/carousel/src/react/__specs__/use-unique-id.spec.ts
+++ b/packages/carousel/src/react/__specs__/use-unique-id.spec.ts
@@ -2,19 +2,17 @@ import { renderHook } from '@testing-library/react-hooks'
 
 import useUniqueId from '../use-unique-id'
 
-jest.mock('../../js/utils', () => ({
-  uniqueId: jest.fn().mockImplementation(prefix => prefix + '12345')
-}))
+
+const uniqueId = jest.fn().mockImplementation(prefix => prefix + '12345')
 
 describe('useUniqueId', () => {
-  const { uniqueId } = require('../../js/utils')
 
   beforeEach(() => {
     uniqueId.mockClear()
   })
 
   it('should provide a stable id across renders', () => {
-    const { rerender, result } = renderHook(() => useUniqueId())
+    const { rerender, result } = renderHook(() => useUniqueId('', uniqueId))
 
     expect(result.current).toEqual('12345')
 
@@ -34,7 +32,7 @@ describe('useUniqueId', () => {
   })
 
   it('supports prefixing', () => {
-    const { rerender, result } = renderHook(() => useUniqueId('the_prefix_'))
+    const { rerender, result } = renderHook(() => useUniqueId('the_prefix_', uniqueId))
 
     expect(result.current).toEqual('the_prefix_12345')
 

--- a/packages/carousel/src/react/__stories__/index.story.tsx
+++ b/packages/carousel/src/react/__stories__/index.story.tsx
@@ -8,10 +8,12 @@ import React from 'react'
 
 import Carousel, { Item } from '..'
 
+const uniqueId = (prefix = '') => `${prefix}mock_unique_id`
+
 interface MockCardProps
   extends Omit<
-    React.ComponentProps<typeof Card>,
-    'title' | 'actionBar' | 'image' | 'metadata1'
+  React.ComponentProps<typeof Card>,
+  'title' | 'actionBar' | 'image' | 'metadata1'
   > {
   titleText: string
 }
@@ -79,18 +81,18 @@ const MockItem: React.FC<React.HTMLAttributes<HTMLDivElement>> = props => (
 
 storiesOf('Carousel/items', module)
   .add('one item', () => (
-    <Carousel>
+    <Carousel uniqueId={uniqueId}>
       <MockItem>just one item</MockItem>
     </Carousel>
   ))
   .add('two items', () => (
-    <Carousel>
+    <Carousel uniqueId={uniqueId}>
       <MockItem>first item</MockItem>
       <MockItem>second item</MockItem>
     </Carousel>
   ))
   .add('many items', () => (
-    <Carousel>
+    <Carousel uniqueId={uniqueId}>
       {new Array(21).fill(null).map((_, index) => (
         <MockItem key={index}>item: {index + 1}</MockItem>
       ))}
@@ -105,7 +107,7 @@ storiesOf('Carousel/items', module)
 
       return (
         <>
-          <Carousel>
+          <Carousel uniqueId={uniqueId}>
             {new Array(count).fill(null).map((_, index) => (
               <MockItem key={index}>item: {index + 1}</MockItem>
             ))}
@@ -134,6 +136,7 @@ storiesOf('Carousel/items', module)
 
 storiesOf('Carousel/controls', module).add('custom alignment', () => (
   <Carousel
+    uniqueId={uniqueId}
     controlPrev={
       <Carousel.Control
         direction={Carousel.Control.directions.prev}
@@ -157,7 +160,7 @@ const sizeStories = storiesOf('Carousel/size', module)
 
 Object.values(Carousel.sizes).forEach(size => {
   sizeStories.add(size, () => (
-    <Carousel size={size}>
+    <Carousel uniqueId={uniqueId} size={size}>
       {new Array(13).fill(null).map((_, index) => (
         <MockItem key={index}>item: {index + 1}</MockItem>
       ))}
@@ -166,7 +169,7 @@ Object.values(Carousel.sizes).forEach(size => {
 })
 storiesOf('Carousel/Item', module)
   .add('with child nodes', () => (
-    <Carousel size={Carousel.sizes.wide}>
+    <Carousel uniqueId={uniqueId} size={Carousel.sizes.wide}>
       {new Array(9).fill(null).map((_, index) => (
         <Carousel.Item key={index}>
           <MockItem />
@@ -175,7 +178,7 @@ storiesOf('Carousel/Item', module)
     </Carousel>
   ))
   .add('with render props', () => (
-    <Carousel size={Carousel.sizes.wide}>
+    <Carousel uniqueId={uniqueId} size={Carousel.sizes.wide}>
       {new Array(9).fill(null).map((_, index) => (
         <Carousel.Item key={index}>
           {(data: React.ComponentProps<typeof Item>) => (
@@ -193,7 +196,7 @@ const cardStories = storiesOf('Carousel/with Card', module)
 Object.values(Carousel.sizes).forEach(size => {
   cardStories.add(size, () => (
     <>
-      <Carousel size={size}>
+      <Carousel uniqueId={uniqueId} size={size}>
         <MockCard metadata1={longStringsMetaData} titleText="Title Here" />
 
         {new Array(13).fill(null).map((_, index) => (
@@ -207,7 +210,7 @@ Object.values(Carousel.sizes).forEach(size => {
 storiesOf('Carousel/with ActionMenu', module)
   .add('positioned child', () => (
     <div style={{ border: '1px solid red', maxWidth: 400, padding: 10 }}>
-      <Carousel size={Carousel.sizes.wide}>
+      <Carousel uniqueId={uniqueId} size={Carousel.sizes.wide}>
         <MockItem>
           <ActionMenu style={{ left: 20, top: 20 }}>
             {new Array(8).fill(null).map((_, index) => (
@@ -228,6 +231,7 @@ storiesOf('Carousel/with ActionMenu', module)
       return (
         <div style={{ border: '1px solid red', maxWidth: 600, padding: 10 }}>
           <Carousel
+            uniqueId={uniqueId}
             size={Carousel.sizes.wide}
             controlPrev={
               <Carousel.Control
@@ -306,6 +310,7 @@ storiesOf('Carousel/with ActionMenu', module)
       return (
         <div style={{ border: '1px solid red', maxWidth: 600, padding: 10 }}>
           <Carousel
+            uniqueId={uniqueId}
             size={Carousel.sizes.wide}
             controlPrev={
               <Carousel.Control

--- a/packages/carousel/src/react/__stories__/index.story.tsx
+++ b/packages/carousel/src/react/__stories__/index.story.tsx
@@ -12,8 +12,8 @@ const uniqueId = (prefix = '') => `${prefix}mock_unique_id`
 
 interface MockCardProps
   extends Omit<
-  React.ComponentProps<typeof Card>,
-  'title' | 'actionBar' | 'image' | 'metadata1'
+    React.ComponentProps<typeof Card>,
+    'title' | 'actionBar' | 'image' | 'metadata1'
   > {
   titleText: string
 }

--- a/packages/carousel/src/react/index.tsx
+++ b/packages/carousel/src/react/index.tsx
@@ -40,6 +40,7 @@ interface CarouselProps extends HTMLPropsFor<'div'> {
   controlPrev?: React.ReactNode
   controlNext?: React.ReactNode
   size?: ValueOf<typeof vars.sizes>
+  uniqueId?: (prefix: string) => string
 }
 interface CarouselStatics {
   Control: typeof Control
@@ -53,9 +54,10 @@ const Carousel: CarouselComponent = ({
   controlPrev,
   controlNext,
   size,
+  uniqueId,
   ...rest
 }) => {
-  const id = useUniqueId('carousel-')
+  const id = useUniqueId('carousel-', uniqueId)
   const ref = React.useRef<HTMLDivElement>(null)
   const { width } = useResizeObserver(ref)
 
@@ -160,12 +162,12 @@ export const Item: React.FC<ItemProps> = props => {
     <li {...styles.item()} {...rest}>
       {typeof children === 'function'
         ? children({
-            isActivePage,
-            itemIndex,
-            itemsPerPage,
-            pageCount,
-            pageIndex
-          })
+          isActivePage,
+          itemIndex,
+          itemsPerPage,
+          pageCount,
+          pageIndex
+        })
         : children}
     </li>
   )
@@ -190,7 +192,7 @@ const Instructions: React.FC<HTMLPropsFor<'div'>> = props => {
 
 interface PagesProps
   extends HTMLPropsFor<'div'>,
-    Required<Pick<UseSwipeOpts, 'onSwipeLeft' | 'onSwipeRight'>> {}
+  Required<Pick<UseSwipeOpts, 'onSwipeLeft' | 'onSwipeRight'>> {}
 interface PagesStatics {}
 interface PagesComponent
   extends RefForwardingComponent<PagesProps, HTMLDivElement, PagesStatics> {}

--- a/packages/carousel/src/react/index.tsx
+++ b/packages/carousel/src/react/index.tsx
@@ -162,12 +162,12 @@ export const Item: React.FC<ItemProps> = props => {
     <li {...styles.item()} {...rest}>
       {typeof children === 'function'
         ? children({
-          isActivePage,
-          itemIndex,
-          itemsPerPage,
-          pageCount,
-          pageIndex
-        })
+            isActivePage,
+            itemIndex,
+            itemsPerPage,
+            pageCount,
+            pageIndex
+          })
         : children}
     </li>
   )
@@ -192,7 +192,7 @@ const Instructions: React.FC<HTMLPropsFor<'div'>> = props => {
 
 interface PagesProps
   extends HTMLPropsFor<'div'>,
-  Required<Pick<UseSwipeOpts, 'onSwipeLeft' | 'onSwipeRight'>> {}
+    Required<Pick<UseSwipeOpts, 'onSwipeLeft' | 'onSwipeRight'>> {}
 interface PagesStatics {}
 interface PagesComponent
   extends RefForwardingComponent<PagesProps, HTMLDivElement, PagesStatics> {}

--- a/packages/carousel/src/react/use-unique-id.ts
+++ b/packages/carousel/src/react/use-unique-id.ts
@@ -2,11 +2,11 @@ import { useLayoutEffect, useState } from 'react'
 
 import { uniqueId } from '../js/utils'
 
-export default function useUniqueId(prefix = '') {
+export default function useUniqueId(prefix = '', customUniqueId?: (prefix: string) => string) {
   const [id, setId] = useState('')
 
   useLayoutEffect(() => {
-    setId(uniqueId(prefix))
+    setId(customUniqueId ? customUniqueId(prefix) : uniqueId(prefix))
   }, [prefix])
 
   return id

--- a/packages/carousel/src/react/use-unique-id.ts
+++ b/packages/carousel/src/react/use-unique-id.ts
@@ -2,7 +2,10 @@ import { useLayoutEffect, useState } from 'react'
 
 import { uniqueId } from '../js/utils'
 
-export default function useUniqueId(prefix = '', customUniqueId?: (prefix: string) => string) {
+export default function useUniqueId(
+  prefix = '',
+  customUniqueId?: (prefix: string) => string
+) {
   const [id, setId] = useState('')
 
   useLayoutEffect(() => {


### PR DESCRIPTION
We had trouble mocking out `uniqueId` for snapshot testing. Looking at how you do it for your tests, we tried doing something similar:

```typescript
jest.mock('@pluralsight/ps-design-system-carousel/dist/esm/js/utils', () => ({
  uniqueId: jest.fn().mockImplementation(prefix => prefix + '12345')
}))
```

But that didn't seem to work for us. Any ideas? I'm not sure if you can mock things out this way, or if you'd have to mock out the entire package.

Otherwise, allowing a custom `uniqueId` function to be passed in seems to be the friendliest solution, as we did for the dropdown (https://github.com/pluralsight/design-system/pull/1522)
