### PR TITLE
fix core module path

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
   "author": "jaketrent",
   "keywords": [],
   "main": "dist/index.js",
-  "module": "js/index.js",
+  "module": "js/index.ts",
   "scripts": {
     "build": "run-s build:js build:css",
     "build:css": "node ./build",


### PR DESCRIPTION
Anything that detects modules and pulls code through this entry will fail, because js/index.js doesn't exist.
