### PR TITLE
Badge design & a11y tweaks

### DIFF
--- a/docs/src/content/components/badge.mdx
+++ b/docs/src/content/components/badge.mdx
@@ -22,9 +22,9 @@ import React from 'react'
 function Example() {
   return (
     <div className="example-grid--col-2">
-      <Badge color={Badge.colors.gray}>Gray Badge</Badge>
-      <Badge color={Badge.colors.gray} appearance={Badge.appearances.subtle}>
-        Gray Badge (Subtle)
+      <Badge color={Badge.colors.neutral}>Neutral Badge</Badge>
+      <Badge color={Badge.colors.neutral} appearance={Badge.appearances.subtle}>
+        Neutral Badge (Subtle)
       </Badge>
       <Badge color={Badge.colors.green}>Green Badge</Badge>
       <Badge color={Badge.colors.green} appearance={Badge.appearances.subtle}>

--- a/docs/src/content/components/badge.mdx
+++ b/docs/src/content/components/badge.mdx
@@ -63,12 +63,12 @@ export default Example
     name="appearance"
     type={<TypesEnum enum={Badge.appearances} />}
     desc="badge appearance (from Badge.appearances)"
-    default="blue"
+    default="default"
   />
   <TypesProp
     name="color"
     type={<TypesEnum enum={Badge.colors} />}
     desc="badge color (from Badge.colors)"
-    default="blue"
+    default="neutral"
   />
 </TypesTable>

--- a/packages/badge/src/css/index.ts
+++ b/packages/badge/src/css/index.ts
@@ -8,7 +8,7 @@ import {
   colorsYellow,
   colorsBlue,
   colorsRed,
-  colorsBorder
+  colorsWhite
 } from '@pluralsight/ps-design-system-core'
 import { names as themeNames } from '@pluralsight/ps-design-system-theme'
 
@@ -17,112 +17,98 @@ import { select } from '../js'
 
 export default {
   '.psds-badge': {
-    border: `1px solid transparent`,
     borderRadius: '2px',
     display: 'inline-block',
     fontSize: type.fontSize100,
-    fontWeight: type.fontWeight500,
+    letterSpacing: type.letterSpacingAllCaps,
+    fontWeight: type.fontWeightStrong,
     lineHeight: type.lineHeightStandard,
     padding: `0 ${layout.spacingXSmall}`,
     textTransform: 'uppercase'
   },
 
-  [select(themeNames.dark, appearances.default, colors.gray)]: {
-    color: colorsTextIcon.highOnDark,
-    backgroundColor: colorsBackgroundUtility[25]
+  [select(themeNames.dark, appearances.default, colors.neutral)]: {
+    color: colorsTextIcon.highOnLight,
+    backgroundColor: colorsWhite
   },
   [select(themeNames.dark, appearances.default, colors.green)]: {
     color: colorsTextIcon.highOnDark,
-    backgroundColor: colorsGreen.base,
-    borderColor: colorsGreen.base
+    backgroundColor: colorsGreen[8]
   },
   [select(themeNames.dark, appearances.default, colors.yellow)]: {
     color: colorsTextIcon.highOnLight,
-    backgroundColor: colorsYellow.base,
-    borderColor: colorsYellow.base
+    backgroundColor: colorsYellow[6]
   },
   [select(themeNames.dark, appearances.default, colors.red)]: {
     color: colorsTextIcon.highOnDark,
-    backgroundColor: colorsRed.base,
-    borderColor: colorsRed.base
+    backgroundColor: colorsRed[7]
   },
   [select(themeNames.dark, appearances.default, colors.blue)]: {
     color: colorsTextIcon.highOnDark,
-    backgroundColor: colorsBlue.base,
-    borderColor: colorsBlue.base
+    backgroundColor: colorsBlue[7]
   },
 
-  [select(themeNames.light, appearances.default, colors.gray)]: {
+  [select(themeNames.light, appearances.default, colors.neutral)]: {
     color: colorsTextIcon.highOnDark,
-    backgroundColor: colorsBackgroundDark[3],
-    borderColor: colorsBackgroundDark[3]
+    backgroundColor: colorsBackgroundDark[3]
   },
   [select(themeNames.light, appearances.default, colors.green)]: {
     color: colorsTextIcon.highOnDark,
-    backgroundColor: colorsGreen.base,
-    borderColor: colorsGreen.base
+    backgroundColor: colorsGreen[8]
   },
   [select(themeNames.light, appearances.default, colors.yellow)]: {
     color: colorsTextIcon.highOnLight,
-    backgroundColor: colorsYellow.base,
-    borderColor: colorsYellow.base
+    backgroundColor: colorsYellow[6]
   },
   [select(themeNames.light, appearances.default, colors.red)]: {
     color: colorsTextIcon.highOnDark,
-    backgroundColor: colorsRed.base,
-    borderColor: colorsRed.base
+    backgroundColor: colorsRed[7]
   },
   [select(themeNames.light, appearances.default, colors.blue)]: {
     color: colorsTextIcon.highOnDark,
-    backgroundColor: colorsBlue.base,
-    borderColor: colorsBlue.base
+    backgroundColor: colorsBlue[7]
   },
 
-  [select(themeNames.dark, appearances.subtle, colors.gray)]: {
+  [select(themeNames.dark, appearances.subtle, colors.neutral)]: {
     color: colorsTextIcon.lowOnDark,
-    borderColor: colorsBorder.highOnDark
+    backgroundColor: colorsBackgroundUtility[40]
   },
   [select(themeNames.dark, appearances.subtle, colors.green)]: {
-    color: colorsGreen.base,
-    borderColor: colorsGreen.base
+    color: colorsGreen[1],
+    backgroundColor: 'rgba(0,143,70,0.5)'
   },
   [select(themeNames.dark, appearances.subtle, colors.yellow)]: {
-    color: colorsYellow.base,
-    borderColor: colorsYellow.base
+    color: colorsYellow[1],
+    backgroundColor: 'rgba(226,181,0,0.5)'
   },
   [select(themeNames.dark, appearances.subtle, colors.red)]: {
-    color: colorsRed[5],
-    borderColor: colorsRed.base
+    color: colorsRed[1],
+    backgroundColor: 'rgba(192,15,0,0.5)'
   },
 
   [select(themeNames.dark, appearances.subtle, colors.blue)]: {
-    color: colorsBlue[5],
-    borderColor: colorsBlue.base
+    color: colorsBlue[1],
+    backgroundColor: 'rgba(0,116,171,0.5)'
   },
 
-  [select(themeNames.light, appearances.subtle, colors.gray)]: {
-    color: colorsTextIcon.highOnLight,
-    backgroundColor: colorsBackgroundUtility[25],
-    borderColor: 'transparent'
+  [select(themeNames.light, appearances.subtle, colors.neutral)]: {
+    color: colorsTextIcon.lowOnLight,
+    backgroundColor: colorsBackgroundUtility[20]
   },
   [select(themeNames.light, appearances.subtle, colors.green)]: {
-    color: colorsTextIcon.highOnLight,
-    backgroundColor: colorsGreen[1],
-    borderColor: colorsGreen[1]
+    color: colorsGreen[10],
+    backgroundColor: colorsGreen[1]
   },
   [select(themeNames.light, appearances.subtle, colors.yellow)]: {
-    color: colorsTextIcon.highOnLight,
-    backgroundColor: colorsYellow[1],
-    borderColor: colorsYellow[1]
+    color: colorsYellow[10],
+    backgroundColor: colorsYellow[1]
   },
   [select(themeNames.light, appearances.subtle, colors.red)]: {
-    color: colorsTextIcon.highOnLight,
-    backgroundColor: colorsRed[1],
-    borderColor: colorsRed[1]
+    color: colorsRed[10],
+    backgroundColor: colorsRed[1]
   },
   [select(themeNames.light, appearances.subtle, colors.blue)]: {
-    color: colorsTextIcon.highOnLight,
-    backgroundColor: colorsBlue[1],
-    borderColor: colorsBlue[1]
+    color: colorsBlue[10],
+    backgroundColor: colorsBlue[1]
   }
 }

--- a/packages/badge/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/badge/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -11,16 +11,16 @@ exports[`Storyshots appearance default 1`] = `
 >
   <div>
     <div
-      data-css-vmzfrg=""
+      data-css-akmt2m=""
     >
       default
        
-      gray
+      neutral
     </div>
   </div>
   <div>
     <div
-      data-css-157u8fk=""
+      data-css-6qp7yi=""
     >
       default
        
@@ -29,7 +29,7 @@ exports[`Storyshots appearance default 1`] = `
   </div>
   <div>
     <div
-      data-css-7q4v5r=""
+      data-css-1370srq=""
     >
       default
        
@@ -38,7 +38,7 @@ exports[`Storyshots appearance default 1`] = `
   </div>
   <div>
     <div
-      data-css-oh7fxh=""
+      data-css-dbjxnr=""
     >
       default
        
@@ -47,7 +47,7 @@ exports[`Storyshots appearance default 1`] = `
   </div>
   <div>
     <div
-      data-css-18fz1k5=""
+      data-css-i7yiwd=""
     >
       default
        
@@ -68,16 +68,16 @@ exports[`Storyshots appearance subtle 1`] = `
 >
   <div>
     <div
-      data-css-1jppf77=""
+      data-css-1imiq63=""
     >
       subtle
        
-      gray
+      neutral
     </div>
   </div>
   <div>
     <div
-      data-css-hmqqyn=""
+      data-css-akls3u=""
     >
       subtle
        
@@ -86,7 +86,7 @@ exports[`Storyshots appearance subtle 1`] = `
   </div>
   <div>
     <div
-      data-css-inha5s=""
+      data-css-1739nde=""
     >
       subtle
        
@@ -95,7 +95,7 @@ exports[`Storyshots appearance subtle 1`] = `
   </div>
   <div>
     <div
-      data-css-3lt21a=""
+      data-css-1svdoaq=""
     >
       subtle
        
@@ -104,7 +104,7 @@ exports[`Storyshots appearance subtle 1`] = `
   </div>
   <div>
     <div
-      data-css-aiwq2=""
+      data-css-rl0hco=""
     >
       subtle
        

--- a/packages/badge/src/react/index.tsx
+++ b/packages/badge/src/react/index.tsx
@@ -43,7 +43,7 @@ const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
   (
     {
       appearance = vars.appearances.default,
-      color = vars.colors.gray,
+      color = vars.colors.neutral,
       ...rest
     },
     forwardedRef

--- a/packages/badge/src/vars/index.ts
+++ b/packages/badge/src/vars/index.ts
@@ -2,4 +2,4 @@ import { keyMirror } from '@pluralsight/ps-design-system-util'
 
 export const appearances = keyMirror('default', 'subtle')
 
-export const colors = keyMirror('gray', 'green', 'yellow', 'red', 'blue')
+export const colors = keyMirror('neutral', 'green', 'yellow', 'red', 'blue')


### PR DESCRIPTION
`badge`
- Breaking change: color 'gray' is now called 'neutral'
- All styles meet WCAG AA contrast guidelines
- New styling for subtle appearance on dark to be more consistent with subtle appearance on light (filled instead of borders)

`docs`
- Change references from 'gray' to 'neutral'
- Correct default values in types table