### PR TITLE
update peer dep range for theme package

### DIFF
--- a/packages/appframe/package.json
+++ b/packages/appframe/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/circularprogress/package.json
+++ b/packages/circularprogress/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/datawell/package.json
+++ b/packages/datawell/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/emptystate/package.json
+++ b/packages/emptystate/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/halo/package.json
+++ b/packages/halo/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/linearprogress/package.json
+++ b/packages/linearprogress/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/multiselect/package.json
+++ b/packages/multiselect/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/navbar/package.json
+++ b/packages/navbar/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.8",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/navbrand/package.json
+++ b/packages/navbrand/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.8",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/navcookiebanner/package.json
+++ b/packages/navcookiebanner/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/navitem/package.json
+++ b/packages/navitem/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.8",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/navuser/package.json
+++ b/packages/navuser/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.8",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/note/package.json
+++ b/packages/note/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/searchinput/package.json
+++ b/packages/searchinput/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/starrating/package.json
+++ b/packages/starrating/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^16.11"
   },

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "invariant": "^2.2.4",
     "react": "^17.0.1"

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/textinput/package.json
+++ b/packages/textinput/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/typeahead/package.json
+++ b/packages/typeahead/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/verticaltabs/package.json
+++ b/packages/verticaltabs/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/viewtoggle/package.json
+++ b/packages/viewtoggle/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/plop-templates/component/package.json.hbs
+++ b/plop-templates/component/package.json.hbs
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@pluralsight/ps-design-system-normalize": "^4.0.0",
-    "@pluralsight/ps-design-system-theme": "^6.0.0",
+    "@pluralsight/ps-design-system-theme": "^7.0.0",
     "glamor": "^2.x.x",
     "react": ">=16.8.6 < 17.0.0"
   },


### PR DESCRIPTION
lerna doesn't bump peerDep versions so we need to do it manually. 

this should silence the majority of peer dep warnings. there are still a few around react 16<>17 third party needs that we can address later