### PR TITLE
datepicker: stabilize storyshots

### DIFF
--- a/packages/datepicker/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/datepicker/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
         <div
           data-css-fpvw2v=""
         >
-          Mar
+          Jan
            
           2021
         </div>
@@ -131,10 +131,22 @@ exports[`Storyshots MultiDate Calendar 1`] = `
         <div
           data-css-h18ka=""
         />
+        <div
+          data-css-h18ka=""
+        />
+        <div
+          data-css-h18ka=""
+        />
+        <div
+          data-css-h18ka=""
+        />
+        <div
+          data-css-h18ka=""
+        />
         <button
-          aria-label="Mon Mar 01 2021"
-          aria-pressed={false}
-          data-css-1uw46i0=""
+          aria-label="Fri Jan 01 2021"
+          aria-pressed={true}
+          data-css-cm4yn4=""
           disabled={false}
           onClick={[Function]}
           role="button"
@@ -142,7 +154,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           1
         </button>
         <button
-          aria-label="Tue Mar 02 2021"
+          aria-label="Sat Jan 02 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -152,7 +164,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           2
         </button>
         <button
-          aria-label="Wed Mar 03 2021"
+          aria-label="Sun Jan 03 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -162,7 +174,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           3
         </button>
         <button
-          aria-label="Thu Mar 04 2021"
+          aria-label="Mon Jan 04 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -172,9 +184,9 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           4
         </button>
         <button
-          aria-label="Fri Mar 05 2021"
-          aria-pressed={false}
-          data-css-1uw46i0=""
+          aria-label="Tue Jan 05 2021"
+          aria-pressed={true}
+          data-css-cm4yn4=""
           disabled={false}
           onClick={[Function]}
           role="button"
@@ -182,7 +194,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           5
         </button>
         <button
-          aria-label="Sat Mar 06 2021"
+          aria-label="Wed Jan 06 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -192,7 +204,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           6
         </button>
         <button
-          aria-label="Sun Mar 07 2021"
+          aria-label="Thu Jan 07 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -202,7 +214,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           7
         </button>
         <button
-          aria-label="Mon Mar 08 2021"
+          aria-label="Fri Jan 08 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -212,7 +224,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           8
         </button>
         <button
-          aria-label="Tue Mar 09 2021"
+          aria-label="Sat Jan 09 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -222,7 +234,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           9
         </button>
         <button
-          aria-label="Wed Mar 10 2021"
+          aria-label="Sun Jan 10 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -232,7 +244,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           10
         </button>
         <button
-          aria-label="Thu Mar 11 2021"
+          aria-label="Mon Jan 11 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -242,7 +254,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           11
         </button>
         <button
-          aria-label="Fri Mar 12 2021"
+          aria-label="Tue Jan 12 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -252,7 +264,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           12
         </button>
         <button
-          aria-label="Sat Mar 13 2021"
+          aria-label="Wed Jan 13 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -262,7 +274,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           13
         </button>
         <button
-          aria-label="Sun Mar 14 2021"
+          aria-label="Thu Jan 14 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -272,7 +284,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           14
         </button>
         <button
-          aria-label="Mon Mar 15 2021"
+          aria-label="Fri Jan 15 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -282,7 +294,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           15
         </button>
         <button
-          aria-label="Tue Mar 16 2021"
+          aria-label="Sat Jan 16 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -292,7 +304,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           16
         </button>
         <button
-          aria-label="Wed Mar 17 2021"
+          aria-label="Sun Jan 17 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -302,7 +314,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           17
         </button>
         <button
-          aria-label="Thu Mar 18 2021"
+          aria-label="Mon Jan 18 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -312,7 +324,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           18
         </button>
         <button
-          aria-label="Fri Mar 19 2021"
+          aria-label="Tue Jan 19 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -322,7 +334,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           19
         </button>
         <button
-          aria-label="Sat Mar 20 2021"
+          aria-label="Wed Jan 20 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -332,7 +344,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           20
         </button>
         <button
-          aria-label="Sun Mar 21 2021"
+          aria-label="Thu Jan 21 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -342,7 +354,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           21
         </button>
         <button
-          aria-label="Mon Mar 22 2021"
+          aria-label="Fri Jan 22 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -352,7 +364,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           22
         </button>
         <button
-          aria-label="Tue Mar 23 2021"
+          aria-label="Sat Jan 23 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -362,7 +374,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           23
         </button>
         <button
-          aria-label="Wed Mar 24 2021"
+          aria-label="Sun Jan 24 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -372,7 +384,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           24
         </button>
         <button
-          aria-label="Thu Mar 25 2021"
+          aria-label="Mon Jan 25 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -382,7 +394,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           25
         </button>
         <button
-          aria-label="Fri Mar 26 2021"
+          aria-label="Tue Jan 26 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -392,7 +404,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           26
         </button>
         <button
-          aria-label="Sat Mar 27 2021"
+          aria-label="Wed Jan 27 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -402,7 +414,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           27
         </button>
         <button
-          aria-label="Sun Mar 28 2021"
+          aria-label="Thu Jan 28 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -412,7 +424,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           28
         </button>
         <button
-          aria-label="Mon Mar 29 2021"
+          aria-label="Fri Jan 29 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -422,7 +434,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           29
         </button>
         <button
-          aria-label="Tue Mar 30 2021"
+          aria-label="Sat Jan 30 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -432,7 +444,7 @@ exports[`Storyshots MultiDate Calendar 1`] = `
           30
         </button>
         <button
-          aria-label="Wed Mar 31 2021"
+          aria-label="Sun Jan 31 2021"
           aria-pressed={false}
           data-css-1uw46i0=""
           disabled={false}
@@ -441,6 +453,15 @@ exports[`Storyshots MultiDate Calendar 1`] = `
         >
           31
         </button>
+        <div
+          data-css-h18ka=""
+        />
+        <div
+          data-css-h18ka=""
+        />
+        <div
+          data-css-h18ka=""
+        />
         <div
           data-css-h18ka=""
         />

--- a/packages/datepicker/src/react/__stories__/index.story.tsx
+++ b/packages/datepicker/src/react/__stories__/index.story.tsx
@@ -284,10 +284,16 @@ storiesOf('RangeDate', module)
   })
 
 storiesOf('MultiDate', module).add('Calendar', () => {
-  const [selected, setSelected] = React.useState<Date[]>([])
+  const initialDate = new Date(2021, 0, 1)
+  const initialDate2 = new Date(2021, 0, 5)
+  const [selected, setSelected] = React.useState<Date[]>([
+    initialDate,
+    initialDate2
+  ])
   const { getDateProps, ...dayzedData } = useDayzed({
     selected,
-    onDateSelected: onMultiDateSelected({ selected, setSelected })
+    onDateSelected: onMultiDateSelected({ selected, setSelected }),
+    date: initialDate
   })
   return (
     <Calendar {...dayzedData}>


### PR DESCRIPTION
Only affected the one MultiDate Calendar story. By init'ing the calendar with a `date` param, this was solved. Also threw in date selection to make the story more illustrative of its feature.

Resolves #1641
