### PR TITLE
fix(navuser): avoid swallowing click

### DIFF
--- a/packages/navuser/package.json
+++ b/packages/navuser/package.json
@@ -34,7 +34,9 @@
     "react": "^17.0.1"
   },
   "devDependencies": {
+    "@pluralsight/ps-design-system-actionmenu": "*",
     "@pluralsight/ps-design-system-build": "^2.0.4",
+    "@pluralsight/ps-design-system-button": "*",
     "@pluralsight/ps-design-system-storybook-preset": "^0.4.3"
   }
 }

--- a/packages/navuser/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/navuser/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -1,5 +1,100 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots NavUser clicks 1`] = `
+<div>
+  <button
+    data-css-y5dqt5=""
+    disabled={false}
+    onClick={[Function]}
+    style={Object {}}
+  >
+    <span
+      data-css-15b13by=""
+    >
+      Click me first
+    </span>
+  </button>
+  <div
+    style={
+      Object {
+        "visibility": "hidden",
+      }
+    }
+  />
+  <button
+    data-css-y5dqt5=""
+    disabled={false}
+    onClick={[Function]}
+    style={Object {}}
+  >
+    <span
+      data-css-15b13by=""
+    >
+      Then click me, first menu closes, mine opens
+    </span>
+  </button>
+  <div
+    style={
+      Object {
+        "visibility": "hidden",
+      }
+    }
+  />
+  <div
+    data-css-1ij5lym=""
+  >
+    <button
+      data-css-6uwj3a=""
+      onClick={[Function]}
+    >
+      <div
+        aria-hidden={true}
+        data-css-79vgce=""
+      >
+        <img
+          data-css-d7y6x2=""
+          onError={[Function]}
+          onLoad={[Function]}
+          src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg?d=https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fps-cdn%2Fdesign-system%2Fassets%2Ftransparent.gif"
+        />
+        <div
+          aria-label="Then click me, same as 2nd button"
+          data-css-1h1qs66=""
+          style={
+            Object {
+              "backgroundColor": "#B28300",
+            }
+          }
+        >
+          T
+        </div>
+      </div>
+      <div
+        data-css-1mmc9g1=""
+      >
+        <div
+          data-css-6flzpu=""
+        >
+          Then click me, same as 2nd button
+        </div>
+        <div
+          data-css-60db85=""
+        >
+          Menu 2 close, Menu 3 open
+        </div>
+      </div>
+    </button>
+  </div>
+  <div
+    style={
+      Object {
+        "visibility": "hidden",
+      }
+    }
+  />
+</div>
+`;
+
 exports[`Storyshots NavUser states 1`] = `
 <div
   style={

--- a/packages/navuser/src/react/__stories__/index.story.tsx
+++ b/packages/navuser/src/react/__stories__/index.story.tsx
@@ -1,38 +1,105 @@
+import Button from '@pluralsight/ps-design-system-button'
+import {
+  colorsBackgroundDark,
+  layout
+} from '@pluralsight/ps-design-system-core'
+import React, { useState } from 'react'
+import { BelowLeft } from '@pluralsight/ps-design-system-position'
+import ActionMenu from '@pluralsight/ps-design-system-actionmenu'
 import { storiesOf } from '@storybook/react'
-import React from 'react'
 
 import NavUser from '..'
 
-storiesOf('NavUser', module).add('states', () => (
-  <Grid>
-    <NavUser src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg" />
+storiesOf('NavUser', module)
+  .add('states', () => (
+    <Grid>
+      <NavUser src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg" />
 
-    <NavUser
-      src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg"
-      name="Jake Trent"
-    />
+      <NavUser
+        src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg"
+        name="Jake Trent"
+      />
 
-    <NavUser
-      src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg"
-      name="Jake Trent"
-      meta="Accenture"
-    />
+      <NavUser
+        src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg"
+        name="Jake Trent"
+        meta="Accenture"
+      />
 
-    <NavUser
-      src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg"
-      name="Jake Trent"
-      meta="Accenture"
-      href="https://jaketrent.com"
-    />
+      <NavUser
+        src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg"
+        name="Jake Trent"
+        meta="Accenture"
+        href="https://jaketrent.com"
+      />
 
-    <NavUser
-      src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg"
-      name="Jake Trent Name That is Long"
-      meta="Accenture Company Name That is Long"
-      onClick={() => alert('clicked')}
-    />
-  </Grid>
-))
+      <NavUser
+        src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg"
+        name="Jake Trent Name That is Long"
+        meta="Accenture Company Name That is Long"
+        onClick={() => alert('clicked')}
+      />
+    </Grid>
+  ))
+  .add('clicks', () => {
+    function Example() {
+      const [toggleOpen, setToggleOpen] = useState('')
+
+      const clickHandler = (name: string) => {
+        const isOpen = name === toggleOpen
+        if (isOpen) {
+          setToggleOpen('')
+        } else {
+          setToggleOpen(name)
+        }
+      }
+
+      return (
+        <div>
+          <BelowLeft
+            show={
+              <ActionMenu onClose={() => clickHandler('div a close')}>
+                <ActionMenu.Item>Open</ActionMenu.Item>
+              </ActionMenu>
+            }
+            when={toggleOpen === 'div a open'}
+          >
+            <Button onClick={() => clickHandler('div a open')}>
+              Click me first
+            </Button>
+          </BelowLeft>
+          <BelowLeft
+            show={
+              <ActionMenu onClose={() => clickHandler('div b close')}>
+                <ActionMenu.Item>Open</ActionMenu.Item>
+              </ActionMenu>
+            }
+            when={toggleOpen === 'div b open'}
+          >
+            <Button onClick={() => clickHandler('div b open')}>
+              Then click me, first menu closes, mine opens
+            </Button>
+          </BelowLeft>
+          <BelowLeft
+            show={
+              <ActionMenu onClose={() => clickHandler('nav user close')}>
+                <ActionMenu.Item>Open</ActionMenu.Item>
+              </ActionMenu>
+            }
+            when={toggleOpen === 'nav user open'}
+          >
+            <NavUser
+              onClick={() => clickHandler('nav user open')}
+              name="Then click me, same as 2nd button"
+              meta="Menu 2 close, Menu 3 open"
+              src="https://en.gravatar.com/userimage/8399312/b15448d840afacd0eb18102baf788255.jpeg"
+            />
+          </BelowLeft>
+        </div>
+      )
+    }
+    return <Example />
+  })
 
 const Grid: React.FC = props => {
   return (

--- a/packages/navuser/src/react/index.tsx
+++ b/packages/navuser/src/react/index.tsx
@@ -58,36 +58,32 @@ const NavUser = React.forwardRef<NavUserElement, NavUserProps>(
 
     const isAnchor = 'href' in props
     const isButton = !isAnchor && 'onClick' in props
-
-    const Wrapper: React.FC = wrapperProps =>
-      isAnchor ? (
-        <a
-          ref={ref as RefFor<'a'>}
-          {...(rest as HTMLPropsFor<'a'>)}
-          {...wrapperProps}
-        />
-      ) : isButton ? (
-        <button
-          ref={ref as RefFor<'button'>}
-          {...wrapperProps}
-          {...(rest as HTMLPropsFor<'button'>)}
-        />
-      ) : (
-        <div
-          ref={ref as RefFor<'div'>}
-          {...wrapperProps}
-          {...(rest as HTMLPropsFor<'div'>)}
-        />
-      )
+    const tagName = isAnchor ? 'a' : isButton ? 'button' : 'div'
+    const wrapperRef = isAnchor
+      ? (ref as RefFor<'a'>)
+      : isButton
+      ? (ref as RefFor<'button'>)
+      : (ref as RefFor<'div'>)
+    const wrapperRest = isAnchor
+      ? (rest as HTMLPropsFor<'a'>)
+      : isButton
+      ? (rest as HTMLPropsFor<'button'>)
+      : (rest as HTMLPropsFor<'div'>)
 
     return (
       <Halo inline gapSize={Halo.gapSizes.small}>
-        <Wrapper {...styles.navUser(props)}>
+        {React.createElement(
+          tagName,
+          {
+            ref: wrapperRef,
+            ...styles.navUser(props),
+            ...wrapperRest
+          },
           <>
             <Avatar src={src} size={Avatar.sizes.xSmall} name={name} />
             <Words name={name} meta={meta} />
           </>
-        </Wrapper>
+        )}
       </Halo>
     )
   }


### PR DESCRIPTION
The click being swallowed was in a very specific instance, as seen by
the added story. Still not sure why the onClick was not being triggered.
Before this commit, would take an extra click (click navuser to click
off and closer actionmenu due to document close listeners, then another
click to open the navuser). The change makes all that happen in one
click.

Resolves: #1656
