### PR TITLE
select: fix build script and module default export

### DIFF
--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "exit 0",
+    "build": "run-s build:cjs build:esm build:css",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --target es5 --outDir dist/cjs",
     "build:css": "build-css --useGlamor -i dist/cjs/css/index.js",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --target es5 --outDir dist/esm",

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -1,3 +1,3 @@
-export { default } from './react'
+export { default, useListbox, UseListboxProps, useMenuRef } from './react'
 export * from './vars'
 export { default as css } from './css'

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -1,3 +1,3 @@
-export * from './react'
+export { default } from './react'
 export * from './vars'
 export { default as css } from './css'


### PR DESCRIPTION
### What You're Solving

-  The `build` script for the select component looks like it was never implemented so we just copied it from another one
-  There was no default export

### How to Verify

- Verify the package builds
- Verify you can use the default export in JSX and use the static vars off of it