### PR TITLE
storybook-addon-theme: ability to set theme per-story

### DIFF
--- a/packages/storybook-addon-theme/README.md
+++ b/packages/storybook-addon-theme/README.md
@@ -1,0 +1,47 @@
+# Storybook Addon Theme
+
+Storybook Addon Theme can be used to change the background color and default theme inside the preview in [Storybook](https://storybook.js.org).
+
+![React Storybook Screenshot](https://user-images.githubusercontent.com/679346/113080059-755a3c00-9193-11eb-9193-f54ec63c2e4a.png)
+
+## Installation
+
+Theme is part of [@pluralsight/storybook-preset](https://github.com/pluralsight/design-system/tree/master/packages/storybook-preset) or you can install it individually with:
+
+```sh
+npm i -D @pluralsight/storybook-addon-theme
+```
+
+## Configuration
+
+Add the following to [`.storybook/main.js`](https://storybook.js.org/docs/react/configure/overview#configure-your-storybook-project):
+
+```js
+module.exports = {
+  addons: ['@pluralsight/storybook-addon-theme']
+}
+```
+
+## Usage
+
+Stories will default to the `dark` theme.
+
+Override the default for a single story, all of a component's stories, or for all stories with the `theme.name` parameter (*[see more instructions here](https://storybook.js.org/docs/react/writing-stories/parameters)*):
+
+```js
+theme: { name: 'light' }
+```
+
+Disable the theme with the `theme.disable` parameter:
+
+```typescript jsx
+theme: { disable: true }
+```
+
+If you're using Storybook's [addon-essentials](https://storybook.js.org/docs/react/essentials/introduction) you'll probably want to disable the `Background` addon since it also sets the background. Add the following to `.storybook/preview.js`:
+```js
+parameters: {
+  backgrounds: { disable: true }
+}
+```
+

--- a/packages/storybook-addon-theme/README.md
+++ b/packages/storybook-addon-theme/README.md
@@ -2,7 +2,7 @@
 
 Storybook Addon Theme can be used to change the background color and default theme inside the preview in [Storybook](https://storybook.js.org).
 
-![React Storybook Screenshot](https://user-images.githubusercontent.com/679346/113080059-755a3c00-9193-11eb-9193-f54ec63c2e4a.png)
+![Storybook screenshot](https://user-images.githubusercontent.com/679346/113085270-c0c51800-919c-11eb-8325-d41f32fc2b50.png)
 
 ## Installation
 

--- a/packages/storybook-addon-theme/README.md
+++ b/packages/storybook-addon-theme/README.md
@@ -6,10 +6,10 @@ Storybook Addon Theme can be used to change the background color and default the
 
 ## Installation
 
-Theme is part of [@pluralsight/storybook-preset](https://github.com/pluralsight/design-system/tree/master/packages/storybook-preset) or you can install it individually with:
+Theme is part of [@pluralsight/ps-design-system-storybook-preset](https://github.com/pluralsight/design-system/tree/master/packages/storybook-preset) or you can install it individually with:
 
 ```sh
-npm i -D @pluralsight/storybook-addon-theme
+npm i -D @pluralsight/ps-design-system-storybook-addon-theme
 ```
 
 ## Configuration
@@ -18,7 +18,7 @@ Add the following to [`.storybook/main.js`](https://storybook.js.org/docs/react/
 
 ```js
 module.exports = {
-  addons: ['@pluralsight/storybook-addon-theme']
+  addons: ['@pluralsight/ps-design-system-storybook-addon-theme']
 }
 ```
 

--- a/packages/storybook-addon-theme/src/components/tool.tsx
+++ b/packages/storybook-addon-theme/src/components/tool.tsx
@@ -1,22 +1,15 @@
 import React from 'react'
-import { useAddonState } from '@storybook/api'
 import { Icons, IconButton } from '@storybook/components'
+import { names } from '@pluralsight/ps-design-system-theme'
 
-import { defaultName, names } from '@pluralsight/ps-design-system-theme'
-
-import { ADDON_ID } from '../constants'
+import { useSelectedTheme } from '../hooks'
 
 export const ThemeTool: React.FC = () => {
-  const [themeName, setThemeName] = useAddonState<keyof typeof names>(
-    `${ADDON_ID}/name`,
-    defaultName
-  )
+  const { theme, setTheme } = useSelectedTheme()
 
-  const isDark = themeName === names.dark
+  const isDark = theme === names.dark
 
-  const toggleTheme = () => {
-    setThemeName(isDark ? names.light : names.dark)
-  }
+  const toggleTheme = () => setTheme(isDark ? names.light : names.dark)
 
   return (
     <IconButton active={isDark} title="Toggle theme" onClick={toggleTheme}>

--- a/packages/storybook-addon-theme/src/components/tool.tsx
+++ b/packages/storybook-addon-theme/src/components/tool.tsx
@@ -5,15 +5,19 @@ import { names } from '@pluralsight/ps-design-system-theme'
 import { useSelectedTheme } from '../hooks'
 
 export const ThemeTool: React.FC = () => {
-  const { theme, setTheme } = useSelectedTheme()
+  const { theme, storyDefaultTheme, setTheme } = useSelectedTheme()
 
   const isDark = theme === names.dark
 
   const toggleTheme = () => setTheme(isDark ? names.light : names.dark)
 
   return (
-    <IconButton active={isDark} title="Toggle theme" onClick={toggleTheme}>
-      <Icons icon="mirror" />
+    <IconButton
+      active={theme !== storyDefaultTheme}
+      title="Toggle theme"
+      onClick={toggleTheme}
+    >
+      <Icons icon={isDark ? 'circle' : 'circlehollow'} />
     </IconButton>
   )
 }

--- a/packages/storybook-addon-theme/src/hooks.ts
+++ b/packages/storybook-addon-theme/src/hooks.ts
@@ -12,7 +12,8 @@ export function useSelectedTheme(api: StorybookApi = storybookApi) {
   const [globals, updateGlobals] = api.useGlobals()
   const userSelectedTheme = globals[PARAM_KEY]?.name
 
-  const theme = userSelectedTheme ?? storyTheme ?? defaultTheme
+  const storyDefaultTheme = storyTheme ?? defaultTheme
+  const theme = userSelectedTheme ?? storyDefaultTheme
 
   const setTheme = useCallback(
     (value: ThemeName) => {
@@ -21,7 +22,7 @@ export function useSelectedTheme(api: StorybookApi = storybookApi) {
     [updateGlobals, globals]
   )
 
-  return { theme, setTheme }
+  return { theme, storyDefaultTheme, setTheme }
 }
 
 type ThemeName = keyof typeof names

--- a/packages/storybook-addon-theme/src/hooks.ts
+++ b/packages/storybook-addon-theme/src/hooks.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react'
+import {
+  names,
+  defaultName as defaultTheme
+} from '@pluralsight/ps-design-system-theme'
+import * as storybookApi from '@storybook/api'
+
+import { PARAM_KEY } from './constants'
+
+export function useSelectedTheme(api: StorybookApi = storybookApi) {
+  const storyTheme = api.useParameter<{ name?: ThemeName }>(PARAM_KEY)?.name
+  const [globals, updateGlobals] = api.useGlobals()
+  const userSelectedTheme = globals[PARAM_KEY]?.name
+
+  const theme = userSelectedTheme ?? storyTheme ?? defaultTheme
+
+  const setTheme = useCallback(
+    (value: ThemeName) => {
+      updateGlobals({ [PARAM_KEY]: { ...globals[PARAM_KEY], name: value } })
+    },
+    [updateGlobals, globals]
+  )
+
+  return { theme, setTheme }
+}
+
+type ThemeName = keyof typeof names
+
+type StorybookApi = {
+  useGlobals: typeof storybookApi.useGlobals
+  useParameter: typeof storybookApi.useParameter
+}

--- a/packages/storybook-addon-theme/src/index.tsx
+++ b/packages/storybook-addon-theme/src/index.tsx
@@ -1,22 +1,19 @@
 import { makeDecorator } from '@storybook/addons'
-import { useAddonState } from '@storybook/client-api'
+import * as api from '@storybook/client-api'
 import React from 'react'
-
-import { names as themeNames } from '@pluralsight/ps-design-system-theme'
 
 import { ADDON_ID, PARAM_KEY } from './constants'
 import { Themed } from './components/themed'
+import { useSelectedTheme } from './hooks'
 
 export const withTheme = makeDecorator({
   name: ADDON_ID,
   parameterName: PARAM_KEY,
   wrapper: (storyFn, context) => {
     // eslint-disable-next-line
-    const [themeName] = useAddonState<keyof typeof themeNames>(
-      `${ADDON_ID}/name`
-    )
+    const { theme } = useSelectedTheme(api)
 
-    return <Themed themeName={themeName}>{storyFn(context)}</Themed>
+    return <Themed themeName={theme}>{storyFn(context)}</Themed>
   }
 })
 


### PR DESCRIPTION
### What You're Solving

- Adds ability to customize the default theme for each story

### Design Decisions

- Copied the way the [Background addon](https://github.com/storybookjs/storybook/tree/next/addons/backgrounds) in Storybook's addon-essentials works (but with a cleaner hooks approach!)

### How to Verify

- [Set](https://storybook.js.org/docs/react/writing-stories/parameters) the `theme.name` parameter on a story to `light` and verify the component loads with the light theme and can be toggled back.
