### PR TITLE
select: stop intercepting all key events

### DIFF
--- a/packages/select/src/react/useListbox.ts
+++ b/packages/select/src/react/useListbox.ts
@@ -111,7 +111,7 @@ export const useListbox = (
       evt.type === 'click' ||
       (evt.type === 'keydown' &&
         'key' in evt &&
-        ['Enter', 'ArrowDown', 'ArrowUp'].includes(evt.key))
+        ['Enter', 'ArrowDown', 'ArrowUp', ' '].includes(evt.key))
     ) {
       evt.preventDefault()
       evt.stopPropagation()

--- a/packages/select/src/react/useListbox.ts
+++ b/packages/select/src/react/useListbox.ts
@@ -111,7 +111,7 @@ export const useListbox = (
       evt.type === 'click' ||
       (evt.type === 'keydown' &&
         'key' in evt &&
-        (evt.key === 'Enter' || 'ArrowDown' || 'ArrowUp'))
+        ['Enter', 'ArrowDown', 'ArrowUp'].includes(evt.key))
     ) {
       evt.preventDefault()
       evt.stopPropagation()


### PR DESCRIPTION
### What You're Solving

- When a select menu is opened it starts intercepting, preventing default, and stopping propagation of all keyboard events because the key check is always returning true.

### How to Verify

- Render a select
- Open the menu
- Verify you can tab around the page still
- Verify the button does not constantly steal focus when clicking/tabbing around the page
