### PR TITLE
tagsinput: fix scroll bar position when items/pills overflow 

### DIFF
--- a/packages/tagsinput/src/css/index.ts
+++ b/packages/tagsinput/src/css/index.ts
@@ -34,8 +34,7 @@ export default {
     margin: `calc(${PILL_GUTTER_SIZE}px * -2)`,
     maxHeight: 75,
     overflowY: 'auto',
-    padding: `${layout.spacingXXSmall} ${layout.spacingXSmall}`,
-    width: '100%'
+    padding: `${layout.spacingXXSmall} ${layout.spacingXSmall}`
   },
   '.psds-tagsinput__pill': { margin: `calc(${PILL_GUTTER_SIZE}px / 2)` },
 

--- a/packages/tagsinput/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/tagsinput/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -31,7 +31,7 @@ exports[`Storyshots Components/TagsInput Basic 1`] = `
           data-css-r9wiij=""
         >
           <div
-            data-css-dpj5et=""
+            data-css-mggyc2=""
           >
             <div
               data-css-12qnym0=""
@@ -166,7 +166,7 @@ exports[`Storyshots Components/TagsInput Custom Input Tag 1`] = `
           data-css-r9wiij=""
         >
           <div
-            data-css-dpj5et=""
+            data-css-mggyc2=""
           >
             <div
               data-css-12qnym0=""
@@ -308,7 +308,7 @@ exports[`Storyshots Components/TagsInput Disabled 1`] = `
           data-css-r9wiij=""
         >
           <div
-            data-css-dpj5et=""
+            data-css-mggyc2=""
           >
             <div
               data-css-12qnym0=""
@@ -450,7 +450,7 @@ exports[`Storyshots Components/TagsInput Error 1`] = `
           data-css-r9wiij=""
         >
           <div
-            data-css-dpj5et=""
+            data-css-mggyc2=""
           >
             <div
               data-css-12qnym0=""
@@ -631,7 +631,7 @@ exports[`Storyshots Components/TagsInput Icon Prefix 1`] = `
           data-css-r9wiij=""
         >
           <div
-            data-css-dpj5et=""
+            data-css-mggyc2=""
           >
             <div
               data-css-12qnym0=""
@@ -772,7 +772,7 @@ exports[`Storyshots Components/TagsInput Icon Suffix 1`] = `
           data-css-r9wiij=""
         >
           <div
-            data-css-dpj5et=""
+            data-css-mggyc2=""
           >
             <div
               data-css-12qnym0=""
@@ -928,7 +928,7 @@ exports[`Storyshots Components/TagsInput No Labels 1`] = `
           data-css-r9wiij=""
         >
           <div
-            data-css-dpj5et=""
+            data-css-mggyc2=""
           >
             <div
               data-css-12qnym0=""
@@ -1065,7 +1065,7 @@ exports[`Storyshots Components/TagsInput React Node Label 1`] = `
           data-css-r9wiij=""
         >
           <div
-            data-css-dpj5et=""
+            data-css-mggyc2=""
           >
             <div
               data-css-12qnym0=""


### PR DESCRIPTION
### What You're Solving
- https://github.com/pluralsight/design-system/issues/1701

### How to Verify
- Render a tagsinput
- create multiple pills so you see a scroll bar
- Verify the scroll is at right most end
