### PR TITLE
tagsinput: match height of buttons & text inputs

### DIFF
--- a/packages/tagsinput/src/css/index.ts
+++ b/packages/tagsinput/src/css/index.ts
@@ -1,6 +1,7 @@
 import { layout } from '@pluralsight/ps-design-system-core'
 
-const PILL_GUTTER_SIZE = 4
+const GUTTER_SIZE = layout.spacingXSmall
+const PILL_GUTTER_SIZE = layout.spacingXXSmall
 
 const INPUT_MIN_HEIGHT = 24 // NOTE: this matches the size of the small Tag
 const INPUT_MIN_WIDTH = 50
@@ -23,27 +24,30 @@ export default {
   },
 
   '.psds-tagsinput__pills-container': {
-    paddingTop: '10px',
-    paddingBottom: '10px'
+    flexGrow: 1
   },
   '.psds-tagsinput__pills': {
     alignItems: 'center',
     display: 'flex',
     flex: 1,
     flexWrap: 'wrap',
-    margin: `calc(${PILL_GUTTER_SIZE}px * -2)`,
+    margin: `0 calc(${PILL_GUTTER_SIZE} * -2)`,
     maxHeight: 75,
     overflowY: 'auto',
-    padding: `${layout.spacingXXSmall} ${layout.spacingXSmall}`
+    padding: `
+      calc(${GUTTER_SIZE} - 1px)
+      ${GUTTER_SIZE}
+      calc(${GUTTER_SIZE} / 2 - 1px)
+      ${GUTTER_SIZE}
+    `
   },
-  '.psds-tagsinput__pill': { margin: `calc(${PILL_GUTTER_SIZE}px / 2)` },
-
-  '.psds-tagsinput__input-container': {
-    margin: `calc(${PILL_GUTTER_SIZE}px / 2)`
+  '.psds-tagsinput__pill': {
+    margin: `0 ${PILL_GUTTER_SIZE} ${PILL_GUTTER_SIZE} 0`
   },
   '.psds-tagsinput__input': {
-    minHeight: INPUT_MIN_HEIGHT,
     minWidth: INPUT_MIN_WIDTH,
+    height: `${INPUT_MIN_HEIGHT}px !important`,
+    marginBottom: `calc(${GUTTER_SIZE} / 2)`,
 
     '&:disabled': { background: 'transparent' }
   }

--- a/packages/tagsinput/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/tagsinput/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -28,13 +28,13 @@ exports[`Storyshots Components/TagsInput Basic 1`] = `
         onKeyPress={[Function]}
       >
         <div
-          data-css-r9wiij=""
+          data-css-1gs0ko2=""
         >
           <div
-            data-css-mggyc2=""
+            data-css-1vmmzqu=""
           >
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -74,7 +74,7 @@ exports[`Storyshots Components/TagsInput Basic 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -114,12 +114,11 @@ exports[`Storyshots Components/TagsInput Basic 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
               data-css-n9fe5c=""
             >
               <input
+                data-css-1cg8ewt=""
                 data-css-1f28mdy=""
-                data-css-8z457z=""
                 id="tagsinput__input-unique-id"
                 onChange={[Function]}
                 onClick={[Function]}
@@ -163,13 +162,13 @@ exports[`Storyshots Components/TagsInput Custom Input Tag 1`] = `
         onKeyPress={[Function]}
       >
         <div
-          data-css-r9wiij=""
+          data-css-1gs0ko2=""
         >
           <div
-            data-css-mggyc2=""
+            data-css-1vmmzqu=""
           >
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -209,7 +208,7 @@ exports[`Storyshots Components/TagsInput Custom Input Tag 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -249,12 +248,11 @@ exports[`Storyshots Components/TagsInput Custom Input Tag 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
               data-css-n9fe5c=""
             >
               <input
+                data-css-1cg8ewt=""
                 data-css-1f28mdy=""
-                data-css-8z457z=""
                 id="tagsinput__input-unique-id"
                 onChange={[Function]}
                 onClick={[Function]}
@@ -305,13 +303,13 @@ exports[`Storyshots Components/TagsInput Disabled 1`] = `
         onKeyPress={[Function]}
       >
         <div
-          data-css-r9wiij=""
+          data-css-1gs0ko2=""
         >
           <div
-            data-css-mggyc2=""
+            data-css-1vmmzqu=""
           >
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -351,7 +349,7 @@ exports[`Storyshots Components/TagsInput Disabled 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -391,13 +389,72 @@ exports[`Storyshots Components/TagsInput Disabled 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
               data-css-n9fe5c=""
             >
               <input
+                data-css-1cg8ewt=""
                 data-css-1f28mdy=""
-                data-css-8z457z=""
                 disabled={true}
+                id="tagsinput__input-unique-id"
+                onChange={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-css-bv851e=""
+    >
+      The sub label
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components/TagsInput Empty 1`] = `
+<div
+  style={
+    Object {
+      "maxWidth": "400px",
+    }
+  }
+>
+  <div
+    data-css-w0yocm=""
+    onClick={[Function]}
+  >
+    <label
+      data-css-5jjrbq=""
+      htmlFor="tagsinput__input-unique-id"
+    >
+      The label
+    </label>
+    <div
+      data-css-63oe3q=""
+      data-css-8qmpxt=""
+    >
+      <div
+        data-css-1ghsi1k=""
+        data-css-gz81g2=""
+        onKeyPress={[Function]}
+      >
+        <div
+          data-css-1gs0ko2=""
+        >
+          <div
+            data-css-1vmmzqu=""
+          >
+            <div
+              data-css-n9fe5c=""
+            >
+              <input
+                data-css-1cg8ewt=""
+                data-css-1f28mdy=""
                 id="tagsinput__input-unique-id"
                 onChange={[Function]}
                 onClick={[Function]}
@@ -447,13 +504,13 @@ exports[`Storyshots Components/TagsInput Error 1`] = `
         onKeyPress={[Function]}
       >
         <div
-          data-css-r9wiij=""
+          data-css-1gs0ko2=""
         >
           <div
-            data-css-mggyc2=""
+            data-css-1vmmzqu=""
           >
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -493,7 +550,7 @@ exports[`Storyshots Components/TagsInput Error 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -533,12 +590,11 @@ exports[`Storyshots Components/TagsInput Error 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
               data-css-n9fe5c=""
             >
               <input
+                data-css-1cg8ewt=""
                 data-css-1f28mdy=""
-                data-css-8z457z=""
                 id="tagsinput__input-unique-id"
                 onChange={[Function]}
                 onClick={[Function]}
@@ -628,13 +684,13 @@ exports[`Storyshots Components/TagsInput Icon Prefix 1`] = `
           </div>
         </div>
         <div
-          data-css-r9wiij=""
+          data-css-1gs0ko2=""
         >
           <div
-            data-css-mggyc2=""
+            data-css-1vmmzqu=""
           >
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -674,7 +730,7 @@ exports[`Storyshots Components/TagsInput Icon Prefix 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -714,12 +770,11 @@ exports[`Storyshots Components/TagsInput Icon Prefix 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
               data-css-n9fe5c=""
             >
               <input
+                data-css-1cg8ewt=""
                 data-css-1f28mdy=""
-                data-css-8z457z=""
                 id="tagsinput__input-unique-id"
                 onChange={[Function]}
                 onClick={[Function]}
@@ -769,13 +824,13 @@ exports[`Storyshots Components/TagsInput Icon Suffix 1`] = `
         onKeyPress={[Function]}
       >
         <div
-          data-css-r9wiij=""
+          data-css-1gs0ko2=""
         >
           <div
-            data-css-mggyc2=""
+            data-css-1vmmzqu=""
           >
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -815,7 +870,7 @@ exports[`Storyshots Components/TagsInput Icon Suffix 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -855,12 +910,11 @@ exports[`Storyshots Components/TagsInput Icon Suffix 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
               data-css-n9fe5c=""
             >
               <input
+                data-css-1cg8ewt=""
                 data-css-1f28mdy=""
-                data-css-8z457z=""
                 id="tagsinput__input-unique-id"
                 onChange={[Function]}
                 onClick={[Function]}
@@ -903,6 +957,666 @@ exports[`Storyshots Components/TagsInput Icon Suffix 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/TagsInput Multiple Lines 1`] = `
+<div
+  style={
+    Object {
+      "maxWidth": "400px",
+    }
+  }
+>
+  <div
+    data-css-w0yocm=""
+    onClick={[Function]}
+  >
+    <label
+      data-css-5jjrbq=""
+      htmlFor="tagsinput__input-unique-id"
+    >
+      The label
+    </label>
+    <div
+      data-css-63oe3q=""
+      data-css-8qmpxt=""
+    >
+      <div
+        data-css-1ghsi1k=""
+        data-css-gz81g2=""
+        onKeyPress={[Function]}
+      >
+        <div
+          data-css-1gs0ko2=""
+        >
+          <div
+            data-css-1vmmzqu=""
+          >
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 1
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 2
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 3
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 4
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 5
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 6
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 7
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 8
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 9
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 10
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 11
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 12
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 13
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 14
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-1g40x7n=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                data-css-1djcb20=""
+              >
+                <div
+                  aria-pressed={true}
+                  data-css-8a12hv=""
+                >
+                  <span
+                    data-css-13bnfv4=""
+                  >
+                    Item 15
+                  </span>
+                  <div
+                    data-css-k31qw2=""
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-label="close icon"
+                      role="img"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.646 7.056l-.702-.702a.5.5 0 00-.708 0L12 10.59 7.764 6.354a.5.5 0 00-.708 0l-.702.702a.5.5 0 000 .708L10.59 12l-4.236 4.236a.5.5 0 000 .707l.702.703a.5.5 0 00.708 0L12 13.41l4.236 4.236a.5.5 0 00.708 0l.702-.703a.5.5 0 000-.707L13.41 12l4.236-4.236a.5.5 0 000-.708z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              data-css-n9fe5c=""
+            >
+              <input
+                data-css-1cg8ewt=""
+                data-css-1f28mdy=""
+                id="tagsinput__input-unique-id"
+                onChange={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-css-bv851e=""
+    >
+      The sub label
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/TagsInput No Labels 1`] = `
 <div
   style={
@@ -925,13 +1639,13 @@ exports[`Storyshots Components/TagsInput No Labels 1`] = `
         onKeyPress={[Function]}
       >
         <div
-          data-css-r9wiij=""
+          data-css-1gs0ko2=""
         >
           <div
-            data-css-mggyc2=""
+            data-css-1vmmzqu=""
           >
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -971,7 +1685,7 @@ exports[`Storyshots Components/TagsInput No Labels 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -1011,12 +1725,11 @@ exports[`Storyshots Components/TagsInput No Labels 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
               data-css-n9fe5c=""
             >
               <input
+                data-css-1cg8ewt=""
                 data-css-1f28mdy=""
-                data-css-8z457z=""
                 id="tagsinput__input-unique-id"
                 onChange={[Function]}
                 onClick={[Function]}
@@ -1062,13 +1775,13 @@ exports[`Storyshots Components/TagsInput React Node Label 1`] = `
         onKeyPress={[Function]}
       >
         <div
-          data-css-r9wiij=""
+          data-css-1gs0ko2=""
         >
           <div
-            data-css-mggyc2=""
+            data-css-1vmmzqu=""
           >
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -1108,7 +1821,7 @@ exports[`Storyshots Components/TagsInput React Node Label 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
+              data-css-1g40x7n=""
               onClick={[Function]}
               onKeyDown={[Function]}
               tabIndex={-1}
@@ -1148,12 +1861,11 @@ exports[`Storyshots Components/TagsInput React Node Label 1`] = `
               </div>
             </div>
             <div
-              data-css-12qnym0=""
               data-css-n9fe5c=""
             >
               <input
+                data-css-1cg8ewt=""
                 data-css-1f28mdy=""
-                data-css-8z457z=""
                 id="tagsinput__input-unique-id"
                 onChange={[Function]}
                 onClick={[Function]}

--- a/packages/tagsinput/src/react/__stories__/index.story.tsx
+++ b/packages/tagsinput/src/react/__stories__/index.story.tsx
@@ -39,10 +39,12 @@ const Template: Story<ComponentProps<typeof TagsInput>> = args => {
     setSearchTerm(evt.target.value)
   }
 
-  const [value, setValue] = useState<Option[]>([
-    { label: 'first', value: 'first' },
-    { label: 'second', value: 'second' }
-  ])
+  const [value, setValue] = useState<Option[]>(
+    args.value || [
+      { label: 'first', value: 'first' },
+      { label: 'second', value: 'second' }
+    ]
+  )
 
   const handleOnKeyPress: KeyboardEventHandler = evt => {
     if (evt.key !== 'Enter') return
@@ -112,4 +114,19 @@ CustomInputTag.args = {
       style={{ outline: '1px dashed pink' }}
     />
   ))
+}
+
+export const Empty = Template.bind({})
+Empty.args = {
+  ...defaultArgs,
+  value: []
+}
+
+export const MultipleLines = Template.bind({})
+MultipleLines.args = {
+  ...defaultArgs,
+  value: [...new Array(15)].map((_, i) => ({
+    label: `Item ${i + 1}`,
+    value: i.toString()
+  }))
 }

--- a/packages/tagsinput/src/react/index.tsx
+++ b/packages/tagsinput/src/react/index.tsx
@@ -40,7 +40,6 @@ const styles = {
   prefix: () => css(stylesheet['.psds-tagsinput__prefix']),
   suffix: () => css(stylesheet['.psds-tagsinput__suffix']),
 
-  inputContainer: () => css(stylesheet['.psds-tagsinput__input-container']),
   input: () => css(stylesheet['.psds-tagsinput__input']),
 
   pillsContainer: () => css(stylesheet['.psds-tagsinput__pills-container']),
@@ -221,7 +220,7 @@ const Pill = forwardRef<HTMLDivElement, PillProps>((props, ref) => {
 })
 
 const PillAdjacentInputContainer = forwardRef<HTMLDivElement>((props, ref) => {
-  return <div ref={ref} {...props} {...styles.inputContainer()} />
+  return <div ref={ref} {...props} />
 })
 
 const PillAdjacentInput = forwardRef<


### PR DESCRIPTION
### What You're Solving

- Redo some layout to make tagsinput consistent with buttons and text inputs at 40px tall
- Fixes text input box being too tall which was adding extra space above the last row of tags
- Fixes placeholder being cut off because it wasn't flex-growing
- Adds "Empty" and "Multiple lines" stories


### Design Decisions

- The gutter around the edges of the box is 8px and the spacing between tags is 4px

### How to Verify

- Verify the tagsinput component is 40px tall
- Verify scrolling a multi-line tagsinput looks correct (scroll bar in the right place, spacing around the edge of the box is correct, etc...)
- Verify a longer placeholder text no longer gets cut off
- Verify the space above the third row of tags is not larger than above the second row
