### PR TITLE
expose package.json in conditional exports

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/css/index.css",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -15,7 +15,10 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "default": "./index.js"
+    ".": {
+      "default": "./index.js"
+    },
+    "./package.json": "./package.json"
   },
   "dependencies": {
     "chalk": "^2.4.2",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "gitHead": "7418883d96a76c59a99f86c2b16516ec752bf913",
   "sideEffects": false,

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/circularprogress/package.json
+++ b/packages/circularprogress/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/css/index.css",

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -20,10 +20,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,10 +18,13 @@
     "test": "tsc --noEmit --project ./tsconfig.json && jest"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/css/index.css",

--- a/packages/datawell/package.json
+++ b/packages/datawell/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test -- --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "gitHead": "7418883d96a76c59a99f86c2b16516ec752bf913",
   "sideEffects": false,

--- a/packages/emptystate/package.json
+++ b/packages/emptystate/package.json
@@ -27,10 +27,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -26,10 +26,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/featureflags/package.json
+++ b/packages/featureflags/package.json
@@ -20,10 +20,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test -- --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/focusmanager/package.json
+++ b/packages/focusmanager/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -25,10 +25,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/halo/package.json
+++ b/packages/halo/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -29,10 +29,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/linearprogress/package.json
+++ b/packages/linearprogress/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test -- --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/multiselect/package.json
+++ b/packages/multiselect/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test -- --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/navbar/package.json
+++ b/packages/navbar/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "gitHead": "7418883d96a76c59a99f86c2b16516ec752bf913",
   "sideEffects": false,

--- a/packages/navbrand/package.json
+++ b/packages/navbrand/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/navcookiebanner/package.json
+++ b/packages/navcookiebanner/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/navitem/package.json
+++ b/packages/navitem/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/navuser/package.json
+++ b/packages/navuser/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/normalize/package.json
+++ b/packages/normalize/package.json
@@ -11,10 +11,13 @@
     "build": "postcss css/index.css --dir dist"
   },
   "exports": {
-    "import": "./dist/index.css",
-    "require": "./dist/index.css",
-    "node": "./dist/index.css",
-    "default": "./dist/index.css"
+    ".": {
+      "import": "./dist/index.css",
+      "require": "./dist/index.css",
+      "node": "./dist/index.css",
+      "default": "./dist/index.css"
+    },
+    "./package.json": "./package.json"
   },
   "style": "dist/index.css",
   "dependencies": {

--- a/packages/note/package.json
+++ b/packages/note/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/position/package.json
+++ b/packages/position/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/screenreaderonly/package.json
+++ b/packages/screenreaderonly/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/scrollable/package.json
+++ b/packages/scrollable/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/searchinput/package.json
+++ b/packages/searchinput/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test -- --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/starrating/package.json
+++ b/packages/starrating/package.json
@@ -24,10 +24,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test -- --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/storybook-addon-center/package.json
+++ b/packages/storybook-addon-center/package.json
@@ -15,10 +15,13 @@
     "build:watch": "yarn build --watch"
   },
   "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/index.js",
-    "node": "./dist/index.js",
-    "default": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "node": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "types": "dist/index.d.ts",
   "dependencies": {

--- a/packages/storybook-addon-theme/package.json
+++ b/packages/storybook-addon-theme/package.json
@@ -17,10 +17,13 @@
     "build:watch": "yarn build --watch"
   },
   "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/index.js",
-    "node": "./dist/index.js",
-    "default": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "node": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "types": "dist/index.d.ts",
   "dependencies": {

--- a/packages/storybook-preset/package.json
+++ b/packages/storybook-preset/package.json
@@ -14,10 +14,13 @@
     "build:watch": "yarn build --watch"
   },
   "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/index.js",
-    "node": "./dist/index.js",
-    "default": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "node": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "types": "dist/index.d.ts",
   "dependencies": {

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test -- --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/tagsinput/package.json
+++ b/packages/tagsinput/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test -- --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/textinput/package.json
+++ b/packages/textinput/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -19,10 +19,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/typeahead/package.json
+++ b/packages/typeahead/package.json
@@ -22,10 +22,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "gitHead": "ea4595a4bff6a08255102a0321bb641dc4d25913",
   "sideEffects": false,

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -20,10 +20,13 @@
     "test:watch": "yarn test --watch"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",

--- a/packages/verticaltabs/package.json
+++ b/packages/verticaltabs/package.json
@@ -19,10 +19,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",

--- a/packages/viewtoggle/package.json
+++ b/packages/viewtoggle/package.json
@@ -21,10 +21,13 @@
     "test:watch": "yarn test --watchAll"
   },
   "exports": {
-    "import": "./dist/esm/index.mjs",
-    "require": "./dist/cjs/index.js",
-    "node": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "style": "dist/index.css",


### PR DESCRIPTION
Conditional exports whitelist places in a package that can be imported from. It makes entry points explicit.

We want to make it the de facto standard to import the package name and avoid pathing files beneath the package.

But Storybook apparently pulls in package.json, so this is enabling that.
https://github.com/storybookjs/storybook/blob/32c63568d6f7f6ef90afd206405524543d5a7068/lib/core-server/src/manager/manager-config.ts#L18

Fixes this error:
https://github.com/storybookjs/storybook/issues/13099#issuecomment-805233273
