### PR TITLE
fix(docs): remove extra parens in @media rules

### DIFF
--- a/docs/src/components/frame/aside.module.css
+++ b/docs/src/components/frame/aside.module.css
@@ -26,7 +26,7 @@
     width: 100%;
   }
 
-  @media ((width >= 768px)) {
+  @media (width >= 768px) {
     transform: translate(0, 0);
 
     &:after {
@@ -42,7 +42,7 @@
     box-shadow: none;
   }
 
-  @media ((width >= 768px)) {
+  @media (width >= 768px) {
     transform: initial;
   }
 }

--- a/docs/src/components/frame/frame.module.css
+++ b/docs/src/components/frame/frame.module.css
@@ -16,10 +16,10 @@
     min-height: calc(100vh - var(--topNavHeight));
   }
 
-  @media ((width >= 768px)) {
+  @media (width >= 768px) {
     padding-left: var(--asideWidth);
   }
-  @media ((width >= 1280px)) {
+  @media (width >= 1280px) {
     padding-right: var(--metaWidth);
   }
 

--- a/docs/src/components/frame/header.module.css
+++ b/docs/src/components/frame/header.module.css
@@ -5,14 +5,14 @@
   padding: var(--psLayoutSpacingXSmall);
   background: var(--appColorsBackgroundHigh);
 
-  @media ((width >= 768px)) {
+  @media (width >= 768px) {
     background-color: transparent;
   }
 
   & .menuButton {
     margin-right: auto;
 
-    @media ((width >= 768px)) {
+    @media (width >= 768px) {
       display: none;
     }
   }
@@ -22,7 +22,7 @@
     top: var(--psLayoutSpacingXSmall);
     right: var(--psLayoutSpacingXSmall);
 
-    @media ((width >= 768px)) {
+    @media (width >= 768px) {
       top: var(--psLayoutSpacingMedium);
       right: var(--psLayoutSpacingMedium);
     }

--- a/docs/src/components/motion/easing.module.css
+++ b/docs/src/components/motion/easing.module.css
@@ -152,7 +152,7 @@ b {
   background: var(--psColorsPink6);
 }
 
-@media ((width >= 1280px)) {
+@media (width >= 1280px) {
   .function {
     flex-direction: row;
   }

--- a/docs/src/components/table-of-contents.module.css
+++ b/docs/src/components/table-of-contents.module.css
@@ -10,7 +10,7 @@
   overflow: hidden;
   background: var(--bg);
 
-  @media (--breakpoint-large) {
+  @media (width >= 768px) {
     position: fixed;
     width: 240px;
     top: calc(var(--topNavHeight) + var(--psLayoutSpacingLarge));

--- a/docs/src/content/index.module.css
+++ b/docs/src/content/index.module.css
@@ -16,7 +16,7 @@
   grid-template-columns: 1fr;
   grid-column-gap: var(--psLayoutSpacingLarge);
 
-  @media ((width >= 768px)) {
+  @media (width >= 768px) {
     grid-template-columns: repeat(2, 1fr);
   }
 }
@@ -63,7 +63,7 @@
     font-weight: var(--psTypeFontWeightMedium);
   }
 
-  @media ((width >= 768px)) {
+  @media (width >= 768px) {
     grid-template-columns: repeat(2, 1fr);
     grid-gap: var(--psLayoutSpacingLarge);
   }


### PR DESCRIPTION
Removing the extra set of parens in the `@media` CSS rules fixed the issues with the docs always showing the mobile layout at all screen widths.

Closes #1737