### PR TITLE
Fix/focus trap dropdown

### DIFF
--- a/packages/dropdown/src/js/index.ts
+++ b/packages/dropdown/src/js/index.ts
@@ -143,13 +143,11 @@ export const useDropdown = (
       }
     }
   }, [itemMatchingValueIndex, isOpen])
-
+  const openKeyEvents = new Set(['Enter', 'ArrowDown', 'ArrowUp', ' '])
   function handleButtonEvent(evt: React.MouseEvent | React.KeyboardEvent) {
     if (
       evt.type === 'click' ||
-      (evt.type === 'keydown' &&
-        'key' in evt &&
-        ['Enter', 'ArrowDown', 'ArrowUp', ' '].includes(evt.key))
+      (evt.type === 'keydown' && 'key' in evt && openKeyEvents.has(evt.key))
     ) {
       evt.preventDefault()
       evt.stopPropagation()

--- a/packages/dropdown/src/js/index.ts
+++ b/packages/dropdown/src/js/index.ts
@@ -149,7 +149,7 @@ export const useDropdown = (
       evt.type === 'click' ||
       (evt.type === 'keydown' &&
         'key' in evt &&
-        (evt.key === 'Enter' || 'ArrowDown' || 'ArrowUp'))
+        ['Enter', 'ArrowDown', 'ArrowUp', ' '].includes(evt.key))
     ) {
       evt.preventDefault()
       evt.stopPropagation()

--- a/packages/select/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/select/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -217,6 +217,50 @@ exports[`Storyshots Components/Select Button Small 1`] = `
 </button>
 `;
 
+exports[`Storyshots Components/Select Custom Menu Item 1`] = `
+Array [
+  <button
+    aria-haspopup="listbox"
+    aria-labelledby="select-button-4fzzzxjyl"
+    data-css-vqbjxt=""
+    id="select-button-4fzzzxjyl"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+  >
+    <div
+      data-css-1nr9efp=""
+    >
+      <span
+        data-css-1p9e07r=""
+      >
+        Select item
+      </span>
+      <div
+        data-css-7dab2f=""
+        data-css-vgdpow=""
+      >
+        <svg
+          aria-label="caret down icon"
+          role="img"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 15.41l-5-5L8.41 9 12 12.58 15.59 9 17 10.41"
+          />
+        </svg>
+      </div>
+    </div>
+  </button>,
+  <div
+    style={
+      Object {
+        "visibility": "hidden",
+      }
+    }
+  />,
+]
+`;
+
 exports[`Storyshots Components/Select Custom Render Option 1`] = `
 Array [
   <button

--- a/packages/select/src/react/__specs__/index.spec.tsx
+++ b/packages/select/src/react/__specs__/index.spec.tsx
@@ -195,7 +195,7 @@ describe('Select', () => {
       pressArrowDown()
       pressEnter()
 
-      expect(button).toHaveTextContent('Can view')
+      expect(button).toHaveTextContent('Can edit')
     })
 
     it('select button onClick is triggered', async () => {
@@ -243,8 +243,8 @@ describe('Select', () => {
       pressEnter()
 
       expect(onChange).toHaveBeenCalledWith(expect.any(Object), {
-        value: 'Can view',
-        label: 'Can view'
+        value: 'Can edit',
+        label: 'Can edit'
       })
     })
   })

--- a/packages/select/src/react/__stories__/index.story.tsx
+++ b/packages/select/src/react/__stories__/index.story.tsx
@@ -16,6 +16,42 @@ export default {
 interface StoryArgs {
   onChange?: any
   onClick?: any
+  options: {
+    value: React.ReactText
+    label: React.ReactText
+  }[]
+  placeholder: string
+  position: ValueOf<typeof Select.positions>
+}
+
+const basicArgs: StoryArgs = {
+  options: [
+    {
+      value: 'Can view',
+      label: 'Can view'
+    },
+    {
+      value: 'Can edit',
+      label: 'Can edit'
+    },
+    {
+      value: 'Make Owner',
+      label: 'Make Owner'
+    }
+  ],
+  onClick: action('on click'),
+  placeholder: 'Select item',
+  position: Select.positions.belowLeft
+}
+
+const Template: Story<StoryArgs> = args => <Select {...args} />
+
+export const Basic = Template.bind({})
+Basic.args = { ...basicArgs }
+
+interface CustomStoryArgs {
+  onChange?: any
+  onClick?: any
   items: {
     description: React.ReactText
     value: React.ReactText
@@ -25,7 +61,7 @@ interface StoryArgs {
   position: ValueOf<typeof Select.positions>
 }
 
-const defaultArgs: StoryArgs = {
+const customArgs: CustomStoryArgs = {
   items: [
     {
       description: 'View details, content and other members in the channel.',
@@ -50,7 +86,7 @@ const defaultArgs: StoryArgs = {
   position: Select.positions.belowLeft
 }
 
-const Template: Story<StoryArgs> = args => {
+const CustomMenuItemTemplate: Story<CustomStoryArgs> = args => {
   const { items } = args
   const [selected] = React.useState()
 
@@ -83,16 +119,16 @@ const Template: Story<StoryArgs> = args => {
   )
 }
 
-export const Basic = Template.bind({})
-Basic.args = { ...defaultArgs }
+export const CustomMenuItem = CustomMenuItemTemplate.bind({})
+CustomMenuItem.args = { ...customArgs }
 
-export const PositionBelowLeft = Template.bind({})
+export const PositionBelowLeft = CustomMenuItemTemplate.bind({})
 PositionBelowLeft.args = {
-  ...defaultArgs,
+  ...customArgs,
   position: Select.positions.belowRight
 }
 
-export const CustomRenderOption: Story<StoryArgs> = args => {
+export const CustomRenderOption: Story<CustomStoryArgs> = args => {
   const { items, placeholder, position } = args
   const [selected] = React.useState()
 
@@ -106,7 +142,7 @@ export const CustomRenderOption: Story<StoryArgs> = args => {
     />
   )
 }
-CustomRenderOption.args = { ...defaultArgs }
+CustomRenderOption.args = { ...customArgs }
 
 const defaultButtonArgs = { children: 'Hello' }
 

--- a/packages/select/src/react/index.tsx
+++ b/packages/select/src/react/index.tsx
@@ -2,7 +2,7 @@ import * as PositionComponents from '@pluralsight/ps-design-system-position'
 import {
   ValueOf,
   forwardRefWithAs,
-  forwardRefWithAsAndStatics
+  forwardRefWithStatics
 } from '@pluralsight/ps-design-system-util'
 import Menu from '@pluralsight/ps-design-system-menu'
 import glamorDefault, * as glamorExports from 'glamor'
@@ -43,39 +43,40 @@ interface SelectProps extends UseListboxProps {
   renderOption?: React.FC
 }
 
-const Select = forwardRefWithAsAndStatics<SelectProps, 'button', SelectStatics>(
-  (props, ref) => {
-    const {
-      options = [],
-      position = 'belowLeft',
-      renderOption = defaultRenderOption,
-      children,
-      ...rest
-    } = props
-    const { buttonProps, selectedProps, menuProps, isOpen } = useListbox(
-      rest,
-      ref
-    )
+const Select = forwardRefWithStatics<
+  SelectProps,
+  HTMLButtonElement,
+  SelectStatics
+>((props, ref) => {
+  const {
+    options = [],
+    position = 'belowLeft',
+    renderOption = defaultRenderOption,
+    children,
+    ...rest
+  } = props
+  const { buttonProps, selectedProps, menuProps, isOpen } = useListbox(
+    rest,
+    ref
+  )
 
-    const RenderOption = React.useMemo(() => renderOption, [renderOption])
-    return (
-      <PositionComponents.Position
-        position={PositionComponents[position]}
-        when={isOpen}
-        show={
-          <Menu origin={Menu.origins.topLeft} {...menuProps} {...styles}>
-            {children ||
-              options.map(i => <RenderOption key={i.value} {...i} />)}
-          </Menu>
-        }
-      >
-        <Button {...buttonProps}>
-          <Selected {...selectedProps} />
-        </Button>
-      </PositionComponents.Position>
-    )
-  }
-)
+  const RenderOption = React.useMemo(() => renderOption, [renderOption])
+  return (
+    <PositionComponents.Position
+      position={PositionComponents[position]}
+      when={isOpen}
+      show={
+        <Menu origin={Menu.origins.topLeft} {...menuProps} {...styles}>
+          {children || options.map(i => <RenderOption key={i.value} {...i} />)}
+        </Menu>
+      }
+    >
+      <Button {...buttonProps}>
+        <Selected {...selectedProps} />
+      </Button>
+    </PositionComponents.Position>
+  )
+})
 
 interface SelectStatics {
   Button: typeof Button


### PR DESCRIPTION
So there were two focus traps and one was the result of tabbing pass the select where it would open the dropdown unintentionally. Our original conditional somehow let Tab through. I'm not sure why but I modified it to use an Array.includes which solved the problem. 

As for Select I updated the stories to include the basic example that got removed on CSF conversion in addition to the MenuItemWithDescription ones. In doing so I noticed an unrelated bug I'm going to create an issue for #1762