### PR TITLE
feat(datepicker): custom date format

### DIFF
--- a/docs/src/content/components/datepicker.mdx
+++ b/docs/src/content/components/datepicker.mdx
@@ -302,6 +302,12 @@ return (
     type="React.Dispatch<React.SetStateAction<ValueOf<typeof slides>>>"
     desc="the set state action for the selected date"
   />
+  <TypesProp
+    name="dateFormat"
+    optional
+    type="string"
+    desc="a <a href='https://date-fns.org/v2.16.1/docs/format'>date-fns compatible format string</a>"
+  />
 </TypesTable>
 
 **Returns:** an array
@@ -395,6 +401,12 @@ return (
     required
     type="boolean"
     desc="distinguishes the first date in the range from the end date"
+  />
+  <TypesProp
+    name="dateFormat"
+    optional
+    type="string"
+    desc="a <a href='https://date-fns.org/v2.16.1/docs/format'>date-fns compatible format string</a>"
   />
 </TypesTable>
 

--- a/packages/datepicker/src/react/__specs__/index.spec.ts
+++ b/packages/datepicker/src/react/__specs__/index.spec.ts
@@ -274,7 +274,7 @@ test('useDateSelectChange', () => {
   expect(formatISO(result.current.selected)).toBe(
     formatISO(new Date('03/10/2020'))
   )
-  expect(result.current.slide).toBe('backward')
+  expect(result.current.slide).toBeUndefined()
   act(() => {
     result.current.onChange({
       target: { value: '03/11/2020' }
@@ -285,6 +285,38 @@ test('useDateSelectChange', () => {
     formatISO(new Date('03/11/2020'))
   )
   expect(result.current.slide).toBe(undefined)
+})
+test('useDateSelectChange: custom date format', () => {
+  const { result } = renderHook(() => {
+    const [selected, setSelected] = React.useState<Date | undefined>()
+    const [slide, setSlide] = React.useState<
+      'forward' | 'backward' | undefined
+      >()
+    const dateFormat = 'yyyy-MM-dd'
+    const [value, onChange] = useDateSelectChange({
+      setSelected,
+      selected,
+      setSlide,
+      dateFormat
+    })
+    return { selected, slide, value, onChange }
+  })
+  act(() => {
+    result.current.onChange({
+      target: { value: '01/10/2020' }
+    } as React.ChangeEvent<HTMLInputElement>)
+  })
+  expect(result.current.value).toBe('01/10/2020')
+  expect(result.current.selected).toBe(undefined)
+  act(() => {
+    result.current.onChange({
+      target: { value: '2020-01-10' }
+    } as React.ChangeEvent<HTMLInputElement>)
+  })
+  expect(result.current.value).toBe('2020-01-10')
+  expect(formatISO(result.current.selected)).toBe(
+    formatISO(new Date('01/10/2020'))
+  )
 })
 test('useRangeSelectChange', () => {
   const { result } = renderHook(() => {

--- a/packages/datepicker/src/react/__specs__/index.spec.ts
+++ b/packages/datepicker/src/react/__specs__/index.spec.ts
@@ -455,3 +455,63 @@ test('useRangeSelectChange', () => {
   expect(result.current.endValue).toBe('05/21/2020')
   expect(result.current.slide).toBe('backward')
 })
+test('useRangeSelectChange: custom date format', () => {
+  const { result } = renderHook(() => {
+    const [selected, setSelected] = React.useState<Date[] | undefined>()
+    const [slide, setSlide] = React.useState<
+      'forward' | 'backward' | undefined
+      >()
+    const dateFormat = 'yyyy-MM-dd'
+    const [startValue, onStartChange] = useRangeSelectChange({
+      start: true,
+      setSelected,
+      selected,
+      setSlide,
+      dateFormat
+    })
+    const [endValue, onEndChange] = useRangeSelectChange({
+      start: false,
+      setSelected,
+      selected,
+      setSlide,
+      dateFormat
+    })
+    return {
+      selected,
+      slide,
+      startValue,
+      onStartChange,
+      endValue,
+      onEndChange
+    }
+  })
+  act(() => {
+    result.current.onStartChange({
+      target: { value: '03/01/2021' }
+    } as React.ChangeEvent<HTMLInputElement>)
+  })
+  act(() => {
+    result.current.onEndChange({
+      target: { value: '03/11/2021' }
+    } as React.ChangeEvent<HTMLInputElement>)
+  })
+  expect(result.current.startValue).toBe('03/01/2021')
+  expect(result.current.endValue).toBe('03/11/2021')
+  expect(result.current.selected).toStrictEqual(undefined)
+  expect(result.current.slide).toBe(undefined)
+  act(() => {
+    result.current.onStartChange({
+      target: { value: '2021-03-01' }
+    } as React.ChangeEvent<HTMLInputElement>)
+  })
+  act(() => {
+    result.current.onEndChange({
+      target: { value: '2021-03-11' }
+    } as React.ChangeEvent<HTMLInputElement>)
+  })
+  expect(result.current.startValue).toBe('2021-03-01')
+  expect(result.current.endValue).toBe('2021-03-11')
+  expect(result.current.selected.map(date => formatISO(date))).toMatchObject(
+    [formatISO(new Date('03/01/2021')), formatISO(new Date('03/11/2021'))]
+  )
+})

--- a/packages/datepicker/src/react/utils.ts
+++ b/packages/datepicker/src/react/utils.ts
@@ -3,6 +3,7 @@ import { ValueOf } from '@pluralsight/ps-design-system-util'
 import differenceInCalendarMonths from 'date-fns/differenceInCalendarMonths'
 import format from 'date-fns/format'
 import parse from 'date-fns/parse'
+import isMatch from 'date-fns/isMatch'
 import type { DateObj } from 'dayzed'
 import glamorDefault, * as glamorExports from 'glamor'
 import React from 'react'
@@ -151,17 +152,18 @@ interface HandleChange<T> {
   selected?: T
   setSlide: React.Dispatch<React.SetStateAction<ValueOf<typeof slides>>>
   setSelected: React.Dispatch<React.SetStateAction<T | undefined>>
+  dateFormat: string
 }
 
 export const useDateSelectChange = ({
   selected,
   setSlide,
-  setSelected
+  setSelected,
+  dateFormat = 'MM/dd/yyyy'
 }: HandleChange<Date>): [
   string,
   (event: React.ChangeEvent<HTMLInputElement>) => void
 ] => {
-  const dateFormat = 'MM/dd/yyyy'
   const [value, setValue] = React.useState<string>(
     selected ? format(selected, dateFormat) : ''
   )
@@ -171,8 +173,14 @@ export const useDateSelectChange = ({
   const onChange: React.ChangeEventHandler<HTMLInputElement> = evt => {
     const nextValue = evt.target.value
     setValue(nextValue)
-    const regex = /[0-1][0-9]\/[0-3][0-9]\/[0-9][0-9][0-9][0-9]/
-    const fulldate = regex.test(nextValue)
+    let fulldate = false
+    try {
+      fulldate = isMatch(nextValue, dateFormat)
+    } catch (err) {
+      if (!(err instanceof RangeError)) {
+        throw err
+      }
+    }
     const nextSelected = fulldate
       ? parse(nextValue, dateFormat, new Date())
       : selected
@@ -204,12 +212,12 @@ export const useRangeSelectChange = ({
   start,
   selected = [],
   setSlide,
-  setSelected
+  setSelected,
+  dateFormat = 'MM/dd/yyyy'
 }: HandleRangeChange): [
   string,
   (event: React.ChangeEvent<HTMLInputElement>) => void
 ] => {
-  const dateFormat = 'MM/dd/yyyy'
   const _selected = start ? selected[0] : selected[1]
   const [value, setValue] = React.useState<string>(
     _selected ? format(_selected, dateFormat) : ''
@@ -220,8 +228,14 @@ export const useRangeSelectChange = ({
   const onChange: React.ChangeEventHandler<HTMLInputElement> = evt => {
     const nextValue = evt.target.value
     setValue(nextValue)
-    const regex = /[0-1][0-9]\/[0-3][0-9]\/[0-9][0-9][0-9][0-9]/
-    const fulldate = regex.test(nextValue)
+    let fulldate = false
+    try {
+      fulldate = isMatch(nextValue, dateFormat)
+    } catch (err) {
+      if (!(err instanceof RangeError)) {
+        throw err
+      }
+    }
     const nextSelected = fulldate
       ? parse(nextValue, dateFormat, new Date())
       : selected

--- a/packages/datepicker/src/react/utils.ts
+++ b/packages/datepicker/src/react/utils.ts
@@ -152,7 +152,7 @@ interface HandleChange<T> {
   selected?: T
   setSlide: React.Dispatch<React.SetStateAction<ValueOf<typeof slides>>>
   setSelected: React.Dispatch<React.SetStateAction<T | undefined>>
-  dateFormat: string
+  dateFormat?: string
 }
 
 export const useDateSelectChange = ({


### PR DESCRIPTION
### What You're Solving

- Currently, the display format for is hard-coded to use 'MM/dd/yyyy'
- With this change, someone using this function can pass their own date format string to control how the date is displayed and entered in the text field.

### Design Decisions

- I added an optional `dateFormat` parameter to the `useDateSelectChange` and `useRangeSelectChange` functions. It defaults to the same format that was already used, so it should be backward compatible.
- The input is validated with a regex `/[0-1][0-9]\/[0-3][0-9]\/[0-9][0-9][0-9][0-9]/`, which doesn't catch some of the nuances of dates (for example, Feb 30th is invalid, but matches the regex)
- I replaced the regex test with the `isMatch` function from date-fns. Any RangeError thrown by that function is caught, since it typically means the date string doesn't match the format string. Other errors are rethrown.
- Replacing the regex broke one test. But it looks like the test was incorrect. The date string used had a "13" for the month, which should be invalid, but passed the regex test, leading to `nextSlide` being set to 'backward'. Now, using the more restrictive `isMatch`, the date string is detected as invalid, and `nextSlide` is now correctly being set to `undefined`. I updated the test to match.
