### PR TITLE
fix(focusmanager): allow detection of dynamic focuable children

### DIFF
--- a/packages/focusmanager/package.json
+++ b/packages/focusmanager/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^3.1.1",
+    "@pluralsight/ps-design-system-button": "^22.1.7",
     "@pluralsight/ps-design-system-storybook-preset": "^0.6.5",
     "@pluralsight/ps-design-system-text": "^20.1.6"
   }

--- a/packages/focusmanager/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/focusmanager/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Components/FocusManager Dynamic Children 1`] = `
+<div>
+  <button
+    data-css-y5dqt5=""
+    disabled={false}
+    style={Object {}}
+  >
+    <span
+      data-css-15b13by=""
+    >
+      Is tabbable
+    </span>
+  </button>
+</div>
+`;
+
 exports[`Storyshots Components/FocusManager No Focusable Children 1`] = `
 <div
   style={

--- a/packages/focusmanager/src/react/__specs__/index.spec.tsx
+++ b/packages/focusmanager/src/react/__specs__/index.spec.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 import { convertStoriesToJestCases } from '@pluralsight/ps-design-system-util'
-import { fireEvent, render } from '@testing-library/react'
+import Button from '@pluralsight/ps-design-system-button'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'
 import React from 'react'
 
@@ -39,7 +41,7 @@ describe('FocusManager', () => {
         <FocusManager>
           <ul>
             <li>
-              <a href="#">first</a>
+              <a href="#">first</a>{' '}
             </li>
           </ul>
         </FocusManager>

--- a/packages/focusmanager/src/react/__stories__/index.story.tsx
+++ b/packages/focusmanager/src/react/__stories__/index.story.tsx
@@ -1,8 +1,8 @@
+import * as Text from '@pluralsight/ps-design-system-text'
+import Button from '@pluralsight/ps-design-system-button'
 import { storiesOf } from '@storybook/react'
 import { Meta, Story } from '@storybook/react/types-6-0'
 import React from 'react'
-
-import * as Text from '@pluralsight/ps-design-system-text'
 
 import FocusManager from '../index'
 
@@ -54,3 +54,18 @@ export const NoFocusableChildren: Story = () => (
     </Text.P>
   </FocusManager>
 )
+
+export const DynamicChildren: Story = () => {
+  const [showButton, setShowButton] = React.useState(false)
+
+  React.useEffect(() => {
+    setTimeout(() => setShowButton(true), 1000)
+  }, [])
+
+  return (
+    <FocusManager trapped={true} autofocus={true}>
+      <Button>Is tabbable</Button>
+      {showButton && <Button>Is not tabbable</Button>}
+    </FocusManager>
+  )
+}

--- a/packages/focusmanager/src/react/use-focus-manager.ts
+++ b/packages/focusmanager/src/react/use-focus-manager.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-import { RefFor } from '@pluralsight/ps-design-system-util'
+import { canUseDOM, RefFor } from '@pluralsight/ps-design-system-util'
 import React from 'react'
 
 const FOCUSABLE_SELECTORS = [
@@ -52,8 +52,25 @@ export default function useFocusManager(
   }, [focusableNodes, ref])
 
   React.useEffect(() => {
+    let observer
+    if (canUseDOM() && node instanceof Node) {
+      observer = new MutationObserver(mutationList => {
+        mutationList.forEach(mutation => {
+          if (mutation.type === 'childList') {
+            const nextEls = getFocusableChildNodes(node)
+            setFocusableEls(nextEls)
+          }
+        })
+      })
+      observer.observe(node, { childList: true })
+    }
+
     const nextEls = getFocusableChildNodes(node)
     setFocusableEls(nextEls)
+
+    return () => {
+      observer?.disconnect()
+    }
   }, [node])
 
   React.useEffect(() => {


### PR DESCRIPTION
Didn't get the test to run properly. Seems to me that even though we
setup MutationObserver shim in the jest setup, it's still not
functioning quite as expected. That or the jest timers are not
interacting with it well.

If we want to try later, the test is here:
https://gist.github.com/jaketrent/76962889738dd9221e9788f964a5570f

Resolves: #1715

To verify, run new dynamic children story and tab through all buttons.
