### PR TITLE
test(carousel): enable axe test

### DIFF
--- a/packages/carousel/src/react/__specs__/index.spec.tsx
+++ b/packages/carousel/src/react/__specs__/index.spec.tsx
@@ -83,12 +83,11 @@ describe('Carousel', () => {
     })
   })
 
-  // TODO: enable and fix
-  // describe.each(cases)('%s story', (_name, Story) => {
-  //   it('has no axe-core violations', async () => {
-  //     const { container } = render(<Story {...Story.args} />)
-  //     const results = await axe(container)
-  //     expect(results).toHaveNoViolations()
-  //   })
-  // })
+  describe.each(cases)('%s story', (_name, Story) => {
+    it('has no axe-core violations', async () => {
+      const { container } = render(<Story {...Story.args} />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
 })


### PR DESCRIPTION
I thought there would be problems exposed by the test, as seen during
the CSF conversion, but I ran the test several times and ways, and I
could not get axe to detect any errors. So, I guess just enable the
tests that were previously written and keep them running.

Resolves: #1755

