### PR TITLE
card axe fix for img labels

### DIFF
--- a/docs/src/content/components/card.mdx
+++ b/docs/src/content/components/card.mdx
@@ -31,7 +31,7 @@ function Example() {
             title={<Card.Title>Advanced TypeScript</Card.Title>}
             progress={0}
             image={
-              <Card.Image src="https://picsum.photos/seed/picsum/540/360" />
+              <Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />
             }
             metadata1={['Brice Wilson', 'Advanced']}
             metadata2={['0m watched']}
@@ -48,7 +48,7 @@ function Example() {
             }
             progress={20}
             image={
-              <Card.Image src="https://picsum.photos/seed/picsum/540/360" />
+              <Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />
             }
             metadata1={['Scott Allen', 'Intermediate']}
             metadata2={['23m watched']}
@@ -79,7 +79,7 @@ function Example() {
             }
             progress={67}
             image={
-              <Card.Image src="https://picsum.photos/seed/picsum/540/360" />
+              <Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />
             }
             metadata1={['Cory House', 'Intermediate']}
             metadata2={['3h 23m watched']}
@@ -102,7 +102,7 @@ function Example() {
             metadata1={['Joe Eames', 'Intermediate']}
             metadata2={['90m watched']}
             image={
-              <Card.Image src="https://picsum.photos/seed/picsum/540/360" />
+              <Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />
             }
             size={Card.sizes.small}
           />
@@ -131,7 +131,7 @@ function Example() {
           size={Card.sizes.large}
           title={<Card.Title>Large card</Card.Title>}
           metadata1={['Jim Cooper']}
-          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
         />
       </div>
       <div style={{ maxWidth: '320px' }}>
@@ -139,7 +139,7 @@ function Example() {
           size={Card.sizes.medium}
           title={<Card.Title>Medium card</Card.Title>}
           metadata1={['Jim Cooper']}
-          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
         />
       </div>
       <div style={{ maxWidth: '140px' }}>
@@ -147,7 +147,7 @@ function Example() {
           size={Card.sizes.small}
           title={<Card.Title>Small card</Card.Title>}
           metadata1={['Jim Cooper']}
-          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
         />
       </div>
     </div>
@@ -160,6 +160,8 @@ export default Example
 ### Image
 
 The image will cover the space given. This space is variable width but set height according to the `size` property.
+
+To ensure screen-readable text, always pass `aria-label` for the image description.
 
 ```typescript
 import Button from '@pluralsight/ps-design-system-button'
@@ -174,7 +176,7 @@ function Example() {
         image={
           <Card.ImageLink>
             <a href="https://google.com" target="_blank">
-              <Card.Image src="https://picsum.photos/seed/picsum/540/360" />
+              <Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />
             </a>
           </Card.ImageLink>
         }
@@ -216,14 +218,14 @@ function Example() {
         <Card
           progress={25}
           title={<Card.Title>The Card Title</Card.Title>}
-          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
         />
       </div>
       <div style={{ width: '320px' }}>
         <Card
           progress={100}
           title={<Card.Title>The Card Title</Card.Title>}
-          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
         />
       </div>
     </div>
@@ -254,7 +256,7 @@ function Example() {
               You By Tech Groupsoft in the Stunning Desert of British Lithuania
             </Card.Title>
           }
-          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
         />
       </div>
       <div style={{ width: '320px' }}>
@@ -270,7 +272,7 @@ function Example() {
               </a>
             </Card.TextLink>
           }
-          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
         />
       </div>
     </div>
@@ -298,7 +300,7 @@ function Example() {
           metadata1={['Simon Allardice']}
           metadata2={['Intermediate', '2h 20m', 'July 24, 1847']}
           title={<Card.Title>Card with Two Lines of Meta</Card.Title>}
-          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
         />
       </div>
       <div style={{ width: '320px' }}>
@@ -316,7 +318,7 @@ function Example() {
             "July 24, 1847 or year thereabouts, it's unclear"
           ]}
           title={<Card.Title>Super-long Metadata</Card.Title>}
-          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+          image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
         />
       </div>
     </div>
@@ -345,7 +347,7 @@ function Example() {
         ]}
         actionBarVisible
         title={<Card.Title>Action bar locked visible</Card.Title>}
-        image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+        image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
       />
     </div>
   )
@@ -369,7 +371,7 @@ function Example() {
       <Card
         tag={<Card.Tag icon={<ChannelIcon />}>Channel</Card.Tag>}
         title={<Card.Title>Icon and text on card</Card.Title>}
-        image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+        image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
       />
     </div>
   )
@@ -401,7 +403,7 @@ function Example() {
         ]}
         tag={<Card.Tag icon={<ChannelIcon />}>Channel</Card.Tag>}
         title={<Card.Title>Combined with other overlays</Card.Title>}
-        image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+        image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
       />
     </div>
   )
@@ -424,7 +426,7 @@ function Example() {
       <Card
         bonusBar={<div>Just bonus</div>}
         title={<Card.Title>Custom elements in lower-left</Card.Title>}
-        image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" />}
+        image={<Card.Image src="https://picsum.photos/seed/picsum/540/360" aria-label="img desc" />}
       />
     </div>
   )
@@ -519,6 +521,7 @@ export default Example
 ### Card.Image
 
 <TypesTable>
+  <TypesProp name="aria-label" type="string" desc="screenreader label" />
   <TypesProp name="src" required type="string" desc="image url" />
 </TypesTable>
 

--- a/packages/card/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/card/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -15,6 +15,7 @@ exports[`Storyshots Components/Card Action Bar 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -162,6 +163,7 @@ exports[`Storyshots Components/Card Action Bar Locked Visible 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -309,6 +311,7 @@ exports[`Storyshots Components/Card Action Bar Multiple 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -475,6 +478,7 @@ exports[`Storyshots Components/Card Bonus Bar Element 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -618,6 +622,7 @@ exports[`Storyshots Components/Card Bonus Bar Text 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -753,6 +758,7 @@ exports[`Storyshots Components/Card Everything Focusable 1`] = `
           href="http://duckduckgo.com?q=image"
         >
           <div
+            aria-label="image"
             data-css-i7gti2=""
             style={
               Object {
@@ -1033,6 +1039,7 @@ exports[`Storyshots Components/Card Everything Locked 1`] = `
           href="http://duckduckgo.com?q=image"
         >
           <div
+            aria-label="image"
             data-css-i7gti2=""
             style={
               Object {
@@ -1356,6 +1363,7 @@ exports[`Storyshots Components/Card Full Overlay 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -1489,6 +1497,7 @@ exports[`Storyshots Components/Card Full Overlay Link 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -1626,6 +1635,7 @@ exports[`Storyshots Components/Card Full Overlay Link Icon 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -1788,6 +1798,7 @@ exports[`Storyshots Components/Card Full Overlay Link Icon Link 1`] = `
           href="http://duckduckgo.com?q=image"
         >
           <div
+            aria-label="image"
             data-css-i7gti2=""
             style={
               Object {
@@ -1946,6 +1957,7 @@ exports[`Storyshots Components/Card Full Overlay Locked Visible 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -2079,6 +2091,7 @@ exports[`Storyshots Components/Card Image 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="image"
         data-css-i7gti2=""
         style={
           Object {
@@ -2209,6 +2222,7 @@ exports[`Storyshots Components/Card Image Link 1`] = `
           href="http://duckduckgo.com"
         >
           <div
+            aria-label="image"
             data-css-i7gti2=""
             style={
               Object {
@@ -2218,6 +2232,132 @@ exports[`Storyshots Components/Card Image Link 1`] = `
           />
         </a>
       </span>
+    </div>
+    <div
+      data-css-piydn8=""
+    >
+      <div
+        data-css-fvvao4=""
+      >
+        <div
+          className=""
+        >
+          <span
+            style={
+              Object {
+                "display": "block",
+                "maxHeight": "0px",
+                "overflow": "hidden",
+                "position": "relative",
+              }
+            }
+          >
+            <span
+              className="shiitake-children"
+              style={
+                Object {
+                  "display": "block",
+                  "width": "100%",
+                }
+              }
+            >
+              Card Title
+              …
+            </span>
+            <span
+              aria-hidden="true"
+              style={
+                Object {
+                  "display": "block",
+                  "height": "0px",
+                  "overflow": "hidden",
+                  "width": "100%",
+                }
+              }
+            >
+              Card Title
+            </span>
+            <span
+              aria-hidden="true"
+              style={
+                Object {
+                  "display": "block",
+                  "left": "-20000px",
+                  "position": "absolute",
+                  "width": "100%",
+                }
+              }
+            >
+              <span
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "display": "block",
+                    }
+                  }
+                >
+                  W
+                </span>
+                <span
+                  style={
+                    Object {
+                      "display": "block",
+                    }
+                  }
+                >
+                  W
+                </span>
+              </span>
+              <span
+                className="shiitake-test-children"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              >
+                
+                …
+              </span>
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components/Card Image With Alt 1`] = `
+<div
+  style={
+    Object {
+      "width": "320px",
+    }
+  }
+>
+  <div
+    data-css-1ybvkp1=""
+  >
+    <div
+      data-css-1pdjifv=""
+    >
+      <div
+        alt="image"
+        aria-label="image"
+        data-css-i7gti2=""
+        style={
+          Object {
+            "backgroundImage": "url(//picsum.photos/400/200?image=42&gravity=north)",
+          }
+        }
+      />
     </div>
     <div
       data-css-piydn8=""
@@ -2335,6 +2475,7 @@ exports[`Storyshots Components/Card Metadata Multiple 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -2479,6 +2620,7 @@ exports[`Storyshots Components/Card Metadata Single 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -2612,6 +2754,7 @@ exports[`Storyshots Components/Card Metadata Text Link 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -2753,6 +2896,7 @@ exports[`Storyshots Components/Card Metadata Text Wrapper 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -2888,6 +3032,7 @@ exports[`Storyshots Components/Card Metadata Two Lines 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -3071,6 +3216,7 @@ exports[`Storyshots Components/Card Progress 1`] = `
         data-css-1pdjifv=""
       >
         <div
+          aria-label="default image"
           data-css-i7gti2=""
           style={
             Object {
@@ -3184,6 +3330,7 @@ exports[`Storyshots Components/Card Progress 1`] = `
         data-css-1pdjifv=""
       >
         <div
+          aria-label="default image"
           data-css-i7gti2=""
           style={
             Object {
@@ -3305,6 +3452,7 @@ exports[`Storyshots Components/Card Progress 1`] = `
         data-css-1pdjifv=""
       >
         <div
+          aria-label="default image"
           data-css-i7gti2=""
           style={
             Object {
@@ -3446,6 +3594,7 @@ exports[`Storyshots Components/Card Sizes 1`] = `
           data-css-wj7e8j=""
         >
           <div
+            aria-label="default image"
             data-css-i7gti2=""
             style={
               Object {
@@ -3567,6 +3716,7 @@ exports[`Storyshots Components/Card Sizes 1`] = `
           data-css-1pdjifv=""
         >
           <div
+            aria-label="default image"
             data-css-i7gti2=""
             style={
               Object {
@@ -3688,6 +3838,7 @@ exports[`Storyshots Components/Card Sizes 1`] = `
           data-css-1s0i6cc=""
         >
           <div
+            aria-label="default image"
             data-css-i7gti2=""
             style={
               Object {
@@ -3814,6 +3965,7 @@ exports[`Storyshots Components/Card Tag Icon 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -3966,6 +4118,7 @@ exports[`Storyshots Components/Card Tag Long Multi Word 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -4118,6 +4271,7 @@ exports[`Storyshots Components/Card Tag Long Single Word 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -4278,6 +4432,7 @@ exports[`Storyshots Components/Card Tag Sizes 1`] = `
           data-css-wj7e8j=""
         >
           <div
+            aria-label="default image"
             data-css-i7gti2=""
             style={
               Object {
@@ -4427,6 +4582,7 @@ exports[`Storyshots Components/Card Tag Sizes 1`] = `
           data-css-1pdjifv=""
         >
           <div
+            aria-label="default image"
             data-css-i7gti2=""
             style={
               Object {
@@ -4576,6 +4732,7 @@ exports[`Storyshots Components/Card Tag Sizes 1`] = `
           data-css-1s0i6cc=""
         >
           <div
+            aria-label="default image"
             data-css-i7gti2=""
             style={
               Object {
@@ -4730,6 +4887,7 @@ exports[`Storyshots Components/Card Tag Text 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -4863,6 +5021,7 @@ exports[`Storyshots Components/Card Title Link 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -4995,6 +5154,7 @@ exports[`Storyshots Components/Card Title Long 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -5119,6 +5279,7 @@ exports[`Storyshots Components/Card Title Long Link 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {
@@ -5251,6 +5412,7 @@ exports[`Storyshots Components/Card Title Text 1`] = `
       data-css-1pdjifv=""
     >
       <div
+        aria-label="default image"
         data-css-i7gti2=""
         style={
           Object {

--- a/packages/card/src/react/__specs__/index.spec.tsx
+++ b/packages/card/src/react/__specs__/index.spec.tsx
@@ -17,12 +17,11 @@ describe('Card', () => {
     expect(getByTestId('undertest')).toBeInTheDocument()
   })
 
-  // TODO: enable and fix
-  // describe.each(cases)('%s story', (_name, Story) => {
-  //   it('has no axe-core violations', async () => {
-  //     const { container } = render(<Story {...Story.args} />)
-  //     const results = await axe(container)
-  //     expect(results).toHaveNoViolations()
-  //   })
-  // })
+  describe.each(cases)('%s story', (_name, Story) => {
+    it('has no axe-core violations', async () => {
+      const { container } = render(<Story {...Story.args} />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    })
+  })
 })

--- a/packages/card/src/react/__specs__/index.spec.tsx
+++ b/packages/card/src/react/__specs__/index.spec.tsx
@@ -10,7 +10,9 @@ describe('Card', () => {
   const cases = convertStoriesToJestCases(stories)
 
   it('renders', () => {
-    const { getByTestId } = render(<Card data-testid="undertest"></Card>)
+    const { getByTestId } = render(
+      <Card image={<div />} title={<div />} data-testid="undertest"></Card>
+    )
 
     expect(getByTestId('undertest')).toBeInTheDocument()
   })

--- a/packages/card/src/react/__stories__/index.story.tsx
+++ b/packages/card/src/react/__stories__/index.story.tsx
@@ -41,7 +41,9 @@ const longTitle =
 
 const CardWithDefaults = (props: Partial<CardProps>) => {
   const title = props.title || <Card.Title>Card Title</Card.Title>
-  const image = props.image || <Card.Image src={getImgSrc()} />
+  const image = props.image || (
+    <Card.Image src={getImgSrc()} aria-label="default image" />
+  )
   return <Card {...props} title={title} image={image} />
 }
 
@@ -73,7 +75,7 @@ export const EverythingLocked: Story = () => (
     image={
       <Card.ImageLink>
         <a href="http://duckduckgo.com?q=image">
-          <Card.Image src={getImgSrc()} />
+          <Card.Image src={getImgSrc()} aria-label="image" />
         </a>
       </Card.ImageLink>
     }
@@ -119,7 +121,7 @@ export const EverythingFocusable: Story = () => (
     image={
       <Card.ImageLink>
         <a href="http://duckduckgo.com?q=image">
-          <Card.Image src={getImgSrc()} />
+          <Card.Image src={getImgSrc()} aria-label="image" />
         </a>
       </Card.ImageLink>
     }
@@ -175,7 +177,15 @@ export const TitleLongLink: Story = () => (
 
 export const Image: Story = () => (
   <CardWithDefaults
-    image={<Card.Image src={getImgSrc({ w: 400, h: 200 })} />}
+    image={
+      <Card.Image src={getImgSrc({ w: 400, h: 200 })} aria-label="image" />
+    }
+  />
+)
+
+export const ImageWithAlt: Story = () => (
+  <CardWithDefaults
+    image={<Card.Image src={getImgSrc({ w: 400, h: 200 })} alt="image" />}
   />
 )
 
@@ -184,7 +194,7 @@ export const ImageLink: Story = () => (
     image={
       <Card.ImageLink>
         <a href="http://duckduckgo.com">
-          <Card.Image src={getImgSrc({ w: 400, h: 200 })} />
+          <Card.Image src={getImgSrc({ w: 400, h: 200 })} aria-label="image" />
         </a>
       </Card.ImageLink>
     }
@@ -283,7 +293,7 @@ export const FullOverlayLinkIconLink: Story = () => (
     image={
       <Card.ImageLink>
         <a href="http://duckduckgo.com?q=image">
-          <Card.Image src={getImgSrc()} />
+          <Card.Image src={getImgSrc()} aria-label="image" />
         </a>
       </Card.ImageLink>
     }

--- a/packages/card/src/react/index.tsx
+++ b/packages/card/src/react/index.tsx
@@ -258,7 +258,15 @@ const MetaData: React.FC<MetaDataProps> = props => {
   )
 }
 
-export interface CardProps extends Record<string, unknown> {
+export interface CardProps
+  extends Omit<
+      React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLDivElement>,
+        HTMLDivElement
+      >,
+      'title'
+    >,
+    Record<string, unknown> {
   actionBar?: React.ReactElement<typeof ActionBarAction>[]
   actionBarVisible?: boolean
   bonusBar?: React.ReactNode

--- a/packages/card/src/react/index.tsx
+++ b/packages/card/src/react/index.tsx
@@ -173,6 +173,7 @@ const FullOverlayLink: React.FC<HTMLPropsFor<'span'>> = props => (
 FullOverlayLink.displayName = 'Card.FullOverlayLink'
 
 interface ImageProps extends HTMLPropsFor<'div'> {
+  alt?: string
   src: string
 }
 const Image: React.FC<ImageProps> = props => {
@@ -181,6 +182,7 @@ const Image: React.FC<ImageProps> = props => {
     <div
       {...styles.image()}
       {...rest}
+      aria-label={rest['aria-label'] || rest.alt}
       style={{ backgroundImage: `url(${src})` }}
     />
   )


### PR DESCRIPTION
Among a couple other related adjustments:

- refactor(card): props extend react.htmlattributes for div
- test(card): fix tsc error in test
- feat(card): allow alt prop to Card.Image
- test(card): resolve axe bug of images without labels in stories
- refactor(docs): add aria-label to Card.Image examples
