### PR TITLE
fix button display when loading on mount

### DIFF
--- a/packages/appframe/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/appframe/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -11,10 +11,10 @@ exports[`Storyshots Components/AppFrame Basic 1`] = `
     <button
       data-css-c3sd2l=""
       disabled={false}
-      style={Object {}}
       tabIndex={0}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         skip to main content
@@ -217,10 +217,10 @@ exports[`Storyshots Components/AppFrame Example Short Content 1`] = `
     <button
       data-css-c3sd2l=""
       disabled={false}
-      style={Object {}}
       tabIndex={0}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         skip to main content
@@ -552,10 +552,10 @@ exports[`Storyshots Components/AppFrame Side Nav Controlled 1`] = `
     <button
       data-css-c3sd2l=""
       disabled={false}
-      style={Object {}}
       tabIndex={0}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         skip to main content
@@ -985,10 +985,10 @@ exports[`Storyshots Components/AppFrame Side Nav Scrolling 1`] = `
     <button
       data-css-c3sd2l=""
       disabled={false}
-      style={Object {}}
       tabIndex={0}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         skip to main content
@@ -1227,10 +1227,10 @@ exports[`Storyshots Components/AppFrame Side Nav Uncontrolled 1`] = `
     <button
       data-css-c3sd2l=""
       disabled={false}
-      style={Object {}}
       tabIndex={0}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         skip to main content
@@ -1660,10 +1660,10 @@ exports[`Storyshots Components/AppFrame/Examples Skills 1`] = `
     <button
       data-css-c3sd2l=""
       disabled={false}
-      style={Object {}}
       tabIndex={0}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         skip to main content

--- a/packages/breadcrumb/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/breadcrumb/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -8,7 +8,6 @@ exports[`Storyshots Components/Breadcrumb As Button 1`] = `
     data-css-scrazl=""
     disabled={false}
     onClick={[Function]}
-    style={Object {}}
   >
     <div
       data-css-73kfkk=""
@@ -28,6 +27,7 @@ exports[`Storyshots Components/Breadcrumb As Button 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       Clicks once
@@ -43,7 +43,6 @@ exports[`Storyshots Components/Breadcrumb As Link 1`] = `
   <a
     data-css-scrazl=""
     href="https://duckduckgo.com"
-    style={Object {}}
   >
     <div
       data-css-73kfkk=""
@@ -63,6 +62,7 @@ exports[`Storyshots Components/Breadcrumb As Link 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       Click as link
@@ -78,7 +78,6 @@ exports[`Storyshots Components/Breadcrumb Basic 1`] = `
   <button
     data-css-scrazl=""
     disabled={false}
-    style={Object {}}
   >
     <div
       data-css-73kfkk=""
@@ -98,6 +97,7 @@ exports[`Storyshots Components/Breadcrumb Basic 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       All the things
@@ -114,7 +114,6 @@ exports[`Storyshots Components/Breadcrumb Disabled 1`] = `
     data-css-18r2msp=""
     disabled={true}
     onClick={[Function]}
-    style={Object {}}
   >
     <div
       data-css-73kfkk=""
@@ -134,6 +133,7 @@ exports[`Storyshots Components/Breadcrumb Disabled 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       Disabled

--- a/packages/button/src/css/index.ts
+++ b/packages/button/src/css/index.ts
@@ -338,6 +338,13 @@ export default {
     width: '100%',
     margin: 0
   },
+  '.psds-button__icon--loadingLabelOnly': {
+    position: 'absolute',
+    top: 0,
+    justifyContent: 'center',
+    width: '100%',
+    margin: 0
+  },
 
   [`.psds-button__loading`]: ({ spin }) => ({
     display: 'inline-block',
@@ -382,5 +389,8 @@ export default {
     alignItems: 'center',
     display: 'inline-flex',
     pointerEvents: 'none'
+  },
+  [`.psds-button__text--invisible`]: {
+    visibility: 'hidden'
   }
 }

--- a/packages/button/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/button/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -7,9 +7,9 @@ exports[`Storyshots Components/Button Appearances 1`] = `
   <button
     data-css-y5dqt5=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       primary
@@ -18,9 +18,9 @@ exports[`Storyshots Components/Button Appearances 1`] = `
   <button
     data-css-1x5ax2g=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       secondary
@@ -29,9 +29,9 @@ exports[`Storyshots Components/Button Appearances 1`] = `
   <button
     data-css-1cb2wrf=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       stroke
@@ -40,9 +40,9 @@ exports[`Storyshots Components/Button Appearances 1`] = `
   <button
     data-css-1uk30vr=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       flat
@@ -58,9 +58,9 @@ exports[`Storyshots Components/Button Appearances Disabled 1`] = `
   <button
     data-css-1283ymw=""
     disabled={true}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       primary
@@ -69,9 +69,9 @@ exports[`Storyshots Components/Button Appearances Disabled 1`] = `
   <button
     data-css-1ukz2bh=""
     disabled={true}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       secondary
@@ -80,9 +80,9 @@ exports[`Storyshots Components/Button Appearances Disabled 1`] = `
   <button
     data-css-1fra720=""
     disabled={true}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       stroke
@@ -91,9 +91,9 @@ exports[`Storyshots Components/Button Appearances Disabled 1`] = `
   <button
     data-css-1jpg809=""
     disabled={true}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       flat
@@ -109,7 +109,6 @@ exports[`Storyshots Components/Button Appearances With Icon 1`] = `
   <button
     data-css-12bozst=""
     disabled={false}
-    style={Object {}}
   >
     <div
       data-css-1mgd019=""
@@ -129,6 +128,7 @@ exports[`Storyshots Components/Button Appearances With Icon 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       primary
@@ -137,7 +137,6 @@ exports[`Storyshots Components/Button Appearances With Icon 1`] = `
   <button
     data-css-168olz2=""
     disabled={false}
-    style={Object {}}
   >
     <div
       data-css-1mgd019=""
@@ -157,6 +156,7 @@ exports[`Storyshots Components/Button Appearances With Icon 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       secondary
@@ -165,7 +165,6 @@ exports[`Storyshots Components/Button Appearances With Icon 1`] = `
   <button
     data-css-t8b8by=""
     disabled={false}
-    style={Object {}}
   >
     <div
       data-css-1mgd019=""
@@ -185,6 +184,7 @@ exports[`Storyshots Components/Button Appearances With Icon 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       stroke
@@ -193,7 +193,6 @@ exports[`Storyshots Components/Button Appearances With Icon 1`] = `
   <button
     data-css-68fqys=""
     disabled={false}
-    style={Object {}}
   >
     <div
       data-css-1mgd019=""
@@ -213,6 +212,7 @@ exports[`Storyshots Components/Button Appearances With Icon 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       flat
@@ -226,9 +226,9 @@ exports[`Storyshots Components/Button As Link 1`] = `
   data-css-y5dqt5=""
   href="https://duckduckgo.com"
   onClick={[Function]}
-  style={Object {}}
 >
   <span
+    aria-hidden={false}
     data-css-15b13by=""
   >
     click me
@@ -241,7 +241,6 @@ exports[`Storyshots Components/Button As Link With Icon 1`] = `
   data-css-12bozst=""
   href="https://duckduckgo.com"
   onClick={[Function]}
-  style={Object {}}
 >
   <div
     data-css-1mgd019=""
@@ -261,6 +260,7 @@ exports[`Storyshots Components/Button As Link With Icon 1`] = `
     </div>
   </div>
   <span
+    aria-hidden={false}
     data-css-15b13by=""
   >
     click me
@@ -273,9 +273,9 @@ exports[`Storyshots Components/Button Basic 1`] = `
   data-css-y5dqt5=""
   disabled={false}
   onClick={[Function]}
-  style={Object {}}
 >
   <span
+    aria-hidden={false}
     data-css-15b13by=""
   >
     click me
@@ -293,9 +293,9 @@ exports[`Storyshots Components/Button Class Name Override 1`] = `
   data-css-y5dqt5=""
   disabled={false}
   onClick={[Function]}
-  style={Object {}}
 >
   <span
+    aria-hidden={false}
     data-css-15b13by=""
   >
     click me
@@ -308,9 +308,9 @@ exports[`Storyshots Components/Button Disabled 1`] = `
   data-css-1283ymw=""
   disabled={true}
   onClick={[Function]}
-  style={Object {}}
 >
   <span
+    aria-hidden={false}
     data-css-15b13by=""
   >
     click me
@@ -323,7 +323,6 @@ exports[`Storyshots Components/Button Disabled With Icon 1`] = `
   data-css-105jfs7=""
   disabled={true}
   onClick={[Function]}
-  style={Object {}}
 >
   <div
     data-css-1mgd019=""
@@ -343,6 +342,7 @@ exports[`Storyshots Components/Button Disabled With Icon 1`] = `
     </div>
   </div>
   <span
+    aria-hidden={false}
     data-css-15b13by=""
   >
     click me
@@ -354,26 +354,12 @@ exports[`Storyshots Components/Button Example Autofocus 1`] = `
 <button
   data-css-y5dqt5=""
   disabled={false}
-  style={Object {}}
 >
   <span
+    aria-hidden={false}
     data-css-15b13by=""
   >
     Should be focused
-  </span>
-</button>
-`;
-
-exports[`Storyshots Components/Button Example Loading Transition 1`] = `
-<button
-  data-css-y5dqt5=""
-  disabled={false}
-  style={Object {}}
->
-  <span
-    data-css-15b13by=""
-  >
-    Wait for it
   </span>
 </button>
 `;
@@ -385,7 +371,6 @@ exports[`Storyshots Components/Button Icon Alignments 1`] = `
   <button
     data-css-12bozst=""
     disabled={false}
-    style={Object {}}
   >
     <div
       data-css-1mgd019=""
@@ -405,6 +390,7 @@ exports[`Storyshots Components/Button Icon Alignments 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       left
@@ -413,7 +399,6 @@ exports[`Storyshots Components/Button Icon Alignments 1`] = `
   <button
     data-css-dx671n=""
     disabled={false}
-    style={Object {}}
   >
     <div
       data-css-8b1vtw=""
@@ -433,6 +418,7 @@ exports[`Storyshots Components/Button Icon Alignments 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       right
@@ -446,7 +432,6 @@ exports[`Storyshots Components/Button Icon Only 1`] = `
   data-css-j12pym=""
   disabled={false}
   onClick={[Function]}
-  style={Object {}}
 >
   <div
     data-css-y80vay=""
@@ -466,6 +451,7 @@ exports[`Storyshots Components/Button Icon Only 1`] = `
     </div>
   </div>
   <span
+    aria-hidden={false}
     data-css-15b13by=""
   />
 </button>
@@ -479,9 +465,9 @@ Array [
     <button
       data-css-vm007=""
       disabled={false}
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         fullWidth
@@ -494,9 +480,9 @@ Array [
     <button
       data-css-y5dqt5=""
       disabled={false}
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         inline
@@ -506,13 +492,52 @@ Array [
 ]
 `;
 
-exports[`Storyshots Components/Button Loading Only 1`] = `
+exports[`Storyshots Components/Button Loading Transition 1`] = `
 <button
-  aria-label="loading"
+  data-css-y5dqt5=""
+  disabled={false}
+>
+  <span
+    aria-hidden={false}
+    data-css-15b13by=""
+  >
+    Wait for it
+  </span>
+</button>
+`;
+
+exports[`Storyshots Components/Button Loading Transition Start True 1`] = `
+<button
+  aria-label="Loading..."
   data-css-y5dqt5=""
   disabled={true}
+>
+  <div
+    data-css-4d535u=""
+  >
+    <div
+      data-css-7dab2f=""
+    >
+      <span
+        data-css-15l7w9e=""
+      />
+    </div>
+  </div>
+  <span
+    aria-hidden={true}
+    data-css-1arqyvm=""
+  >
+    Wait for it
+  </span>
+</button>
+`;
+
+exports[`Storyshots Components/Button Loading With Icon 1`] = `
+<button
+  aria-label="loading"
+  data-css-12bozst=""
+  disabled={true}
   onClick={[Function]}
-  style={Object {}}
 >
   <div
     data-css-1mgd019=""
@@ -526,7 +551,35 @@ exports[`Storyshots Components/Button Loading Only 1`] = `
     </div>
   </div>
   <span
+    aria-hidden={false}
     data-css-15b13by=""
+  >
+    click me
+  </span>
+</button>
+`;
+
+exports[`Storyshots Components/Button Loading With Label No Icon 1`] = `
+<button
+  aria-label="loading"
+  data-css-y5dqt5=""
+  disabled={true}
+  onClick={[Function]}
+>
+  <div
+    data-css-4d535u=""
+  >
+    <div
+      data-css-7dab2f=""
+    >
+      <span
+        data-css-15l7w9e=""
+      />
+    </div>
+  </div>
+  <span
+    aria-hidden={true}
+    data-css-1arqyvm=""
   >
     click me
   </span>
@@ -540,9 +593,9 @@ exports[`Storyshots Components/Button Sizes 1`] = `
   <button
     data-css-v92x0z=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       xSmall
@@ -551,9 +604,9 @@ exports[`Storyshots Components/Button Sizes 1`] = `
   <button
     data-css-b1m7w4=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       small
@@ -562,9 +615,9 @@ exports[`Storyshots Components/Button Sizes 1`] = `
   <button
     data-css-y5dqt5=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       medium
@@ -573,9 +626,9 @@ exports[`Storyshots Components/Button Sizes 1`] = `
   <button
     data-css-1p8sqig=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       large
@@ -591,7 +644,6 @@ exports[`Storyshots Components/Button Sizes With Icon 1`] = `
   <button
     data-css-11py1ib=""
     disabled={false}
-    style={Object {}}
   >
     <div
       data-css-73kfkk=""
@@ -611,6 +663,7 @@ exports[`Storyshots Components/Button Sizes With Icon 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       xSmall
@@ -619,7 +672,6 @@ exports[`Storyshots Components/Button Sizes With Icon 1`] = `
   <button
     data-css-1ep5uzm=""
     disabled={false}
-    style={Object {}}
   >
     <div
       data-css-73kfkk=""
@@ -639,6 +691,7 @@ exports[`Storyshots Components/Button Sizes With Icon 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       small
@@ -647,7 +700,6 @@ exports[`Storyshots Components/Button Sizes With Icon 1`] = `
   <button
     data-css-12bozst=""
     disabled={false}
-    style={Object {}}
   >
     <div
       data-css-1mgd019=""
@@ -667,6 +719,7 @@ exports[`Storyshots Components/Button Sizes With Icon 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       medium
@@ -675,7 +728,6 @@ exports[`Storyshots Components/Button Sizes With Icon 1`] = `
   <button
     data-css-k62s0p=""
     disabled={false}
-    style={Object {}}
   >
     <div
       data-css-1mgd019=""
@@ -695,6 +747,7 @@ exports[`Storyshots Components/Button Sizes With Icon 1`] = `
       </div>
     </div>
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       large
@@ -715,6 +768,7 @@ exports[`Storyshots Components/Button Style Override 1`] = `
   }
 >
   <span
+    aria-hidden={false}
     data-css-15b13by=""
   >
     click me
@@ -727,9 +781,9 @@ Array [
   <button
     data-css-1uk30vr=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       dark
@@ -738,9 +792,9 @@ Array [
   <button
     data-css-am7l87=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       light
@@ -749,9 +803,9 @@ Array [
   <button
     data-css-1uk30vr=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       dark
@@ -767,9 +821,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-v92x0z=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       primary
@@ -778,9 +832,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-b1m7w4=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       primary
@@ -789,9 +843,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-y5dqt5=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       primary
@@ -800,9 +854,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-1p8sqig=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       primary
@@ -811,9 +865,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-uv8iir=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       secondary
@@ -822,9 +876,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-c3sd2l=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       secondary
@@ -833,9 +887,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-1x5ax2g=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       secondary
@@ -844,9 +898,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-g84eh2=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       secondary
@@ -855,9 +909,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-1char72=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       stroke
@@ -866,9 +920,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-1mpmjtf=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       stroke
@@ -877,9 +931,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-1cb2wrf=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       stroke
@@ -888,9 +942,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-iilb0c=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       stroke
@@ -899,9 +953,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-10fisbo=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       flat
@@ -910,9 +964,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-1d3b8qh=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       flat
@@ -921,9 +975,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-1uk30vr=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       flat
@@ -932,9 +986,9 @@ exports[`Storyshots Components/Button Variations 1`] = `
   <button
     data-css-1b5o285=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       flat
@@ -950,9 +1004,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-v92x0z=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       primary
@@ -961,9 +1015,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-b1m7w4=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       primary
@@ -972,9 +1026,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-y5dqt5=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       primary
@@ -983,9 +1037,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-1p8sqig=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       primary
@@ -994,9 +1048,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-uv8iir=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       secondary
@@ -1005,9 +1059,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-c3sd2l=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       secondary
@@ -1016,9 +1070,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-1x5ax2g=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       secondary
@@ -1027,9 +1081,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-g84eh2=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       secondary
@@ -1038,9 +1092,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-1char72=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       stroke
@@ -1049,9 +1103,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-1mpmjtf=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       stroke
@@ -1060,9 +1114,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-1cb2wrf=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       stroke
@@ -1071,9 +1125,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-iilb0c=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       stroke
@@ -1082,9 +1136,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-10fisbo=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       flat
@@ -1093,9 +1147,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-1d3b8qh=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       flat
@@ -1104,9 +1158,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-1uk30vr=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       flat
@@ -1115,9 +1169,9 @@ exports[`Storyshots Components/Button Vert Alignment 1`] = `
   <button
     data-css-1b5o285=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       flat
@@ -1131,7 +1185,6 @@ exports[`Storyshots Components/Button With Icon 1`] = `
   data-css-12bozst=""
   disabled={false}
   onClick={[Function]}
-  style={Object {}}
 >
   <div
     data-css-1mgd019=""
@@ -1151,32 +1204,7 @@ exports[`Storyshots Components/Button With Icon 1`] = `
     </div>
   </div>
   <span
-    data-css-15b13by=""
-  >
-    click me
-  </span>
-</button>
-`;
-
-exports[`Storyshots Components/Button With Loading 1`] = `
-<button
-  data-css-y5dqt5=""
-  disabled={true}
-  onClick={[Function]}
-  style={Object {}}
->
-  <div
-    data-css-1mgd019=""
-  >
-    <div
-      data-css-7dab2f=""
-    >
-      <span
-        data-css-15l7w9e=""
-      />
-    </div>
-  </div>
-  <span
+    aria-hidden={false}
     data-css-15b13by=""
   >
     click me

--- a/packages/button/src/react/__stories__/index.story.tsx
+++ b/packages/button/src/react/__stories__/index.story.tsx
@@ -41,9 +41,6 @@ Basic.args = { ...defaultArgs }
 export const WithIcon = Template.bind({})
 WithIcon.args = { ...defaultArgs, icon: <PlaceholderIcon /> }
 
-export const WithLoading = Template.bind({})
-WithLoading.args = { ...defaultArgs, loading: true }
-
 export const AsLink = Template.bind({})
 AsLink.args = { ...defaultArgs, href: 'https://duckduckgo.com' }
 
@@ -71,8 +68,20 @@ IconOnly.args = {
   icon: <PlaceholderIcon />
 }
 
-export const LoadingOnly = Template.bind({})
-LoadingOnly.args = { ...defaultArgs, 'aria-label': 'loading', loading: true }
+export const LoadingWithIcon = Template.bind({})
+LoadingWithIcon.args = {
+  ...defaultArgs,
+  'aria-label': 'loading',
+  loading: true,
+  icon: <PlaceholderIcon />
+}
+
+export const LoadingWithLabelNoIcon = Template.bind({})
+LoadingWithLabelNoIcon.args = {
+  ...defaultArgs,
+  'aria-label': 'loading',
+  loading: true
+}
 
 export const StyleOverride = Template.bind({})
 StyleOverride.args = { ...defaultArgs, style: { background: 'red' } }
@@ -211,7 +220,7 @@ export const ExampleAutofocus: Story = () => {
   return <Example />
 }
 
-export const ExampleLoadingTransition: Story = () => {
+export const LoadingTransition: Story = () => {
   const Example: React.FC = () => {
     const [loading, setLoading] = React.useState<boolean>(false)
 
@@ -224,6 +233,28 @@ export const ExampleLoadingTransition: Story = () => {
     }, [loading])
 
     return <Button loading={loading}>Wait for it</Button>
+  }
+
+  return <Example />
+}
+
+export const LoadingTransitionStartTrue: Story = () => {
+  const Example: React.FC = () => {
+    const [loading, setLoading] = React.useState<boolean>(true)
+
+    React.useEffect(() => {
+      const timer = setInterval(() => {
+        setLoading(!loading)
+      }, 1500)
+
+      return () => clearInterval(timer)
+    }, [loading])
+
+    return (
+      <Button aria-label={loading && 'Loading...'} loading={loading}>
+        Wait for it
+      </Button>
+    )
   }
 
   return <Example />

--- a/packages/button/src/react/index.tsx
+++ b/packages/button/src/react/index.tsx
@@ -69,18 +69,18 @@ const styles = {
         `.psds-button__loading--appearance-${appearance}.psds-button__loading--theme-${themeName}`
       ]
     ),
-  icon: ({ iconAlign, iconOnly, isLoadingAndLabelOnly, size }) =>
-    glamor.css(
+  icon: ({ iconAlign, iconOnly, labelOnly, loading, size }) => {
+    return glamor.css(
       stylesheet['.psds-button__icon'],
       stylesheet[`.psds-button__icon--iconAlign-${iconAlign}`],
       stylesheet[
         `.psds-button__icon--iconAlign-${iconAlign}.psds-button--size-${size}`
       ],
-      (iconOnly || isLoadingAndLabelOnly) &&
+      (iconOnly || (loading && labelOnly)) &&
         stylesheet['.psds-button__icon--iconOnly'],
-      isLoadingAndLabelOnly &&
-        stylesheet['.psds-button__icon--loadingLabelOnly']
-    ),
+      loading && labelOnly && stylesheet['.psds-button__icon--loadingLabelOnly']
+    )
+  },
   text: (invisible?: boolean) =>
     glamor.compose(
       glamor.css(stylesheet[`.psds-button__text`]),
@@ -99,7 +99,7 @@ const mapIconSize = (size: string) => {
 }
 
 interface IconContainerProps extends HTMLPropsFor<'div'> {
-  children: React.ReactNode
+  labelOnly: boolean
   loading: boolean
   icon: React.ReactNode
   appearance: string
@@ -115,9 +115,8 @@ const IconContainer: React.FC<IconContainerProps> = props =>
       {...styles.icon({
         iconAlign: props.iconAlign,
         iconOnly: props.iconOnly,
-        // TODO: avoid new derived value. Pass hasLabel and icon from top to bottom
-        isLoadingAndLabelOnly:
-          React.Children.count(props.children) > 0 && !props.icon,
+        labelOnly: props.labelOnly,
+        loading: props.loading,
         size: props.size
       })}
     >
@@ -136,7 +135,8 @@ const IconContainer: React.FC<IconContainerProps> = props =>
       {...styles.icon({
         iconAlign: props.iconAlign,
         iconOnly: props.iconOnly,
-        isLoadingAndLabelOnly: false,
+        labelOnly: props.labelOnly,
+        loading: props.loading,
         size: props.size
       })}
     >
@@ -196,7 +196,6 @@ const Button = React.forwardRef<ButtonElement, ButtonProps>(
 
     const hasLabel = React.Children.count(children) > 0
     const iconOnly = !hasLabel
-    const shouldRenderInvisibleLabel = hasLabel && loading && !icon
 
     const glamorStyle = styles.button({
       appearance,
@@ -215,18 +214,18 @@ const Button = React.forwardRef<ButtonElement, ButtonProps>(
         icon={icon}
         iconAlign={iconAlign}
         iconOnly={iconOnly}
+        labelOnly={hasLabel && !icon}
         loading={loading}
         size={size}
         themeName={themeName}
-      >
-        {children}
-      </IconContainer>
+      ></IconContainer>
     )
 
+    const isLoadingAndLabelOnly = hasLabel && loading && !icon
     const labelEl = (
       <span
-        {...styles.text(shouldRenderInvisibleLabel)}
-        aria-hidden={shouldRenderInvisibleLabel}
+        {...styles.text(isLoadingAndLabelOnly)}
+        aria-hidden={isLoadingAndLabelOnly}
       >
         {children}
       </span>

--- a/packages/button/src/react/index.tsx
+++ b/packages/button/src/react/index.tsx
@@ -98,7 +98,7 @@ const mapIconSize = (size: string) => {
   return btnToIconSizes[size] ? btnToIconSizes[size] : iconSizes.medium
 }
 
-interface RenderIconProps extends HTMLPropsFor<'div'> {
+interface IconContainerProps extends HTMLPropsFor<'div'> {
   children: React.ReactNode
   loading: boolean
   icon: React.ReactNode
@@ -109,8 +109,7 @@ interface RenderIconProps extends HTMLPropsFor<'div'> {
   iconAlign: string
 }
 
-// TODO: rename as component
-const renderIcon: React.FC<RenderIconProps> = props =>
+const IconContainer: React.FC<IconContainerProps> = props =>
   props.loading ? (
     <div
       {...styles.icon({
@@ -209,16 +208,20 @@ const Button = React.forwardRef<ButtonElement, ButtonProps>(
       size,
       themeName
     })
-    const iconEl = renderIcon({
-      appearance,
-      children,
-      icon,
-      iconAlign,
-      iconOnly,
-      loading,
-      size,
-      themeName
-    })
+
+    const iconEl = (
+      <IconContainer
+        appearance={appearance}
+        icon={icon}
+        iconAlign={iconAlign}
+        iconOnly={iconOnly}
+        loading={loading}
+        size={size}
+        themeName={themeName}
+      >
+        {children}
+      </IconContainer>
+    )
 
     const labelEl = (
       <span

--- a/packages/datepicker/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/datepicker/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -24,7 +24,6 @@ Array [
             data-css-phznnm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
           >
             <div
               data-css-y80vay=""
@@ -44,6 +43,7 @@ Array [
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -59,7 +59,6 @@ Array [
             data-css-phznnm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
           >
             <div
               data-css-y80vay=""
@@ -79,6 +78,7 @@ Array [
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -1344,7 +1344,6 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
           data-css-phznnm=""
           disabled={false}
           onClick={[Function]}
-          style={Object {}}
         >
           <div
             data-css-y80vay=""
@@ -1364,6 +1363,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>
@@ -1379,7 +1379,6 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
           data-css-phznnm=""
           disabled={false}
           onClick={[Function]}
-          style={Object {}}
         >
           <div
             data-css-y80vay=""
@@ -1399,6 +1398,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>
@@ -1822,7 +1822,6 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
           data-css-phznnm=""
           disabled={false}
           onClick={[Function]}
-          style={Object {}}
         >
           <div
             data-css-y80vay=""
@@ -1842,6 +1841,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>
@@ -1857,7 +1857,6 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
           data-css-phznnm=""
           disabled={false}
           onClick={[Function]}
-          style={Object {}}
         >
           <div
             data-css-y80vay=""
@@ -1877,6 +1876,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>
@@ -2337,7 +2337,6 @@ Array [
             data-css-phznnm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
           >
             <div
               data-css-y80vay=""
@@ -2357,6 +2356,7 @@ Array [
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -2372,7 +2372,6 @@ Array [
             data-css-phznnm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
           >
             <div
               data-css-y80vay=""
@@ -2392,6 +2391,7 @@ Array [
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -2902,7 +2902,6 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
             data-css-phznnm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
           >
             <div
               data-css-y80vay=""
@@ -2922,6 +2921,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -2937,7 +2937,6 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
             data-css-phznnm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
           >
             <div
               data-css-y80vay=""
@@ -2957,6 +2956,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -3467,7 +3467,6 @@ Array [
             data-css-phznnm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
           >
             <div
               data-css-y80vay=""
@@ -3487,6 +3486,7 @@ Array [
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -3554,7 +3554,6 @@ Array [
             data-css-phznnm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
           >
             <div
               data-css-y80vay=""
@@ -3574,6 +3573,7 @@ Array [
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -4377,7 +4377,6 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
           data-css-phznnm=""
           disabled={false}
           onClick={[Function]}
-          style={Object {}}
         >
           <div
             data-css-y80vay=""
@@ -4397,6 +4396,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>
@@ -4412,7 +4412,6 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
           data-css-phznnm=""
           disabled={false}
           onClick={[Function]}
-          style={Object {}}
         >
           <div
             data-css-y80vay=""
@@ -4432,6 +4431,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>
@@ -4826,7 +4826,6 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
           data-css-phznnm=""
           disabled={false}
           onClick={[Function]}
-          style={Object {}}
         >
           <div
             data-css-y80vay=""
@@ -4846,6 +4845,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>
@@ -4861,7 +4861,6 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
           data-css-phznnm=""
           disabled={false}
           onClick={[Function]}
-          style={Object {}}
         >
           <div
             data-css-y80vay=""
@@ -4881,6 +4880,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>

--- a/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -22,9 +22,9 @@ exports[`Storyshots Components/Dialog Modal Default 1`] = `
     data-css-y5dqt5=""
     disabled={false}
     onClick={[Function]}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       close modal
@@ -115,9 +115,9 @@ exports[`Storyshots Components/Dialog Modal Default 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -133,9 +133,9 @@ exports[`Storyshots Components/Dialog Modal Default 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA
@@ -170,9 +170,9 @@ exports[`Storyshots Components/Dialog Modal No Click Overlay 1`] = `
     data-css-y5dqt5=""
     disabled={false}
     onClick={[Function]}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       close modal
@@ -263,9 +263,9 @@ exports[`Storyshots Components/Dialog Modal No Click Overlay 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -281,9 +281,9 @@ exports[`Storyshots Components/Dialog Modal No Click Overlay 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA
@@ -318,9 +318,9 @@ exports[`Storyshots Components/Dialog Modal No Closebutton 1`] = `
     data-css-y5dqt5=""
     disabled={false}
     onClick={[Function]}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       close modal
@@ -395,9 +395,9 @@ exports[`Storyshots Components/Dialog Modal No Closebutton 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -413,9 +413,9 @@ exports[`Storyshots Components/Dialog Modal No Closebutton 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA
@@ -450,9 +450,9 @@ exports[`Storyshots Components/Dialog Modal No Escape Key 1`] = `
     data-css-y5dqt5=""
     disabled={false}
     onClick={[Function]}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       close modal
@@ -542,9 +542,9 @@ exports[`Storyshots Components/Dialog Modal No Escape Key 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -560,9 +560,9 @@ exports[`Storyshots Components/Dialog Modal No Escape Key 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA
@@ -597,9 +597,9 @@ exports[`Storyshots Components/Dialog Modal No Focus On Mount 1`] = `
     data-css-y5dqt5=""
     disabled={false}
     onClick={[Function]}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       close modal
@@ -690,9 +690,9 @@ exports[`Storyshots Components/Dialog Modal No Focus On Mount 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -708,9 +708,9 @@ exports[`Storyshots Components/Dialog Modal No Focus On Mount 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA
@@ -745,9 +745,9 @@ exports[`Storyshots Components/Dialog Modal No Focusable Child Elements 1`] = `
     data-css-y5dqt5=""
     disabled={false}
     onClick={[Function]}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       close modal
@@ -827,9 +827,9 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
     data-css-y5dqt5=""
     disabled={false}
     onClick={[Function]}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       close modal
@@ -1244,9 +1244,9 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
     data-css-y5dqt5=""
     disabled={false}
     onClick={[Function]}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       close modal
@@ -1661,9 +1661,9 @@ exports[`Storyshots Components/Dialog Modal Styles For 1`] = `
     data-css-y5dqt5=""
     disabled={false}
     onClick={[Function]}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       close modal
@@ -1754,9 +1754,9 @@ exports[`Storyshots Components/Dialog Modal Styles For 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -1772,9 +1772,9 @@ exports[`Storyshots Components/Dialog Modal Styles For 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA
@@ -1855,9 +1855,9 @@ exports[`Storyshots Components/Dialog On Close 1`] = `
       <button
         data-css-mw9m92=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Secondary CTA
@@ -1873,9 +1873,9 @@ exports[`Storyshots Components/Dialog On Close 1`] = `
       <button
         data-css-1sp8ths=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Primary CTA
@@ -1974,9 +1974,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -1992,9 +1992,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA
@@ -2056,9 +2056,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -2074,9 +2074,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA
@@ -2138,9 +2138,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -2156,9 +2156,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA
@@ -2220,9 +2220,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -2238,9 +2238,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA
@@ -2302,9 +2302,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -2320,9 +2320,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA
@@ -2384,9 +2384,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -2402,9 +2402,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA
@@ -2466,9 +2466,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-mw9m92=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Secondary CTA
@@ -2484,9 +2484,9 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           <button
             data-css-1sp8ths=""
             disabled={false}
-            style={Object {}}
           >
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             >
               Primary CTA

--- a/packages/drawer/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/drawer/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -387,7 +387,6 @@ exports[`Storyshots Components/Row Row Component With Actions 1`] = `
           data-css-1dnyz38=""
           disabled={false}
           onClick={[Function]}
-          style={Object {}}
         >
           <div
             data-css-4ducb0=""
@@ -407,6 +406,7 @@ exports[`Storyshots Components/Row Row Component With Actions 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>
@@ -956,7 +956,6 @@ exports[`Storyshots Components/Row With Row Component 1`] = `
         <button
           data-css-1dnyz38=""
           disabled={false}
-          style={Object {}}
         >
           <div
             data-css-4ducb0=""
@@ -976,6 +975,7 @@ exports[`Storyshots Components/Row With Row Component 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>

--- a/packages/emptystate/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/emptystate/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -86,9 +86,9 @@ exports[`Storyshots Components/EmptyState Actions With A Button 1`] = `
         <button
           data-css-1cb2wrf=""
           disabled={false}
-          style={Object {}}
         >
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           >
             Asssessments
@@ -106,9 +106,9 @@ exports[`Storyshots Components/EmptyState Actions With A Button 1`] = `
         <button
           data-css-1cb2wrf=""
           disabled={false}
-          style={Object {}}
         >
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           >
             Guides
@@ -126,9 +126,9 @@ exports[`Storyshots Components/EmptyState Actions With A Button 1`] = `
         <button
           data-css-1cb2wrf=""
           disabled={false}
-          style={Object {}}
         >
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           >
             Interactive Courses
@@ -146,9 +146,9 @@ exports[`Storyshots Components/EmptyState Actions With A Button 1`] = `
         <button
           data-css-1cb2wrf=""
           disabled={false}
-          style={Object {}}
         >
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           >
             Paths
@@ -166,9 +166,9 @@ exports[`Storyshots Components/EmptyState Actions With A Button 1`] = `
         <button
           data-css-1cb2wrf=""
           disabled={false}
-          style={Object {}}
         >
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           >
             Projects
@@ -186,9 +186,9 @@ exports[`Storyshots Components/EmptyState Actions With A Button 1`] = `
         <button
           data-css-1cb2wrf=""
           disabled={false}
-          style={Object {}}
         >
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           >
             Video Courses
@@ -591,9 +591,9 @@ exports[`Storyshots Components/EmptyState Combo 1`] = `
     <button
       data-css-y5dqt5=""
       disabled={false}
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         Do a Thing
@@ -2654,9 +2654,9 @@ Array [
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Do a Thing
@@ -2737,9 +2737,9 @@ Array [
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Do a Thing
@@ -2832,9 +2832,9 @@ Array [
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Do a Thing
@@ -2921,9 +2921,9 @@ exports[`Storyshots Components/EmptyState Small Fixed Size Container 1`] = `
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Do a Thing

--- a/packages/errors/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/errors/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -75,9 +75,9 @@ exports[`Storyshots Components/Errors Custom Error Page 1`] = `
     <a
       data-css-y5dqt5=""
       href="https://help.pluralsight.com/help/contact-us"
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         Contact support
@@ -155,9 +155,9 @@ exports[`Storyshots Components/Errors Custom Error Page 1`] = `
     <a
       data-css-y5dqt5=""
       href="https://help.pluralsight.com/help/contact-us"
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         Contact support
@@ -249,9 +249,9 @@ exports[`Storyshots Components/Errors Sizes 1`] = `
     <a
       data-css-y5dqt5=""
       href="https://help.pluralsight.com/help/contact-us"
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         Contact support
@@ -330,9 +330,9 @@ exports[`Storyshots Components/Errors Sizes 1`] = `
     <a
       data-css-y5dqt5=""
       href="https://help.pluralsight.com/help/contact-us"
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         Contact support
@@ -404,9 +404,9 @@ exports[`Storyshots Components/Errors Sizes 1`] = `
     <a
       data-css-y5dqt5=""
       href="https://help.pluralsight.com/help/contact-us"
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         Contact support
@@ -485,9 +485,9 @@ exports[`Storyshots Components/Errors Sizes 1`] = `
     <a
       data-css-y5dqt5=""
       href="https://help.pluralsight.com/help/contact-us"
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         Contact support
@@ -559,9 +559,9 @@ exports[`Storyshots Components/Errors Sizes 1`] = `
     <a
       data-css-y5dqt5=""
       href="https://help.pluralsight.com/help/contact-us"
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         Contact support
@@ -640,9 +640,9 @@ exports[`Storyshots Components/Errors Sizes 1`] = `
     <a
       data-css-y5dqt5=""
       href="https://help.pluralsight.com/help/contact-us"
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         Contact support
@@ -847,9 +847,9 @@ exports[`Storyshots Components/Errors Sizes 1`] = `
     <a
       data-css-y5dqt5=""
       href="https://help.pluralsight.com/help/contact-us"
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         Contact support
@@ -928,9 +928,9 @@ exports[`Storyshots Components/Errors Sizes 1`] = `
     <a
       data-css-y5dqt5=""
       href="https://help.pluralsight.com/help/contact-us"
-      style={Object {}}
     >
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       >
         Contact support

--- a/packages/focusmanager/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/focusmanager/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -10,9 +10,9 @@ exports[`Storyshots Components/FocusManager Deep Dynamic Children 1`] = `
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Is tabbable
@@ -28,9 +28,9 @@ exports[`Storyshots Components/FocusManager Dynamic Children 1`] = `
   <button
     data-css-y5dqt5=""
     disabled={false}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       Is tabbable

--- a/packages/form/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/form/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -45,9 +45,9 @@ exports[`Storyshots Components/Form Button Row Aligns 1`] = `
             <button
               data-css-y5dqt5=""
               disabled={false}
-              style={Object {}}
             >
               <span
+                aria-hidden={false}
                 data-css-15b13by=""
               >
                 Save
@@ -60,9 +60,9 @@ exports[`Storyshots Components/Form Button Row Aligns 1`] = `
             <button
               data-css-1uk30vr=""
               disabled={false}
-              style={Object {}}
             >
               <span
+                aria-hidden={false}
                 data-css-15b13by=""
               >
                 Cancel
@@ -101,9 +101,9 @@ exports[`Storyshots Components/Form Button Row Aligns 1`] = `
             <button
               data-css-y5dqt5=""
               disabled={false}
-              style={Object {}}
             >
               <span
+                aria-hidden={false}
                 data-css-15b13by=""
               >
                 Save
@@ -116,9 +116,9 @@ exports[`Storyshots Components/Form Button Row Aligns 1`] = `
             <button
               data-css-1uk30vr=""
               disabled={false}
-              style={Object {}}
             >
               <span
+                aria-hidden={false}
                 data-css-15b13by=""
               >
                 Cancel
@@ -163,9 +163,9 @@ exports[`Storyshots Components/Form Button Row Single Button 1`] = `
             <button
               data-css-y5dqt5=""
               disabled={false}
-              style={Object {}}
             >
               <span
+                aria-hidden={false}
                 data-css-15b13by=""
               >
                 Only One
@@ -876,9 +876,9 @@ exports[`Storyshots Components/Form Sample 1`] = `
             <button
               data-css-y5dqt5=""
               disabled={false}
-              style={Object {}}
             >
               <span
+                aria-hidden={false}
                 data-css-15b13by=""
               >
                 Save
@@ -891,9 +891,9 @@ exports[`Storyshots Components/Form Sample 1`] = `
             <button
               data-css-1uk30vr=""
               disabled={false}
-              style={Object {}}
             >
               <span
+                aria-hidden={false}
                 data-css-15b13by=""
               >
                 Cancel

--- a/packages/layout/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/layout/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -591,9 +591,9 @@ exports[`Storyshots Components/PageHeadingLayout Long Title With Actions 1`] = `
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Wow, an action
@@ -629,9 +629,9 @@ exports[`Storyshots Components/PageHeadingLayout Long Title With Lots Of Actions
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Wow, an action
@@ -646,9 +646,9 @@ exports[`Storyshots Components/PageHeadingLayout Long Title With Lots Of Actions
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Wow, an action
@@ -663,9 +663,9 @@ exports[`Storyshots Components/PageHeadingLayout Long Title With Lots Of Actions
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Wow, an action
@@ -680,9 +680,9 @@ exports[`Storyshots Components/PageHeadingLayout Long Title With Lots Of Actions
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Wow, an action
@@ -718,9 +718,9 @@ exports[`Storyshots Components/PageHeadingLayout Lots Of Actions 1`] = `
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Wow, an action
@@ -735,9 +735,9 @@ exports[`Storyshots Components/PageHeadingLayout Lots Of Actions 1`] = `
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Wow, an action
@@ -752,9 +752,9 @@ exports[`Storyshots Components/PageHeadingLayout Lots Of Actions 1`] = `
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Wow, an action
@@ -769,9 +769,9 @@ exports[`Storyshots Components/PageHeadingLayout Lots Of Actions 1`] = `
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Wow, an action
@@ -807,9 +807,9 @@ exports[`Storyshots Components/PageHeadingLayout With Actions 1`] = `
       <button
         data-css-y5dqt5=""
         disabled={false}
-        style={Object {}}
       >
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         >
           Wow, an action

--- a/packages/navuser/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/navuser/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -185,9 +185,9 @@ exports[`Storyshots Components/NavUser With Action Menu 1`] = `
     data-css-y5dqt5=""
     disabled={false}
     onClick={[Function]}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       Click me first
@@ -205,9 +205,9 @@ exports[`Storyshots Components/NavUser With Action Menu 1`] = `
     data-css-y5dqt5=""
     disabled={false}
     onClick={[Function]}
-    style={Object {}}
   >
     <span
+      aria-hidden={false}
       data-css-15b13by=""
     >
       Then click me, first menu closes, mine opens

--- a/packages/row/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/row/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -30,7 +30,6 @@ exports[`Storyshots Components/Row Action Bar 1`] = `
       <button
         data-css-1dnyz38=""
         disabled={false}
-        style={Object {}}
       >
         <div
           data-css-4ducb0=""
@@ -50,6 +49,7 @@ exports[`Storyshots Components/Row Action Bar 1`] = `
           </div>
         </div>
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         />
       </button>
@@ -73,7 +73,6 @@ exports[`Storyshots Components/Row Action Bar 1`] = `
       <button
         data-css-1dnyz38=""
         disabled={false}
-        style={Object {}}
       >
         <div
           data-css-4ducb0=""
@@ -93,6 +92,7 @@ exports[`Storyshots Components/Row Action Bar 1`] = `
           </div>
         </div>
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         />
       </button>
@@ -116,7 +116,6 @@ exports[`Storyshots Components/Row Action Bar 1`] = `
       <button
         data-css-1dnyz38=""
         disabled={false}
-        style={Object {}}
       >
         <div
           data-css-4ducb0=""
@@ -136,6 +135,7 @@ exports[`Storyshots Components/Row Action Bar 1`] = `
           </div>
         </div>
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         />
       </button>
@@ -159,7 +159,6 @@ exports[`Storyshots Components/Row Action Bar 1`] = `
       <button
         data-css-1dnyz38=""
         disabled={false}
-        style={Object {}}
       >
         <div
           data-css-4ducb0=""
@@ -179,6 +178,7 @@ exports[`Storyshots Components/Row Action Bar 1`] = `
           </div>
         </div>
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         />
       </button>
@@ -278,7 +278,6 @@ exports[`Storyshots Components/Row Combo 1`] = `
     <button
       data-css-1dnyz38=""
       disabled={false}
-      style={Object {}}
     >
       <div
         data-css-4ducb0=""
@@ -298,13 +297,13 @@ exports[`Storyshots Components/Row Combo 1`] = `
         </div>
       </div>
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       />
     </button>
     <button
       data-css-1dnyz38=""
       disabled={false}
-      style={Object {}}
     >
       <div
         data-css-4ducb0=""
@@ -326,13 +325,13 @@ exports[`Storyshots Components/Row Combo 1`] = `
         </div>
       </div>
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       />
     </button>
     <button
       data-css-1dnyz38=""
       disabled={false}
-      style={Object {}}
     >
       <div
         data-css-4ducb0=""
@@ -352,6 +351,7 @@ exports[`Storyshots Components/Row Combo 1`] = `
         </div>
       </div>
       <span
+        aria-hidden={false}
         data-css-15b13by=""
       />
     </button>
@@ -1184,7 +1184,6 @@ Array [
       <button
         data-css-1dnyz38=""
         disabled={false}
-        style={Object {}}
       >
         <div
           data-css-4ducb0=""
@@ -1204,6 +1203,7 @@ Array [
           </div>
         </div>
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         />
       </button>
@@ -1236,7 +1236,6 @@ Array [
       <button
         data-css-1dnyz38=""
         disabled={false}
-        style={Object {}}
       >
         <div
           data-css-4ducb0=""
@@ -1256,6 +1255,7 @@ Array [
           </div>
         </div>
         <span
+          aria-hidden={false}
           data-css-15b13by=""
         />
       </button>

--- a/packages/searchinput/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/searchinput/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -34,7 +34,6 @@ exports[`Storyshots Components/SearchInput Basic 1`] = `
           data-css-ttgr6s=""
           disabled={false}
           onClick={[Function]}
-          style={Object {}}
         >
           <div
             data-css-4ducb0=""
@@ -54,6 +53,7 @@ exports[`Storyshots Components/SearchInput Basic 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>
@@ -113,7 +113,6 @@ exports[`Storyshots Components/SearchInput Loading 1`] = `
           data-css-ttgr6s=""
           disabled={false}
           onClick={[Function]}
-          style={Object {}}
         >
           <div
             data-css-4ducb0=""
@@ -133,6 +132,7 @@ exports[`Storyshots Components/SearchInput Loading 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>
@@ -250,7 +250,6 @@ exports[`Storyshots Components/SearchInput Static Value 1`] = `
           data-css-1dnyz38=""
           disabled={false}
           onClick={[Function]}
-          style={Object {}}
         >
           <div
             data-css-4ducb0=""
@@ -270,6 +269,7 @@ exports[`Storyshots Components/SearchInput Static Value 1`] = `
             </div>
           </div>
           <span
+            aria-hidden={false}
             data-css-15b13by=""
           />
         </button>

--- a/packages/table/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/table/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -1559,7 +1559,6 @@ exports[`Storyshots Components/Table/drawer Left Indented 1`] = `
             data-css-66vnlm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
             title="Expand/Collapse additional content"
           >
             <div
@@ -1580,6 +1579,7 @@ exports[`Storyshots Components/Table/drawer Left Indented 1`] = `
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -1653,7 +1653,6 @@ exports[`Storyshots Components/Table/drawer Left Indented 1`] = `
             data-css-66vnlm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
             title="Expand/Collapse additional content"
           >
             <div
@@ -1674,6 +1673,7 @@ exports[`Storyshots Components/Table/drawer Left Indented 1`] = `
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -1747,7 +1747,6 @@ exports[`Storyshots Components/Table/drawer Left Indented 1`] = `
             data-css-66vnlm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
             title="Expand/Collapse additional content"
           >
             <div
@@ -1768,6 +1767,7 @@ exports[`Storyshots Components/Table/drawer Left Indented 1`] = `
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -1841,7 +1841,6 @@ exports[`Storyshots Components/Table/drawer Left Indented 1`] = `
             data-css-66vnlm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
             title="Expand/Collapse additional content"
           >
             <div
@@ -1862,6 +1861,7 @@ exports[`Storyshots Components/Table/drawer Left Indented 1`] = `
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -1935,7 +1935,6 @@ exports[`Storyshots Components/Table/drawer Left Indented 1`] = `
             data-css-66vnlm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
             title="Expand/Collapse additional content"
           >
             <div
@@ -1956,6 +1955,7 @@ exports[`Storyshots Components/Table/drawer Left Indented 1`] = `
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -2101,7 +2101,6 @@ exports[`Storyshots Components/Table/drawer Right Not Indented 1`] = `
             data-css-66vnlm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
             title="Expand/Collapse additional content"
           >
             <div
@@ -2122,6 +2121,7 @@ exports[`Storyshots Components/Table/drawer Right Not Indented 1`] = `
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -2190,7 +2190,6 @@ exports[`Storyshots Components/Table/drawer Right Not Indented 1`] = `
             data-css-66vnlm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
             title="Expand/Collapse additional content"
           >
             <div
@@ -2211,6 +2210,7 @@ exports[`Storyshots Components/Table/drawer Right Not Indented 1`] = `
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -2279,7 +2279,6 @@ exports[`Storyshots Components/Table/drawer Right Not Indented 1`] = `
             data-css-66vnlm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
             title="Expand/Collapse additional content"
           >
             <div
@@ -2300,6 +2299,7 @@ exports[`Storyshots Components/Table/drawer Right Not Indented 1`] = `
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -2368,7 +2368,6 @@ exports[`Storyshots Components/Table/drawer Right Not Indented 1`] = `
             data-css-66vnlm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
             title="Expand/Collapse additional content"
           >
             <div
@@ -2389,6 +2388,7 @@ exports[`Storyshots Components/Table/drawer Right Not Indented 1`] = `
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>
@@ -2457,7 +2457,6 @@ exports[`Storyshots Components/Table/drawer Right Not Indented 1`] = `
             data-css-66vnlm=""
             disabled={false}
             onClick={[Function]}
-            style={Object {}}
             title="Expand/Collapse additional content"
           >
             <div
@@ -2478,6 +2477,7 @@ exports[`Storyshots Components/Table/drawer Right Not Indented 1`] = `
               </div>
             </div>
             <span
+              aria-hidden={false}
               data-css-15b13by=""
             />
           </button>


### PR DESCRIPTION
This was working in the case where the state was not loading to start
and then switched to it. Now, it will work consistently whether it
starts loading or not.

Approach changed. Instead of measuring width, display invisible text to
maintain width during loading state.

Related:
https://pluralsight.slack.com/archives/C5CMEKH5Z/p1624282887087800

