### PR TITLE
add changelog link to datepicker doc

### DIFF
--- a/docs/src/content/components/datepicker.mdx
+++ b/docs/src/content/components/datepicker.mdx
@@ -15,6 +15,13 @@ import { layout } from '@pluralsight/ps-design-system-core'
 
 ## Components
 
+<Usage
+  install="npm install @pluralsight/ps-design-system-datepicker"
+  import="import { DatePicker, /* ... */ } from '@pluralsight/ps-design-system-datepicker'"
+  packageName="datepicker"
+  version={props.version}
+/>
+
 ## DatePicker
 This is a very similar descendant of the prevous DatePicker. It is a convenience wrapper around the common case. The API is familiar but has some differences. It is a controlled component with `value`. It takes an `onSelect` prop that returns a [`dayzed.DateObj`](https://github.com/deseretdigital/dayzed/blob/ebf1de1ceb9695738895f8b08bf45ad9a894fe00/typings/dayzed.d.ts#L9-L16) each time a valid date is selected.
 


### PR DESCRIPTION
From user doc walkthrough that we noticed this.

Brian, I'm not sure if this is the right place to put this, but I think it's the best at the moment. The DatePicker docs are not the common case in what they contain or how they're organized.

Resolves: #1837

