### PR TITLE
text: fix incorrect label line-height values

### DIFF
--- a/packages/text/src/css/index.ts
+++ b/packages/text/src/css/index.ts
@@ -118,17 +118,17 @@ export default {
   [`.psds-text__label--size-${vars.labelSizes.small}`]: {
     fontSize: type.fontSize200,
     letterSpacing: type.letterSpacingLoose,
-    lineHeight: '24px'
+    lineHeight: '20px'
   },
   [`.psds-text__label--size-${vars.labelSizes.medium}`]: {
     fontSize: type.fontSize300,
     letterSpacing: type.letterSpacingLoose,
-    lineHeight: '28px'
+    lineHeight: '20px'
   },
   [`.psds-text__label--size-${vars.labelSizes.large}`]: {
     fontSize: type.fontSize400,
     letterSpacing: type.letterSpacingNone,
-    lineHeight: '32px'
+    lineHeight: '24px'
   },
 
   [`.psds-text__list`]: {

--- a/packages/text/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/text/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -234,7 +234,7 @@ exports[`Storyshots Components/Text/Label Basic 1`] = `
   data-css-yto836=""
 >
   <span
-    data-css-r8e5nl=""
+    data-css-fwyzym=""
     onClick={[Function]}
   >
     <h1>
@@ -249,7 +249,7 @@ exports[`Storyshots Components/Text/Label Caps 1`] = `
   data-css-yto836=""
 >
   <span
-    data-css-wz4xbe=""
+    data-css-x2h5do=""
     onClick={[Function]}
   >
     <h1>
@@ -264,7 +264,7 @@ exports[`Storyshots Components/Text/Label Mono 1`] = `
   data-css-yto836=""
 >
   <span
-    data-css-phyd8e=""
+    data-css-1kbv5k2=""
     onClick={[Function]}
   >
     <h1>
@@ -279,7 +279,7 @@ exports[`Storyshots Components/Text/Label Strong 1`] = `
   data-css-yto836=""
 >
   <span
-    data-css-bsz03x=""
+    data-css-1okv4od=""
     onClick={[Function]}
   >
     <h1>
@@ -294,7 +294,7 @@ exports[`Storyshots Components/Text/Label Strong Caps 1`] = `
   data-css-yto836=""
 >
   <span
-    data-css-1q07l0j=""
+    data-css-40hjc7=""
     onClick={[Function]}
   >
     <h1>


### PR DESCRIPTION
Line-height values for small, medium, large label components have been corrected to match Figma.

Resolves: #1852