### PR TITLE
fix(docs): don't allow table of contents to overlay content on mobile

### DIFF
--- a/docs/src/components/frame/frame.module.css
+++ b/docs/src/components/frame/frame.module.css
@@ -19,7 +19,7 @@
   @media (width >= 768px) {
     padding-left: var(--asideWidth);
   }
-  @media (width >= 1280px) {
+  @media (width >= 960px) {
     padding-right: var(--metaWidth);
   }
 

--- a/docs/src/components/table-of-contents.module.css
+++ b/docs/src/components/table-of-contents.module.css
@@ -10,7 +10,7 @@
   overflow: hidden;
   background: var(--bg);
 
-  @media (width >= 768px) {
+  @media (width >= 960px) {
     position: fixed;
     width: 240px;
     top: calc(var(--topNavHeight) + var(--psLayoutSpacingLarge));


### PR DESCRIPTION
Resolves: #1822

