### PR TITLE
fix(textarea): allow maxLength and textarea-specific props in TS

### DIFF
--- a/packages/textarea/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/textarea/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -19,6 +19,7 @@ Array [
         <textarea
           data-css-1paz7u7=""
           disabled={false}
+          maxLength={23}
           placeholder="Some placeholder"
           style={
             Object {

--- a/packages/textarea/src/react/__stories__/index.story.tsx
+++ b/packages/textarea/src/react/__stories__/index.story.tsx
@@ -37,6 +37,7 @@ export const AllLabels: Story = () => (
       label="Some label"
       placeholder="Some placeholder"
       subLabel="Some sub label"
+      maxLength={23}
     />
 
     <TextArea

--- a/packages/textarea/src/react/index.tsx
+++ b/packages/textarea/src/react/index.tsx
@@ -80,7 +80,13 @@ export interface TextAreaStatics {
 }
 
 export interface TextAreaProps
-  extends Omit<React.HTMLAttributes<HTMLTextAreaElement>, 'rows'> {
+  extends Omit<
+    React.DetailedHTMLProps<
+      React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+      HTMLTextAreaElement
+    >,
+    'rows'
+  > {
   appearance?: ValueOf<typeof vars.appearances>
   disabled?: boolean
   error?: boolean


### PR DESCRIPTION
Related to: 
https://pluralsight.slack.com/archives/C70HPSJPP/p1626281065135900?thread_ts=1626191988.133400&cid=C70HPSJPP

This won't be the last time this happens. React.HTMLAttributes, which we've recently standardized on, just doesn't have all the attributes for these kinds of HTML elements.

Resolves: #1934
