### PR TITLE
Major release normalize

### DIFF
--- a/packages/actionmenu/package.json
+++ b/packages/actionmenu/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/appframe/package.json
+++ b/packages/appframe/package.json
@@ -40,7 +40,7 @@
     "focus-within": "^3.0.2"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -35,7 +35,7 @@
     "tiny-hashes": "^1.0.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -33,7 +33,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -37,7 +37,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-icon": "^24.0.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -37,7 +37,7 @@
     "shiitake": "^3.0.2"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -38,7 +38,7 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/circularprogress/package.json
+++ b/packages/circularprogress/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/datawell/package.json
+++ b/packages/datawell/package.json
@@ -36,7 +36,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -42,7 +42,7 @@
     "dayzed": "^3.2.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -38,7 +38,7 @@
     "element-closest": "^3.0.2"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -37,7 +37,7 @@
     "react-innertext": "^1.1.5"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/emptystate/package.json
+++ b/packages/emptystate/package.json
@@ -39,7 +39,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -42,7 +42,7 @@
     "camelize": "^1.0.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -42,7 +42,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/focusmanager/package.json
+++ b/packages/focusmanager/package.json
@@ -27,7 +27,7 @@
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -38,7 +38,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/halo/package.json
+++ b/packages/halo/package.json
@@ -36,7 +36,7 @@
     "hoist-non-react-statics": "^3.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -45,7 +45,7 @@
     "svgo": "^2.3.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -39,7 +39,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/linearprogress/package.json
+++ b/packages/linearprogress/package.json
@@ -36,7 +36,7 @@
     "@pluralsight/ps-design-system-screenreaderonly": "^5.0.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -34,7 +34,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -36,7 +36,7 @@
     "focus-within": "^3.0.2"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/multiselect/package.json
+++ b/packages/multiselect/package.json
@@ -40,7 +40,7 @@
     "downshift": "^6.1.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/navbar/package.json
+++ b/packages/navbar/package.json
@@ -37,7 +37,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/navbrand/package.json
+++ b/packages/navbrand/package.json
@@ -36,7 +36,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/navcookiebanner/package.json
+++ b/packages/navcookiebanner/package.json
@@ -37,7 +37,7 @@
     "react-cookie": "^4.0.3"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/navitem/package.json
+++ b/packages/navitem/package.json
@@ -37,7 +37,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/navuser/package.json
+++ b/packages/navuser/package.json
@@ -37,7 +37,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/normalize/css/index.css
+++ b/packages/normalize/css/index.css
@@ -69,9 +69,9 @@
 html {
   box-sizing: border-box;
   text-size-adjust: 100%;
-  font-family: var(--psTypeFontFamily);
+  font-family: var(--ps-type-font-family);
   font-size: 0.875em;
-  font-weight: var(--psTypeFontWeightRegular);
+  font-weight: var(--ps-type-font-weight-regular);
   line-height: 1.71429; /* calc(var(--ps-type-line-height-standard) / var(--ps-type-font-size-small)); */
   font-feature-settings: 'tnum' on, 'lnum' on;
 }
@@ -108,14 +108,14 @@ h3,
 h4,
 h5,
 h6 {
-  font-weight: var(--psTypeFontWeightRegular);
+  font-weight: var(--ps-type-font-weight-regular);
 }
 
 ul,
 ol,
 dd {
-  margin-left: var(--psLayoutSpacingLarge);
-  line-height: var(--psTypeLineHeightStandard);
+  margin-left: var(--ps-layout-spacing-large);
+  line-height: var(--ps-type-line-height-standard);
 }
 
 ul,

--- a/packages/normalize/package.json
+++ b/packages/normalize/package.json
@@ -12,7 +12,7 @@
   },
   "style": "dist/index.css",
   "dependencies": {
-    "@pluralsight/ps-design-system-core": "8.2.2",
+    "@pluralsight/ps-design-system-core": "^9.0.0",
     "normalize.css": "^8.0.1"
   },
   "devDependencies": {

--- a/packages/note/package.json
+++ b/packages/note/package.json
@@ -36,7 +36,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/position/package.json
+++ b/packages/position/package.json
@@ -32,7 +32,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "glamor": "^2.x.x",
     "react": "^17.0.1"
   },

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -34,7 +34,7 @@
     "shave": "^2.5.6"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/screenreaderonly/package.json
+++ b/packages/screenreaderonly/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/scrollable/package.json
+++ b/packages/scrollable/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/searchinput/package.json
+++ b/packages/searchinput/package.json
@@ -39,7 +39,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -36,7 +36,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/starrating/package.json
+++ b/packages/starrating/package.json
@@ -38,7 +38,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -38,7 +38,7 @@
     "invariant": "^2.2.4"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -36,7 +36,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/tagsinput/package.json
+++ b/packages/tagsinput/package.json
@@ -39,7 +39,7 @@
     "downshift": "^6.1.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -34,7 +34,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -36,7 +36,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/textinput/package.json
+++ b/packages/textinput/package.json
@@ -37,7 +37,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -29,7 +29,7 @@
     "hoist-non-react-statics": "^3.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "glamor": "^2.20.40",
     "react": "^17.0.1"
   },

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -34,7 +34,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/typeahead/package.json
+++ b/packages/typeahead/package.json
@@ -39,7 +39,7 @@
     "downshift": "^6.1.2"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/verticaltabs/package.json
+++ b/packages/verticaltabs/package.json
@@ -34,7 +34,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },

--- a/packages/viewtoggle/package.json
+++ b/packages/viewtoggle/package.json
@@ -35,7 +35,7 @@
     "@pluralsight/ps-design-system-util": "^9.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^5.1.2",
+    "@pluralsight/ps-design-system-normalize": "^6.0.0",
     "@pluralsight/ps-design-system-theme": "^8.1.4",
     "react": "^17.0.1"
   },


### PR DESCRIPTION
Preceded by: #1948
Resolves: #1947

Major release of normalize for switching it to use dashified core@9 css custom properties.

Setting all latest DS components to depend on this peerDependency version.
