### PR TITLE
feat(*): export additional component types

### DIFF
--- a/packages/actionmenu/src/react/index.tsx
+++ b/packages/actionmenu/src/react/index.tsx
@@ -38,7 +38,7 @@ interface ActionMenuProps
   onClose?: () => void
   origin?: ValueOf<typeof vars.origins>
 }
-type ActionMenuComponent = RefForwardingComponent<
+export type ActionMenuComponent = RefForwardingComponent<
   ActionMenuProps,
   HTMLUListElement,
   ActionMenuStatics

--- a/packages/appframe/src/react/index.tsx
+++ b/packages/appframe/src/react/index.tsx
@@ -66,7 +66,7 @@ interface AppFrameStatics {
   TopNav: typeof TopNav
 }
 
-interface AppFrameComponent
+export interface AppFrameComponent
   extends RefForwardingComponent<
     AppFrameProps,
     HTMLDivElement,

--- a/packages/avatar/src/react/index.tsx
+++ b/packages/avatar/src/react/index.tsx
@@ -22,7 +22,7 @@ interface AvatarStatics {
   widths: typeof widths
 }
 
-type AvatarComponent = RefForwardingComponent<
+export type AvatarComponent = RefForwardingComponent<
   AvatarProps,
   HTMLDivElement,
   AvatarStatics

--- a/packages/badge/src/react/index.tsx
+++ b/packages/badge/src/react/index.tsx
@@ -22,7 +22,7 @@ interface BadgeStatics {
   colors: typeof vars.colors
 }
 
-interface BadgeComponent
+export interface BadgeComponent
   extends RefForwardingComponent<BadgeProps, HTMLDivElement, BadgeStatics> {}
 
 const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(

--- a/packages/banner/src/react/index.tsx
+++ b/packages/banner/src/react/index.tsx
@@ -27,7 +27,7 @@ interface BannerStatics {
   colors: typeof vars.colors
 }
 
-interface BannerComponent
+export interface BannerComponent
   extends RefForwardingComponent<BannerProps, HTMLDivElement, BannerStatics> {}
 
 const Banner = React.forwardRef((props, ref) => {

--- a/packages/carousel/src/react/index.tsx
+++ b/packages/carousel/src/react/index.tsx
@@ -36,7 +36,7 @@ interface CarouselStatics {
   sizes: typeof vars.sizes
 }
 
-type CarouselComponent = React.FC<CarouselProps> & CarouselStatics
+export type CarouselComponent = React.FC<CarouselProps> & CarouselStatics
 
 const Carousel: CarouselComponent = ({
   className,

--- a/packages/circularprogress/src/react/index.tsx
+++ b/packages/circularprogress/src/react/index.tsx
@@ -23,7 +23,7 @@ interface CircularProgressStatics {
   sizes: typeof vars.sizes
 }
 
-interface CircularProgressComponent
+export interface CircularProgressComponent
   extends RefForwardingComponent<
     CircularProgressProps,
     HTMLDivElement,

--- a/packages/datawell/src/react/index.tsx
+++ b/packages/datawell/src/react/index.tsx
@@ -15,7 +15,7 @@ interface DataWellProps extends React.HTMLAttributes<HTMLDivElement> {
 
 interface DataWellStatics {}
 
-interface DataWellComponent
+export interface DataWellComponent
   extends RefForwardingComponent<
     DataWellProps,
     HTMLDivElement,

--- a/packages/dropdown/src/react/index.tsx
+++ b/packages/dropdown/src/react/index.tsx
@@ -48,7 +48,7 @@ interface DropdownProps
   uniqueId?: (prefix: string) => string
   value?: React.ReactText
 }
-interface DropdownComponent
+export interface DropdownComponent
   extends RefForwardingComponent<
     DropdownProps,
     HTMLButtonElement,

--- a/packages/emptystate/src/react/index.tsx
+++ b/packages/emptystate/src/react/index.tsx
@@ -33,7 +33,7 @@ interface EmptyStateStatics {
   sizes: typeof sizes
 }
 
-interface EmptyStateComponent
+export interface EmptyStateComponent
   extends RefForwardingComponent<
     EmptyStateProps,
     HTMLDivElement,

--- a/packages/halo/src/react/index.tsx
+++ b/packages/halo/src/react/index.tsx
@@ -30,7 +30,7 @@ interface HaloStatics {
   shapes: typeof vars.shapes
 }
 
-type HaloComponent = RefForwardingComponent<
+export type HaloComponent = RefForwardingComponent<
   HaloProps,
   HTMLDivElement,
   HaloStatics

--- a/packages/multiselect/src/react/index.tsx
+++ b/packages/multiselect/src/react/index.tsx
@@ -35,7 +35,7 @@ interface MultiSelectFieldStatics {
   SubLabel: typeof Field.SubLabel
 }
 
-type MultiSelectFieldComponent = React.FC<MultiSelectFieldProps> &
+export type MultiSelectFieldComponent = React.FC<MultiSelectFieldProps> &
   MultiSelectFieldStatics
 
 const MultiSelect: MultiSelectFieldComponent = props => {

--- a/packages/navbrand/src/react/index.tsx
+++ b/packages/navbrand/src/react/index.tsx
@@ -18,7 +18,7 @@ interface NavBrandProps
   rel?: string
 }
 
-type NavBrandElement = HTMLAnchorElement | HTMLButtonElement | HTMLDivElement
+export type NavBrandElement = HTMLAnchorElement | HTMLButtonElement | HTMLDivElement
 
 const NavBrand = React.forwardRef<NavBrandElement, NavBrandProps>(
   (props, forwardedRef) => {

--- a/packages/navuser/src/react/index.tsx
+++ b/packages/navuser/src/react/index.tsx
@@ -20,7 +20,7 @@ interface NavUserProps
   >
 }
 
-type NavUserElement = HTMLAnchorElement | HTMLButtonElement | HTMLDivElement
+export type NavUserElement = HTMLAnchorElement | HTMLButtonElement | HTMLDivElement
 
 const NavUser = React.forwardRef<NavUserElement, NavUserProps>(
   (props, forwardedRef) => {

--- a/packages/switch/src/react/index.tsx
+++ b/packages/switch/src/react/index.tsx
@@ -32,7 +32,7 @@ interface SwitchProps
   tabIndex?: number
 }
 
-interface SwitchComponent
+export interface SwitchComponent
   extends RefForwardingComponent<
     SwitchProps,
     HTMLInputElement | HTMLLabelElement,

--- a/packages/tab/src/react/list-item.tsx
+++ b/packages/tab/src/react/list-item.tsx
@@ -22,7 +22,7 @@ export interface ListItemButtonProps
 }
 type ListItemElement = HTMLButtonElement | HTMLAnchorElement
 type ListItemProps = ListItemAnchorProps | ListItemButtonProps
-type ListItemComponent = React.ForwardRefExoticComponent<ListItemProps> & {
+export type ListItemComponent = React.ForwardRefExoticComponent<ListItemProps> & {
   (props: ListItemAnchorProps, ref?: RefFor<'a'>): JSX.Element
   (props: ListItemButtonProps, ref?: RefFor<'button'>): JSX.Element
 }

--- a/packages/table/src/react/index.tsx
+++ b/packages/table/src/react/index.tsx
@@ -28,7 +28,7 @@ interface TableStatics {
   Row: typeof TableRow
   alignments: typeof alignments
 }
-type TableComponent = React.ForwardRefExoticComponent<TableProps> & TableStatics
+export type TableComponent = React.ForwardRefExoticComponent<TableProps> & TableStatics
 
 const Table = React.forwardRef<HTMLTableElement, TableProps>((props, ref) => {
   const {

--- a/packages/tagsinput/src/react/index.tsx
+++ b/packages/tagsinput/src/react/index.tsx
@@ -34,7 +34,7 @@ interface TagsInputStatics {
   SubLabel: typeof Field.SubLabel
 }
 
-type TagsInputComponent = React.FC<TagsInputProps> & TagsInputStatics
+export type TagsInputComponent = React.FC<TagsInputProps> & TagsInputStatics
 
 const TagsInput: TagsInputComponent = props => {
   const {

--- a/packages/theme/src/react/index.tsx
+++ b/packages/theme/src/react/index.tsx
@@ -10,7 +10,7 @@ export const ThemeContext = React.createContext<ValueOf<Names>>(defaultName)
 
 type ThemeProps = { name?: ValueOf<Names> }
 type ThemeStatics = { defaultName: typeof defaultName; names: Names }
-type ThemeComponent = React.FC<ThemeProps> & ThemeStatics
+export type ThemeComponent = React.FC<ThemeProps> & ThemeStatics
 
 const Theme: ThemeComponent = props => {
   const { name = defaultName } = props

--- a/packages/tooltip/src/react/index.tsx
+++ b/packages/tooltip/src/react/index.tsx
@@ -67,7 +67,7 @@ interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
   tailPosition?: ValueOf<typeof vars.tailPositions>
 }
 
-interface TooltipComponent
+export interface TooltipComponent
   extends RefForwardingComponent<
     TooltipProps,
     HTMLDivElement,

--- a/packages/verticaltabs/src/react/index.tsx
+++ b/packages/verticaltabs/src/react/index.tsx
@@ -23,7 +23,7 @@ interface VerticalTabsStatics {
   Tier2: typeof Tier2
 }
 
-interface VerticalTabsComponents
+export interface VerticalTabsComponents
   extends RefForwardingComponent<
     VerticalTabsProps,
     HTMLUListElement,

--- a/packages/viewtoggle/src/react/index.tsx
+++ b/packages/viewtoggle/src/react/index.tsx
@@ -18,7 +18,7 @@ interface ViewToggleStatics {
   Option: typeof Option
 }
 
-interface ViewToggleComponent
+export interface ViewToggleComponent
   extends RefForwardingComponent<
     ViewToggleProps,
     HTMLDivElement,


### PR DESCRIPTION
This PR exports additional types and interfaces from a number of components.

The goal of these additional exports is to enable further manipulation of the components. For example, exporting the `DropdownComponent` type makes it much easier to [hoist the statics](https://github.com/mridgway/hoist-non-react-statics) from `Dropdown` into a new component.

While it is debatable whether folks **should** do that sort of thing, this change will enable it. :) 

No guarantees that this covers all of the types, and I don't have enough context to know if this will ruin everything.