### PR TITLE
fix(normalize): exclude postcss.config.js from node_modules

### DIFF
--- a/packages/normalize/package.json
+++ b/packages/normalize/package.json
@@ -7,6 +7,10 @@
   "author": "jaketrent",
   "keywords": [],
   "main": "dist/index.css",
+  "files": [
+    "dist/*",
+    "!postcss.config.js"
+  ],
   "scripts": {
     "build": "postcss css/index.css --dir dist"
   },


### PR DESCRIPTION
Normalize should be browser ready. We don't want the postcss-loader for our users to have to respect our postcss.config.js in normalize builds.
