### PR TITLE
Fix export pattern to avoid treeshaking styles

### DIFF
--- a/packages/avatar/src/index.ts
+++ b/packages/avatar/src/index.ts
@@ -1,5 +1,6 @@
 import './css/index.css'
+import Avatar from './react/index'
 
-export { default } from './react/index'
+export default Avatar
 export * from './vars/index'
 export * from './js/index'

--- a/packages/button/src/index.ts
+++ b/packages/button/src/index.ts
@@ -1,5 +1,8 @@
 import '@pluralsight/ps-design-system-icon/styles.css'
-import './css/index.css'
 
-export { default, ButtonProps } from './react/index'
+import './css/index.css'
+import Button from './react/index'
+
+export default Button
+export type { ButtonProps } from './react/index'
 export * from './vars/index'

--- a/packages/icon/src/index.ts
+++ b/packages/icon/src/index.ts
@@ -1,6 +1,7 @@
 import './css/index.css'
+import Icon from './react/index'
 
-export * from './vars/index'
-export { default } from './react/index'
+export default Icon
 export * from './react/icons'
 export * as icons from './react/icons'
+export * from './vars/index'


### PR DESCRIPTION
Tools like MiniExtractPlugin were not respecting sideEffects: true on these files. They were removing the styles from final bundles. The reason is unknown, but making these files import then export like this seems to resolve the problem, avoiding the overly-eager treeshaking.
