### PR TITLE
Re-add old camelCase vars to Core

### DIFF
--- a/packages/core/src/css/accessibility.css
+++ b/packages/core/src/css/accessibility.css
@@ -1,3 +1,4 @@
+.screenreader-only, /* DEPRECATED */
 .psds-screenreader-only {
   position: absolute;
   top: auto;

--- a/packages/core/src/css/breakpoints.css
+++ b/packages/core/src/css/breakpoints.css
@@ -5,3 +5,12 @@
   --ps-breakpoints-large: 1280px;
   --ps-breakpoints-xlarge: 1600px;
 }
+
+/* DEPRECATED */
+:root {
+  --psBreakpointsXSmall: 640px;
+  --psBreakpointsSmall: 768px;
+  --psBreakpointsMedium: 1024px;
+  --psBreakpointsLarge: 1280px;
+  --psBreakpointsXLarge: 1600px;
+}

--- a/packages/core/src/css/colors.css
+++ b/packages/core/src/css/colors.css
@@ -164,3 +164,181 @@
 
   --ps-colors-black: #000000;
 }
+
+/* DEPRECATED */
+:root {
+  --psColorsBlueBase: #0084bd;
+  --psColorsBlue1: #d9f1ff;
+  --psColorsBlue2: #b9e4fd;
+  --psColorsBlue3: #8ed1f6;
+  --psColorsBlue4: #58b9eb;
+  --psColorsBlue5: #2ea0d6;
+  --psColorsBlue6: #0084bd;
+  --psColorsBlue7: #0074ab;
+  --psColorsBlue8: #006395;
+  --psColorsBlue9: #005685;
+  --psColorsBlue10: #00446b;
+
+  --psColorsTealBase: #00baa5;
+  --psColorsTeal1: #d5faf5;
+  --psColorsTeal2: #affaef;
+  --psColorsTeal3: #84f0e1;
+  --psColorsTeal4: #5ce6d4;
+  --psColorsTeal5: #2fd1be;
+  --psColorsTeal6: #00baa5;
+  --psColorsTeal7: #00a894;
+  --psColorsTeal8: #009380;
+  --psColorsTeal9: #007a6a;
+  --psColorsTeal10: #006658;
+
+  --psColorsGreenBase: #009e52;
+  --psColorsGreen1: #d9fae5;
+  --psColorsGreen2: #adf0c8;
+  --psColorsGreen3: #82e2ab;
+  --psColorsGreen4: #57d08e;
+  --psColorsGreen5: #2bb970;
+  --psColorsGreen6: #009e52;
+  --psColorsGreen7: #008f46;
+  --psColorsGreen8: #007c3a;
+  --psColorsGreen9: #00672e;
+  --psColorsGreen10: #005724;
+
+  --psColorsLimeBase: #8cca08;
+  --psColorsLime1: #ecffc7;
+  --psColorsLime2: #deffa3;
+  --psColorsLime3: #ccfc7a;
+  --psColorsLime4: #b8f052;
+  --psColorsLime5: #a3e029;
+  --psColorsLime6: #8cca08;
+  --psColorsLime7: #7bb600;
+  --psColorsLime8: #6ba300;
+  --psColorsLime9: #588a00;
+  --psColorsLime10: #4c7700;
+
+  --psColorsYellowBase: #fad000;
+  --psColorsYellow1: #fffbcc;
+  --psColorsYellow2: #fff7a8;
+  --psColorsYellow3: #fff380;
+  --psColorsYellow4: #ffeb57;
+  --psColorsYellow5: #ffdf29;
+  --psColorsYellow6: #fad000;
+  --psColorsYellow7: #e2b500;
+  --psColorsYellow8: #cc9e00;
+  --psColorsYellow9: #b28300;
+  --psColorsYellow10: #946500;
+
+  --psColorsOrangeBase: #f59127;
+  --psColorsOrange1: #ffecd1;
+  --psColorsOrange2: #ffdcad;
+  --psColorsOrange3: #ffcd8a;
+  --psColorsOrange4: #ffba61;
+  --psColorsOrange5: #ffa43e;
+  --psColorsOrange6: #f59127;
+  --psColorsOrange7: #e27a18;
+  --psColorsOrange8: #cb670b;
+  --psColorsOrange9: #b85500;
+  --psColorsOrange10: #9e4100;
+
+  --psColorsRedBase: #d21c09;
+  --psColorsRed1: #ffd6d6;
+  --psColorsRed2: #ffb3b3;
+  --psColorsRed3: #ff8a8a;
+  --psColorsRed4: #f86968;
+  --psColorsRed5: #e94a3f;
+  --psColorsRed6: #d21c09;
+  --psColorsRed7: #c00f00;
+  --psColorsRed8: #ab0600;
+  --psColorsRed9: #920000;
+  --psColorsRed10: #750000;
+
+  --psColorsPinkBase: #e7558b;
+  --psColorsPink1: #ffddeb;
+  --psColorsPink2: #ffc2db;
+  --psColorsPink3: #ffa3c8;
+  --psColorsPink4: #ff8ab5;
+  --psColorsPink5: #f66fa1;
+  --psColorsPink6: #e7558b;
+  --psColorsPink7: #d1487b;
+  --psColorsPink8: #c13368;
+  --psColorsPink9: #a22554;
+  --psColorsPink10: #8a1a45;
+
+  --psColorsPurpleBase: #8359df;
+  --psColorsPurple1: #e9deff;
+  --psColorsPurple2: #d6c2ff;
+  --psColorsPurple3: #c0a3ff;
+  --psColorsPurple4: #a883f8;
+  --psColorsPurple5: #956ced;
+  --psColorsPurple6: #8359df;
+  --psColorsPurple7: #7048c6;
+  --psColorsPurple8: #5934ac;
+  --psColorsPurple9: #482592;
+  --psColorsPurple10: #351973;
+
+  --psColorsTextIconHighOnDark: rgba(255, 255, 255, 0.95);
+  --psColorsTextIconHighOnLight: rgba(0, 0, 0, 0.9);
+  --psColorsTextIconLowOnDark: rgba(255, 255, 255, 0.7);
+  --psColorsTextIconLowOnLight: rgba(0, 0, 0, 0.65);
+
+  --psColorsBorderHighOnDark: rgba(255, 255, 255, 0.3);
+  --psColorsBorderHighOnLight: rgba(0, 0, 0, 0.3);
+  --psColorsBorderLowOnDark: rgba(255, 255, 255, 0.15);
+  --psColorsBorderLowOnLight: rgba(0, 0, 0, 0.15);
+
+  --psColorsBackgroundDark1: #0d0f12;
+  --psColorsBackgroundDark2: #181c20;
+  --psColorsBackgroundDark3: #1e2429;
+
+  --psColorsBackgroundLight1: #f0f3f5;
+  --psColorsBackgroundLight2: #f7f9fa;
+  --psColorsBackgroundLight3: #ffffff;
+
+  --psColorsBackgroundUtilityBase: #b0b0b0;
+  --psColorsBackgroundUtility10: rgba(138, 153, 168, 0.1);
+  --psColorsBackgroundUtility15: rgba(138, 153, 168, 0.15);
+  --psColorsBackgroundUtility20: rgba(138, 153, 168, 0.2);
+  --psColorsBackgroundUtility25: rgba(138, 153, 168, 0.25);
+  --psColorsBackgroundUtility30: rgba(138, 153, 168, 0.3);
+  --psColorsBackgroundUtility40: rgba(138, 153, 168, 0.4);
+  --psColorsBackgroundUtility60: rgba(138, 153, 168, 0.6);
+
+  --psColorsGradientSkillsBackground: linear-gradient(
+    90deg,
+    #e80a89 0%,
+    #f15b2a 100%
+  );
+  --psColorsGradientSkillsStop0: #e80a89;
+  --psColorsGradientSkillsStop100: #f15b2a;
+  --psColorsGradientFlowBackground: linear-gradient(
+    90deg,
+    #2968b2 0%,
+    #27aae1 100%
+  );
+  --psColorsGradientFlowStop0: #2968b2;
+  --psColorsGradientFlowStop100: #27aae1;
+
+  --psColorsPrimaryActionBackground: #0074ab;
+  --psColorsPrimaryActionTextDarkTheme: #2ea0d6;
+  --psColorsPrimaryActionTextLightTheme: #0074ab;
+
+  --psColorsStatusError: #d21c09;
+  --psColorsStatusInfo: #0084bd;
+  --psColorsStatusSuccess: #009e52;
+  --psColorsStatusWarning: #fad000;
+
+  --psColorsWhite: #ffffff;
+  --psColorsBone: #f2f2f2;
+
+  --psColorsCodeWhite: #f2f2f2;
+  --psColorsCodeGray: #aaaaaa;
+  --psColorsCodeRed: #f26d6d;
+  --psColorsCodeOrange: #ff9466;
+  --psColorsCodeYellow: #ffca80;
+  --psColorsCodeGreen: #b8cc7a;
+  --psColorsCodeTurquoise: #abd9c6;
+  --psColorsCodeBlue: #8ac7e6;
+  --psColorsCodePurple: #e695bd;
+  --psColorsCodeSand: #d99077;
+
+  --psColorsBlack: #000000;
+}

--- a/packages/core/src/css/layers.css
+++ b/packages/core/src/css/layers.css
@@ -5,3 +5,12 @@
   --ps-layers-dropdown: 1000;
   --ps-layers-skip-to-content-banner: 1600;
 }
+
+/* DEPRECATED */
+:root {
+  --psLayersMain: 0;
+  --psLayersGlobalSidenav: 930;
+  --psLayersGlobalTopnav: 950;
+  --psLayersDropdown: 1000;
+  --psLayersSkipToContentBanner: 1600;
+}

--- a/packages/core/src/css/layout.css
+++ b/packages/core/src/css/layout.css
@@ -7,3 +7,14 @@
   --ps-layout-spacing-xlarge: 48px;
   --ps-layout-spacing-xxLarge: 64px;
 }
+
+/* DEPRECATED */
+:root {
+  --psLayoutSpacingXXSmall: 4px;
+  --psLayoutSpacingXSmall: 8px;
+  --psLayoutSpacingSmall: 12px;
+  --psLayoutSpacingMedium: 16px;
+  --psLayoutSpacingLarge: 24px;
+  --psLayoutSpacingXLarge: 48px;
+  --psLayoutSpacingXXLarge: 64px;
+}

--- a/packages/core/src/css/motion.css
+++ b/packages/core/src/css/motion.css
@@ -5,3 +5,12 @@
   --ps-motion-speed-slow: 400ms;
   --ps-motion-speed-xslow: 500ms;
 }
+
+/* DEPRECATED */
+:root {
+  --psMotionSpeedXFast: 100ms;
+  --psMotionSpeedFast: 200ms;
+  --psMotionSpeedNormal: 300ms;
+  --psMotionSpeedSlow: 400ms;
+  --psMotionSpeedXSlow: 500ms;
+}

--- a/packages/core/src/css/type.css
+++ b/packages/core/src/css/type.css
@@ -77,3 +77,77 @@
   --ps-type-line-height-extra: 32px;
   --ps-type-line-height-huge: 40px;
 }
+
+/* DEPRECATED */
+:root {
+  /* prettier-ignore */
+  --psTypeFontFamily: 'PS TT Commons Roman', 'Gotham SSm A', 'Gotham SSm B', Arial, sans-serif;
+  --psTypeFontFamilyCode: 'DM Mono', 'Source Code Pro', monospace;
+
+  --psTypeFontSizeGigantic: 60px;
+  --psTypeFontSizeJumbo: 48px;
+  --psTypeFontSizeXXLarge: 36px;
+  --psTypeFontSizeXLarge: 30px;
+  --psTypeFontSizeLarge: 24px;
+  --psTypeFontSizeMedium: 18px;
+  --psTypeFontSizeSmall: 14px;
+  --psTypeFontSizeXSmall: 12px;
+
+  --psTypeFontSizeBase: 16px;
+  --psTypeFontSize1200: 88px;
+  --psTypeFontSize1100: 72px;
+  --psTypeFontSize1000: 56px;
+  --psTypeFontSize900: 40px;
+  --psTypeFontSize800: 34px;
+  --psTypeFontSize700: 28px;
+  --psTypeFontSize600: 24px;
+  --psTypeFontSize500: 20px;
+  --psTypeFontSize400: 18px;
+  --psTypeFontSize300: 16px;
+  --psTypeFontSize200: 14px;
+  --psTypeFontSize100: 12px;
+
+  --psTypeLetterSpacingGigantic: -1px;
+  --psTypeLetterSpacingJumbo: -0.72px;
+  --psTypeLetterSpacingXXLarge: -0.54px;
+  --psTypeLetterSpacingXLarge: -0.45px;
+  --psTypeLetterSpacingLarge: 0.36px;
+  --psTypeLetterSpacingMedium: 0;
+  --psTypeLetterSpacingSmall: 0;
+  --psTypeLetterSpacingXSmall: 0;
+
+  --psTypeLetterSpacingTighter: -0.025em;
+  --psTypeLetterSpacingTight: -0.01em;
+  --psTypeLetterSpacingNone: 0;
+  --psTypeLetterSpacingLoose: 0.01em;
+  --psTypeLetterSpacingLooser: 0.025em;
+  --psTypeLetterSpacingAllCaps: 0.08em;
+
+  --psTypeFontWeightBlack: 900;
+  --psTypeFontWeightXBold: 800;
+  --psTypeFontWeightBold: 700;
+  --psTypeFontWeightDemiBold: 600;
+  --psTypeFontWeightMedium: 500;
+  --psTypeFontWeightRegular: 400;
+  --psTypeFontWeightBook: 400;
+  --psTypeFontWeightLight: 300;
+  --psTypeFontWeightXLight: 200;
+  --psTypeFontWeightThin: 100;
+
+  --psTypeFontWeightDefault: 400;
+  --psTypeFontWeightStrong: 600;
+  --psTypeFontWeight900: 900;
+  --psTypeFontWeight800: 800;
+  --psTypeFontWeight700: 700;
+  --psTypeFontWeight600: 600;
+  --psTypeFontWeight500: 500;
+  --psTypeFontWeight400: 400;
+  --psTypeFontWeight300: 300;
+  --psTypeFontWeight200: 200;
+  --psTypeFontWeight100: 100;
+
+  --psTypeLineHeightTight: 20px;
+  --psTypeLineHeightStandard: 24px;
+  --psTypeLineHeightExtra: 32px;
+  --psTypeLineHeightHuge: 40px;
+}


### PR DESCRIPTION
Will allow teams to handle partial upgrade situations, such as that recently experienced by Flow.

For example, in a conversation with Flow devs:

This is a problem with our Core package, where we changed the variable names. Then, you upgraded some components and not others. And you worked with another team who updated some code but not others. And the single set of new variable names was insufficient to handle this partial upgrade situation. So, the most likely option was to rollback until you could upgrade everything, but that seems difficult to do at once, especially with other teams.

I thought of a proposed solution this morning and wondered what you thought. What if we put the old vars side by side with the new vars in the latest version of the core package? This would allow everything to work, whether it needed the old or new vars, once you upgrade Core to latest. The old vars in that package would be immediately deprecated to show that they’d be eventually removed. I don’t know when that removal would be, but it should give a reasonable window for all code to be upgraded gradually and then also not remain a drag in the DS codebase for a long time.

The team was agreed that this is a helpful solution.
