### PR TITLE
Separate imports - Set 2

### DIFF
--- a/packages/button/react.d.ts
+++ b/packages/button/react.d.ts
@@ -1,2 +1,47 @@
-export { default, ButtonProps } from './dist/esm/react/index'
-export * from './dist/esm/vars/index'
+import { ValueOf } from '@pluralsight/ps-design-system-util'
+import React from 'react'
+import * as vars from './dist/esm/vars/index'
+export interface ButtonProps
+  extends Omit<
+    React.DetailedHTMLProps<
+      React.ButtonHTMLAttributes<HTMLButtonElement>,
+      HTMLButtonElement
+    >,
+    'value'
+  > {
+  appearance?: ValueOf<typeof vars.appearances>
+  disabled?: boolean
+  value?: React.ReactText
+  layout?: ValueOf<typeof vars.layouts>
+  icon?: React.ReactNode
+  iconAlign?: ValueOf<typeof vars.iconAligns>
+  loading?: boolean
+  size?: ValueOf<typeof vars.sizes>
+  href?: string
+  target?: string
+  rel?: string
+}
+interface ButtonStatics {
+  appearances: typeof vars.appearances
+  layouts: typeof vars.layouts
+  iconAligns: typeof vars.iconAligns
+  sizes: typeof vars.sizes
+}
+declare const Button: React.ForwardRefExoticComponent<ButtonProps> &
+  ButtonStatics
+export declare const appearances: Readonly<
+  import('@pluralsight/ps-design-system-util/dist/esm/key-mirror').KeyMirror<
+    ['primary', 'secondary', 'stroke', 'flat']
+  >
+>
+export declare const iconAligns: Readonly<
+  import('@pluralsight/ps-design-system-util/dist/esm/key-mirror').KeyMirror<
+    ['left', 'right']
+  >
+>
+export declare const sizes: Readonly<
+  import('@pluralsight/ps-design-system-util/dist/esm/key-mirror').KeyMirror<
+    ['xSmall', 'small', 'medium', 'large']
+  >
+>
+export default Button

--- a/packages/button/react.d.ts
+++ b/packages/button/react.d.ts
@@ -1,3 +1,2 @@
-import './dist/esm/css/index.css'
 export { default, ButtonProps } from './dist/esm/react/index'
 export * from './dist/esm/vars/index'

--- a/packages/circularprogress/package.json
+++ b/packages/circularprogress/package.json
@@ -9,6 +9,10 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "files": [
+    "react.d.ts",
+    "react.mjs",
+    "react.js",
+    "styles.css",
     "src/*",
     "dist/*",
     "!src/*/__stories__/*",
@@ -25,7 +29,8 @@
     "test:watch": "yarn test --watchAll"
   },
   "sideEffects": [
-    "**/*.css"
+    "**/*.css",
+    "src/index.ts"
   ],
   "style": "dist/esm/css/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/circularprogress/react.d.ts
+++ b/packages/circularprogress/react.d.ts
@@ -1,0 +1,4 @@
+import CircularProgress from './dist/esm/react/index'
+
+export default CircularProgress
+export * from './dist/esm/vars/index'

--- a/packages/circularprogress/react.js
+++ b/packages/circularprogress/react.js
@@ -1,0 +1,4 @@
+module.exports = require('./dist/cjs/react/index.js')
+
+const vars = require('./dist/cjs/vars/index.js')
+Object.keys(vars).forEach(key => (exports[key] = vars[key]))

--- a/packages/circularprogress/react.mjs
+++ b/packages/circularprogress/react.mjs
@@ -1,0 +1,4 @@
+import CircularProgress from './dist/esm/react/index'
+
+export default CircularProgress
+export * from './dist/esm/vars/index'

--- a/packages/circularprogress/src/index.ts
+++ b/packages/circularprogress/src/index.ts
@@ -1,2 +1,5 @@
-export { default } from './react/index'
+import './css/index.css'
+import CircularProgress from './react/index'
+
+export default CircularProgress
 export * from './vars/index'

--- a/packages/circularprogress/src/react/index.tsx
+++ b/packages/circularprogress/src/react/index.tsx
@@ -7,7 +7,6 @@ import {
 } from '@pluralsight/ps-design-system-util'
 import React from 'react'
 
-import '../css/index.css'
 import * as vars from '../vars/index'
 
 const radius = vars.style.width / 2 - vars.style.strokeWidth / 2

--- a/packages/circularprogress/styles.css
+++ b/packages/circularprogress/styles.css
@@ -1,0 +1,1 @@
+@import './dist/esm/css/index.css';

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -9,6 +9,10 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "files": [
+    "react.d.ts",
+    "react.mjs",
+    "react.js",
+    "styles.css",
     "src/*",
     "dist/*",
     "!src/*/__stories__/*",
@@ -25,7 +29,8 @@
     "test:watch": "yarn test --watchAll"
   },
   "sideEffects": [
-    "**/*.css"
+    "**/*.css",
+    "src/index.ts"
   ],
   "style": "dist/esm/css/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/dialog/react.d.ts
+++ b/packages/dialog/react.d.ts
@@ -1,0 +1,3 @@
+import Dialog from './dist/esm/react/index'
+export default Dialog
+export * from './dist/esm/vars/index'

--- a/packages/dialog/react.js
+++ b/packages/dialog/react.js
@@ -1,0 +1,4 @@
+module.exports = require('./dist/cjs/react/index.js')
+
+const vars = require('./dist/cjs/vars/index.js')
+Object.keys(vars).forEach(key => (exports[key] = vars[key]))

--- a/packages/dialog/react.mjs
+++ b/packages/dialog/react.mjs
@@ -1,0 +1,2 @@
+export { default } from './dist/esm/react/index'
+export * from './dist/esm/vars/index'

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -1,2 +1,5 @@
-export { default } from './react/index'
+import './css/index.css'
+import Dialog from './react/index'
+
+export default Dialog
 export * from './vars/index'

--- a/packages/dialog/src/react/__stories__/index.story.tsx
+++ b/packages/dialog/src/react/__stories__/index.story.tsx
@@ -6,7 +6,7 @@ import { Meta, Story } from '@storybook/react/types-6-0'
 import Button from '@pluralsight/ps-design-system-button'
 import * as Text from '@pluralsight/ps-design-system-text'
 
-import Dialog from '../index'
+import Dialog from '../../index'
 
 const closeAction = action('close')
 const openAction = action('open')

--- a/packages/dialog/src/react/index.tsx
+++ b/packages/dialog/src/react/index.tsx
@@ -11,7 +11,6 @@ import {
 } from '@pluralsight/ps-design-system-util'
 import React from 'react'
 
-import '../css/index.css'
 import * as vars from '../vars/index'
 
 /* eslint-disable-next-line camelcase */

--- a/packages/dialog/styles.css
+++ b/packages/dialog/styles.css
@@ -1,0 +1,1 @@
+@import './dist/esm/css/index.css';

--- a/packages/halo/package.json
+++ b/packages/halo/package.json
@@ -9,6 +9,9 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "files": [
+    "react.d.ts",
+    "react.mjs",
+    "styles.css",
     "src/*",
     "dist/*",
     "!src/*/__stories__/*",
@@ -25,7 +28,8 @@
     "test:watch": "yarn test --watchAll"
   },
   "sideEffects": [
-    "**/*.css"
+    "**/*.css",
+    "src/index.ts"
   ],
   "style": "dist/esm/css/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/halo/react.d.ts
+++ b/packages/halo/react.d.ts
@@ -1,0 +1,3 @@
+import Halo from './dist/esm/react/index'
+export default Halo
+export * from './dist/esm/vars/index'

--- a/packages/halo/react.js
+++ b/packages/halo/react.js
@@ -1,0 +1,4 @@
+module.exports = require('./dist/cjs/react/index.js')
+
+const vars = require('./dist/cjs/vars/index.js')
+Object.keys(vars).forEach(key => (exports[key] = vars[key]))

--- a/packages/halo/react.mjs
+++ b/packages/halo/react.mjs
@@ -1,0 +1,4 @@
+import Halo from './dist/esm/react/index'
+
+export default Halo
+export * from './dist/esm/vars/index'

--- a/packages/halo/src/index.ts
+++ b/packages/halo/src/index.ts
@@ -1,2 +1,5 @@
-export { default } from './react/index'
+import './css/index.css'
+import Halo from './react/index'
+
+export default Halo
 export * from './vars/index'

--- a/packages/halo/src/react/__stories__/index.story.tsx
+++ b/packages/halo/src/react/__stories__/index.story.tsx
@@ -2,7 +2,7 @@ import { Meta, Story } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Focusable from './focusable'
-import Halo from '../index'
+import Halo from '../../index'
 
 const defaultArgs = { children: <Focusable /> }
 

--- a/packages/halo/src/react/index.tsx
+++ b/packages/halo/src/react/index.tsx
@@ -8,7 +8,6 @@ import {
 import polyfillFocusWithin from 'focus-within'
 import React from 'react'
 
-import '../css/index.css'
 import * as vars from '../vars/index'
 
 if (canUseDOM()) polyfillFocusWithin(document)

--- a/packages/halo/styles.css
+++ b/packages/halo/styles.css
@@ -1,0 +1,1 @@
+@import './dist/esm/css/index.css';

--- a/packages/icon/react.d.ts
+++ b/packages/icon/react.d.ts
@@ -1,4 +1,21 @@
-export * from './dist/esm/vars'
-export { default } from './dist/esm/react'
+import {
+  RefForwardingComponent,
+  ValueOf
+} from '@pluralsight/ps-design-system-util'
+import React from 'react'
+import { colors, sizes } from './dist/esm/vars'
+export interface IconProps extends React.HTMLAttributes<HTMLDivElement> {
+  color?: ValueOf<typeof colors>
+  size?: ValueOf<typeof sizes>
+}
+export interface IconStatics {
+  colors: typeof colors
+  sizes: typeof sizes
+}
+export interface IconComponent
+  extends RefForwardingComponent<IconProps, HTMLDivElement, IconStatics> {}
+declare const Icon: IconComponent
+export { colors, sizes }
+export default Icon
 export * from './dist/esm/react/icons'
 export * as icons from './dist/esm/react/icons'

--- a/packages/icon/react.js
+++ b/packages/icon/react.js
@@ -1,7 +1,3 @@
-// export * from './dist/esm/react/icons/index.js'
-// export { default } from './dist/esm/react/index.js'
-// export * from './dist/esm/vars/index.js'
-
 module.exports = require('./dist/cjs/react/index.js')
 
 const vars = require('./dist/cjs/vars/index.js')

--- a/packages/icon/react.js
+++ b/packages/icon/react.js
@@ -1,7 +1,23 @@
+/* eslint-disable no-prototype-builtins */
 module.exports = require('./dist/cjs/react/index.js')
 
-const vars = require('./dist/cjs/vars/index.js')
-Object.keys(vars).forEach(key => (exports[key] = vars[key]))
+const __createBinding = function (o, m, k, k2) {
+  if (k2 === undefined) k2 = k
+  Object.defineProperty(o, k2, {
+    enumerable: true,
+    get: function () {
+      return m[k]
+    }
+  })
+}
 
-const icons = require('./dist/cjs/react/icons/index.js')
-Object.keys(icons).forEach(key => (exports[key] = icons[key]))
+const __exportStar = function (m, exports) {
+  for (const p in m)
+    if (p !== 'default' && !exports.hasOwnProperty(p))
+      __createBinding(exports, m, p)
+}
+
+__exportStar(require('./dist/cjs/react/icons/index.js'), module.exports)
+
+const vars = require('./dist/cjs/vars/index.js')
+Object.keys(vars).forEach(key => __createBinding(module.exports, vars, key))

--- a/packages/searchinput/package.json
+++ b/packages/searchinput/package.json
@@ -7,6 +7,10 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "files": [
+    "react.d.ts",
+    "react.mjs",
+    "react.js",
+    "styles.css",
     "src/*",
     "dist/*",
     "!src/*/__stories__/*",
@@ -26,7 +30,8 @@
     "test:watch": "yarn test --watchAll"
   },
   "sideEffects": [
-    "**/*.css"
+    "**/*.css",
+    "src/index.ts"
   ],
   "style": "dist/esm/css/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/searchinput/react.d.ts
+++ b/packages/searchinput/react.d.ts
@@ -1,0 +1,9 @@
+import React from 'react'
+import { TextInputProps } from '@pluralsight/ps-design-system-textinput/react'
+export interface SearchInputProps extends TextInputProps {
+  loading?: boolean
+  onClear?: (evt?: React.MouseEvent) => void
+  onChange?: (evt: React.ChangeEvent<HTMLInputElement>) => void
+}
+declare const SearchInput: React.ForwardRefExoticComponent<SearchInputProps>
+export default SearchInput

--- a/packages/searchinput/react.js
+++ b/packages/searchinput/react.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/cjs/react/index.js')

--- a/packages/searchinput/react.mjs
+++ b/packages/searchinput/react.mjs
@@ -1,0 +1,3 @@
+import SearchInput from './dist/esm/react/index'
+
+export default SearchInput

--- a/packages/searchinput/src/react/index.tsx
+++ b/packages/searchinput/src/react/index.tsx
@@ -1,14 +1,12 @@
 import React from 'react'
 
-import Button from '@pluralsight/ps-design-system-button'
-import CircularProgress from '@pluralsight/ps-design-system-circularprogress'
-import { CloseIcon, SearchIcon } from '@pluralsight/ps-design-system-icon'
+import Button from '@pluralsight/ps-design-system-button/react'
+import CircularProgress from '@pluralsight/ps-design-system-circularprogress/react'
+import { CloseIcon, SearchIcon } from '@pluralsight/ps-design-system-icon/react'
 import TextInput, {
   TextInputProps
-} from '@pluralsight/ps-design-system-textinput'
+} from '@pluralsight/ps-design-system-textinput/react'
 import { RefFor, classNames } from '@pluralsight/ps-design-system-util'
-
-import '../css/index.css'
 
 export interface SearchInputProps extends TextInputProps {
   loading?: boolean

--- a/packages/searchinput/styles.css
+++ b/packages/searchinput/styles.css
@@ -3,6 +3,4 @@ import '@pluralsight/ps-design-system-circularprogress/styles.css'
 import '@pluralsight/ps-design-system-icon/styles.css'
 import '@pluralsight/ps-design-system-textinput/styles.css'
 
-import '../css/index.css'
-
-export { default } from './react/index'
+@import './dist/esm/css/index.css';

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -9,6 +9,10 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "files": [
+    "react.d.ts",
+    "react.mjs",
+    "react.js",
+    "styles.css",
     "src/*",
     "dist/*",
     "!src/*/__stories__/*",
@@ -25,7 +29,8 @@
     "test:watch": "yarn test --watchAll"
   },
   "sideEffects": [
-    "**/*.css"
+    "**/*.css",
+    "src/index.ts"
   ],
   "style": "dist/esm/css/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/textarea/react.d.ts
+++ b/packages/textarea/react.d.ts
@@ -1,0 +1,40 @@
+import {
+  ValueOf,
+  RefForwardingComponent
+} from '@pluralsight/ps-design-system-util'
+import React from 'react'
+import * as vars from './dist/esm/vars/index'
+export interface TextAreaStatics {
+  appearances: typeof vars.appearances
+}
+export interface TextAreaProps
+  extends Omit<
+    React.DetailedHTMLProps<
+      React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+      HTMLTextAreaElement
+    >,
+    'rows'
+  > {
+  appearance?: ValueOf<typeof vars.appearances>
+  disabled?: boolean
+  error?: boolean
+  label?: React.ReactNode
+  placeholder?: string
+  rows?: React.ReactText
+  subLabel?: React.ReactNode
+  value?: React.ReactText
+  name?: string
+}
+export interface TextAreaComponent
+  extends RefForwardingComponent<
+    TextAreaProps,
+    HTMLTextAreaElement,
+    TextAreaStatics
+  > {}
+declare const TextArea: TextAreaComponent
+export declare const appearances: Readonly<
+  import('@pluralsight/ps-design-system-util/dist/esm/key-mirror').KeyMirror<
+    ['default', 'subtle']
+  >
+>
+export default TextArea

--- a/packages/textarea/react.js
+++ b/packages/textarea/react.js
@@ -1,0 +1,4 @@
+module.exports = require('./dist/cjs/react/index.js')
+
+const vars = require('./dist/cjs/vars/index.js')
+Object.keys(vars).forEach(key => (exports[key] = vars[key]))

--- a/packages/textarea/react.mjs
+++ b/packages/textarea/react.mjs
@@ -1,0 +1,4 @@
+import TextArea from './dist/esm/react/index'
+
+export default TextArea
+export * from './dist/esm/vars/index'

--- a/packages/textarea/src/index.ts
+++ b/packages/textarea/src/index.ts
@@ -1,3 +1,8 @@
+import '@pluralsight/ps-design-system-halo/styles.css'
+import '@pluralsight/ps-design-system-icon/styles.css'
+
+import './css/index.css'
+
 export { default } from './react/index'
 
 export * from './vars/index'

--- a/packages/textarea/src/react/__stories__/index.story.tsx
+++ b/packages/textarea/src/react/__stories__/index.story.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions'
 import { Meta, Story } from '@storybook/react/types-6-0'
 import React from 'react'
 
-import TextArea from '../index'
+import TextArea from '../../index'
 
 export default {
   title: 'Components/TextArea',

--- a/packages/textarea/src/react/index.tsx
+++ b/packages/textarea/src/react/index.tsx
@@ -1,6 +1,6 @@
 import { layout, type } from '@pluralsight/ps-design-system-core'
-import Halo from '@pluralsight/ps-design-system-halo'
-import { WarningIcon } from '@pluralsight/ps-design-system-icon'
+import Halo from '@pluralsight/ps-design-system-halo/react'
+import { WarningIcon } from '@pluralsight/ps-design-system-icon/react'
 import {
   useTheme,
   names as themeNames
@@ -12,7 +12,6 @@ import {
 } from '@pluralsight/ps-design-system-util'
 import React from 'react'
 
-import '../css/index.css'
 import * as vars from '../vars/index'
 
 const calcRowsPxHeight = (rows: React.ReactText) => {

--- a/packages/textarea/styles.css
+++ b/packages/textarea/styles.css
@@ -1,0 +1,4 @@
+@import '@pluralsight/ps-design-system-halo/styles.css';
+@import '@pluralsight/ps-design-system-icon/styles.css';
+
+@import './dist/esm/css/index.css';

--- a/packages/textinput/package.json
+++ b/packages/textinput/package.json
@@ -9,6 +9,10 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "files": [
+    "react.d.ts",
+    "react.mjs",
+    "react.js",
+    "styles.css",
     "src/*",
     "dist/*",
     "!src/*/__stories__/*",
@@ -25,7 +29,8 @@
     "test:watch": "yarn test --watchAll"
   },
   "sideEffects": [
-    "**/*.css"
+    "**/*.css",
+    "src/index.ts"
   ],
   "style": "dist/esm/css/index.css",
   "types": "dist/esm/index.d.ts",

--- a/packages/textinput/react.d.ts
+++ b/packages/textinput/react.d.ts
@@ -1,0 +1,6 @@
+export {
+  default,
+  TextInputStatics,
+  TextInputProps
+} from './dist/esm/react/index'
+export * from './dist/esm/vars/index'

--- a/packages/textinput/react.js
+++ b/packages/textinput/react.js
@@ -1,0 +1,4 @@
+module.exports = require('./dist/cjs/react/index.js')
+
+const vars = require('./dist/cjs/vars/index.js')
+Object.keys(vars).forEach(key => (exports[key] = vars[key]))

--- a/packages/textinput/react.mjs
+++ b/packages/textinput/react.mjs
@@ -1,0 +1,4 @@
+import TextInput from './dist/esm/react/index'
+
+export default TextInput
+export * from './dist/esm/vars/index'

--- a/packages/textinput/src/index.ts
+++ b/packages/textinput/src/index.ts
@@ -1,2 +1,8 @@
-export { default, TextInputProps } from './react/index'
+import '@pluralsight/ps-design-system-halo/styles.css'
+import '@pluralsight/ps-design-system-icon/styles.css'
+
+import './css/index.css'
+import TextInput from './react/index'
+
+export default TextInput
 export * from './vars/index'

--- a/packages/textinput/src/react/__stories__/examples.story.tsx
+++ b/packages/textinput/src/react/__stories__/examples.story.tsx
@@ -11,7 +11,7 @@ import React, {
   useState
 } from 'react'
 
-import TextInput from '..'
+import TextInput from '../../index'
 
 const PaddingDecorator: DecoratorFn = storyFn => (
   <div style={{ height: '100vh', padding: layout.spacingLarge }}>

--- a/packages/textinput/src/react/__stories__/index.story.tsx
+++ b/packages/textinput/src/react/__stories__/index.story.tsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions'
 import { Meta, Story } from '@storybook/react/types-6-0'
 import React from 'react'
 
-import TextInput from '../index'
+import TextInput from '../../index'
 
 const defaultArgs = {
   onFocus: action('on focus'),

--- a/packages/textinput/src/react/index.tsx
+++ b/packages/textinput/src/react/index.tsx
@@ -1,5 +1,5 @@
-import Halo from '@pluralsight/ps-design-system-halo'
-import { WarningIcon } from '@pluralsight/ps-design-system-icon'
+import Halo from '@pluralsight/ps-design-system-halo/react'
+import { WarningIcon } from '@pluralsight/ps-design-system-icon/react'
 import {
   useTheme,
   names as themeNames
@@ -11,7 +11,6 @@ import {
 } from '@pluralsight/ps-design-system-util'
 import React from 'react'
 
-import '../css/index.css'
 import * as vars from '../vars/index'
 
 const styles = {

--- a/packages/textinput/styles.css
+++ b/packages/textinput/styles.css
@@ -1,0 +1,4 @@
+@import '@pluralsight/ps-design-system-halo/styles.css';
+@import '@pluralsight/ps-design-system-icon/styles.css';
+
+@import './dist/esm/css/index.css';


### PR DESCRIPTION
Contributes to #1950 

Found that the named exports were being overwritten in Icon. Icon imports when rendering now work. Learned some hard lessons about CJS modules. Don't set `exports.x` and then `module.exports`. It will overwrite what you can import from that module, but the `exports` object looks fine w/in the module.

Went back and completed the react.d.ts definitions for a couple elements and the new ones in this set. This includes dist/esm/react/index.d.ts content, which is completes what was there in the first couple.