### PR TITLE
Accessibility section in docs

### DIFF
--- a/docs/src/components/mdx/index.tsx
+++ b/docs/src/components/mdx/index.tsx
@@ -28,7 +28,6 @@ const components = {
   Button,
   blockquote: BlockQuote,
   CheckCircleFillIcon,
-  WarningFilledIcon,
   code: CodeBlock,
   Guideline,
   h1: H1,
@@ -44,7 +43,8 @@ const components = {
   TypesProp: Types.Prop,
   TypesEnum: Types.Enum,
   ul: Ul,
-  Usage
+  Usage,
+  WarningFilledIcon
 }
 
 export const MDXProvider: React.FC = props => (

--- a/docs/src/components/mdx/index.tsx
+++ b/docs/src/components/mdx/index.tsx
@@ -1,5 +1,7 @@
 import { MDXProvider as BaseProvider } from '@mdx-js/react'
+import Button from '@pluralsight/ps-design-system-button'
 import Badge from '@pluralsight/ps-design-system-badge'
+import { CheckCircleFillIcon, ExternalLinkIcon } from '@pluralsight/ps-design-system-icon'
 import * as Text from '@pluralsight/ps-design-system-text'
 import React from 'react'
 
@@ -20,8 +22,11 @@ const components = {
   a: A,
   A,
   Badge,
+  Button,
   blockquote: BlockQuote,
+  CheckCircleFillIcon,
   code: CodeBlock,
+  ExternalLinkIcon,
   Guideline,
   h1: H1,
   h2: H2,

--- a/docs/src/components/mdx/index.tsx
+++ b/docs/src/components/mdx/index.tsx
@@ -1,7 +1,10 @@
 import { MDXProvider as BaseProvider } from '@mdx-js/react'
 import Button from '@pluralsight/ps-design-system-button'
 import Badge from '@pluralsight/ps-design-system-badge'
-import { CheckCircleFillIcon, ExternalLinkIcon } from '@pluralsight/ps-design-system-icon'
+import {
+  CheckCircleFillIcon,
+  WarningFilledIcon
+} from '@pluralsight/ps-design-system-icon'
 import * as Text from '@pluralsight/ps-design-system-text'
 import React from 'react'
 
@@ -25,8 +28,8 @@ const components = {
   Button,
   blockquote: BlockQuote,
   CheckCircleFillIcon,
+  WarningFilledIcon,
   code: CodeBlock,
-  ExternalLinkIcon,
   Guideline,
   h1: H1,
   h2: H2,

--- a/docs/src/components/usage.module.css
+++ b/docs/src/components/usage.module.css
@@ -1,3 +1,12 @@
+.links {
+  margin: var(--ps-layout-spacing-xlarge) 0 var(--ps-layout-spacing-large) 0;
+  list-style: none;
+}
+.links li {
+  display: inline;
+  margin-right: var(--ps-layout-spacing-small);
+}
+
 .usage {
   margin: 0 0 var(--ps-layout-spacing-xlarge) 0;
   list-style: none;
@@ -6,15 +15,16 @@
 }
 .item {
   display: flex;
-  margin-bottom: var(--ps-layout-spacing-medium);
+  margin-bottom: var(--ps-layout-spacing-xsmall);
   white-space: pre-wrap;
 }
 .label {
   font-size: var(--ps-type-font-size-xsmall);
-  width: 80px;
+  width: 48px;
   color: var(--app-colors-text-icon-low);
 }
 .value {
   font-family: var(--ps-type-font-family-code);
+  font-size: var(--ps-type-font-size-xsmall);
   color: var(--app-colors-text-icon-high);
 }

--- a/docs/src/components/usage.tsx
+++ b/docs/src/components/usage.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import { A } from './mdx/links'
 import Button from '@pluralsight/ps-design-system-button'
 import {
   SocialGithubIcon,
@@ -51,6 +50,17 @@ export const Usage: React.FC<UsageProps> = props => {
             icon={<ExternalLinkIcon />}
           >
             NPM
+          </Button>
+        </li>
+        <li>
+          <Button
+            appearance="secondary"
+            href={`https://bundlephobia.com/package/@pluralsight/ps-design-system-${props.packageName}`}
+            target="_blank"
+            size="small"
+            icon={<ExternalLinkIcon />}
+          >
+            Bundle size
           </Button>
         </li>
         <li>

--- a/docs/src/components/usage.tsx
+++ b/docs/src/components/usage.tsx
@@ -24,6 +24,7 @@ export const Usage: React.FC<UsageProps> = props => {
             appearance="secondary"
             href={`https://github.com/pluralsight/design-system/blob/master/packages/${props.packageName}`}
             target="_blank"
+            rel="noreferrer"
             size="small"
             icon={<SocialGithubIcon />}
           >
@@ -35,6 +36,7 @@ export const Usage: React.FC<UsageProps> = props => {
             appearance="secondary"
             href={`https://github.com/pluralsight/design-system/blob/master/packages/${props.packageName}/CHANGELOG.md`}
             target="_blank"
+            rel="noreferrer"
             size="small"
             icon={<ListIcon />}
           >
@@ -46,6 +48,7 @@ export const Usage: React.FC<UsageProps> = props => {
             appearance="secondary"
             href={`https://bundlephobia.com/package/@pluralsight/ps-design-system-${props.packageName}`}
             target="_blank"
+            rel="noreferrer"
             size="small"
             icon={<ExternalLinkIcon />}
           >
@@ -57,6 +60,7 @@ export const Usage: React.FC<UsageProps> = props => {
             appearance="secondary"
             href={`${props.figmaUrl}`}
             target="_blank"
+            rel="noreferrer"
             size="small"
             icon={
               <Icon>

--- a/docs/src/components/usage.tsx
+++ b/docs/src/components/usage.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import Button from '@pluralsight/ps-design-system-button'
-import {
+import Icon, {
   SocialGithubIcon,
   ExternalLinkIcon,
   ListIcon
@@ -44,17 +44,6 @@ export const Usage: React.FC<UsageProps> = props => {
         <li>
           <Button
             appearance="secondary"
-            href={`https://www.npmjs.com/package/@pluralsight/ps-design-system-${props.packageName}`}
-            target="_blank"
-            size="small"
-            icon={<ExternalLinkIcon />}
-          >
-            NPM
-          </Button>
-        </li>
-        <li>
-          <Button
-            appearance="secondary"
             href={`https://bundlephobia.com/package/@pluralsight/ps-design-system-${props.packageName}`}
             target="_blank"
             size="small"
@@ -69,7 +58,17 @@ export const Usage: React.FC<UsageProps> = props => {
             href={`${props.figmaUrl}`}
             target="_blank"
             size="small"
-            icon={<ExternalLinkIcon />}
+            icon={
+              <Icon>
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    fillRule="evenodd"
+                    clipRule="evenodd"
+                    d="M4.25 5.5C4.25 3.15279 6.15279 1.25 8.5 1.25H15.5C17.8472 1.25 19.75 3.15279 19.75 5.5C19.75 6.95165 19.0222 8.23331 17.9116 9C19.0222 9.7667 19.75 11.0484 19.75 12.5C19.75 14.8472 17.8472 16.75 15.5 16.75C14.4512 16.75 13.4912 16.3701 12.75 15.7405V19.5C12.75 21.8472 10.8472 23.75 8.5 23.75C6.15279 23.75 4.25 21.8472 4.25 19.5C4.25 18.0484 4.97779 16.7667 6.0884 16C4.97779 15.2333 4.25 13.9516 4.25 12.5C4.25 11.0484 4.97779 9.7667 6.0884 9C4.97779 8.2333 4.25 6.95164 4.25 5.5ZM8.5 15.25H11.25V9.75H8.5C6.98122 9.75 5.75 10.9812 5.75 12.5C5.75 14.0188 6.98122 15.25 8.5 15.25ZM11.25 16.75H8.5C6.98122 16.75 5.75 17.9812 5.75 19.5C5.75 21.0188 6.98122 22.25 8.5 22.25C10.0188 22.25 11.25 21.0188 11.25 19.5V16.75ZM18.25 5.5C18.25 7.01878 17.0188 8.25 15.5 8.25H12.75V2.75H15.5C17.0188 2.75 18.25 3.98122 18.25 5.5ZM15.5 9.75C13.9812 9.75 12.75 10.9812 12.75 12.5C12.75 14.0188 13.9812 15.25 15.5 15.25C17.0188 15.25 18.25 14.0188 18.25 12.5C18.25 10.9812 17.0188 9.75 15.5 9.75ZM8.5 8.25H11.25V2.75H8.5C6.98122 2.75 5.75 3.98122 5.75 5.5C5.75 7.01878 6.98122 8.25 8.5 8.25Z"
+                  />
+                </svg>
+              </Icon>
+            }
           >
             Figma
           </Button>

--- a/docs/src/components/usage.tsx
+++ b/docs/src/components/usage.tsx
@@ -1,9 +1,16 @@
 import React from 'react'
 
 import { A } from './mdx/links'
+import Button from '@pluralsight/ps-design-system-button'
+import {
+  SocialGithubIcon,
+  ExternalLinkIcon,
+  ListIcon
+} from '@pluralsight/ps-design-system-icon'
 import * as styles from './usage.module.css'
 
 interface UsageProps {
+  figmaUrl: string
   install: string
   import: string
   packageName: string
@@ -11,17 +18,58 @@ interface UsageProps {
 }
 export const Usage: React.FC<UsageProps> = props => {
   return (
-    <ul className={styles.usage}>
-      <Item label="Version">
-        <A
-          href={`https://github.com/pluralsight/design-system/blob/master/packages/${props.packageName}/CHANGELOG.md`}
-        >
-          {props.version || 'CHANGELOG'}
-        </A>
-      </Item>
-      <Item label="Install">{props.install.trim()}</Item>
-      <Item label="Import">{props.import.trim()}</Item>
-    </ul>
+    <>
+      <ul className={styles.links}>
+        <li>
+          <Button
+            appearance="secondary"
+            href={`https://github.com/pluralsight/design-system/blob/master/packages/${props.packageName}`}
+            target="_blank"
+            size="small"
+            icon={<SocialGithubIcon />}
+          >
+            Source
+          </Button>
+        </li>
+        <li>
+          <Button
+            appearance="secondary"
+            href={`https://github.com/pluralsight/design-system/blob/master/packages/${props.packageName}/CHANGELOG.md`}
+            target="_blank"
+            size="small"
+            icon={<ListIcon />}
+          >
+            Changelog
+          </Button>
+        </li>
+        <li>
+          <Button
+            appearance="secondary"
+            href={`https://www.npmjs.com/package/@pluralsight/ps-design-system-${props.packageName}`}
+            target="_blank"
+            size="small"
+            icon={<ExternalLinkIcon />}
+          >
+            NPM
+          </Button>
+        </li>
+        <li>
+          <Button
+            appearance="secondary"
+            href={`${props.figmaUrl}`}
+            target="_blank"
+            size="small"
+            icon={<ExternalLinkIcon />}
+          >
+            Figma
+          </Button>
+        </li>
+      </ul>
+      <ul className={styles.usage}>
+        <Item label="Install">{props.install.trim()}</Item>
+        <Item label="Import">{props.import.trim()}</Item>
+      </ul>
+    </>
   )
 }
 

--- a/docs/src/content/components/dropdown.mdx
+++ b/docs/src/content/components/dropdown.mdx
@@ -386,7 +386,7 @@ export default Example
 <CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests. <br />
 <WarningFilledIcon color="red" size="xSmall" /> No manual audit.
 
-Adheres to the WAI-ARIA <A href="https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox" target="_blank">Listbox</A> pattern.
+Adheres to the WAI-ARIA <A href="https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox" target="_blank" rel="noreferrer">Listbox</A> pattern.
 
 ## Props
 

--- a/docs/src/content/components/dropdown.mdx
+++ b/docs/src/content/components/dropdown.mdx
@@ -359,6 +359,24 @@ function Example() {
 export default Example
 ```
 
+## Accessibility summary
+
+### WCAG 2.1 AA
+
+<CheckCircleFillIcon color="green" /> 100% axe-core tests
+
+Last manual audit Jun 14, 2021
+
+### ARIA roles
+
+<Button href="https://jaketrent.com" iconAlign="right" icon={<ExternalLinkIcon />} appearance="secondary">menu (default)</Button>
+
+### Accessibility notes
+
+List additional details.
+
+Keep it terse.
+
 ## Usage & Types
 
 <Usage

--- a/docs/src/content/components/dropdown.mdx
+++ b/docs/src/content/components/dropdown.mdx
@@ -66,7 +66,7 @@ function Example() {
 export default Example
 ```
 
-### Label & Sublabels
+### Label
 
 Primary identification of a dropdown comes through the label. Usage hints are given in the placeholder. Supporting text and error messaging is set in the subLabel.
 
@@ -381,7 +381,7 @@ export default Example
 
 ## Accessibility
 
-**WCAG 2.1 AA Partial Compliance**
+**Partially WCAG 2.1 AA Compliant**
 
 <CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests. <br />
 <WarningFilledIcon color="red" size="xSmall" /> No manual audit.

--- a/docs/src/content/components/dropdown.mdx
+++ b/docs/src/content/components/dropdown.mdx
@@ -7,6 +7,16 @@ import Dropdown from '@pluralsight/ps-design-system-dropdown'
 
 # Dropdown
 
+<Intro>A form input for making a single selection from a list of items.</Intro>
+
+<Usage
+  figmaUrl="https://www.figma.com/file/YsTklBecdddy9RZ3HXddIseD/?node-id=10235%3A29996"
+  install="npm install @pluralsight/ps-design-system-dropdown"
+  import="import Dropdown from '@pluralsight/ps-design-system-dropdown'"
+  packageName="dropdown"
+  version={props.version}
+/>
+
 <TableOfContents {...props} />
 
 ## Examples
@@ -16,7 +26,6 @@ import Dropdown from '@pluralsight/ps-design-system-dropdown'
 ```typescript
 import React from 'react'
 import ActionMenu from '@pluralsight/ps-design-system-dropdown'
-import Dropdown from '@pluralsight/ps-design-system-dropdown'
 import Button from '@pluralsight/ps-design-system-button'
 import { layout } from '@pluralsight/ps-design-system-core'
 
@@ -29,7 +38,6 @@ function Example() {
   const [value, setValue] = React.useState(options[1].value)
   return (
     <div className="example-flex-column">
-      <Button onClick={() => setValue('beg')}>Set Beginner</Button>
       <Dropdown
         label="Level"
         placeholder="Select"
@@ -42,6 +50,15 @@ function Example() {
         value={value}
       />
       <div>Selected: {value}</div>
+      <div>
+        <Button
+          appearance="secondary"
+          size="xSmall"
+          onClick={() => setValue('beg')}
+        >
+          Set Beginner
+        </Button>
+      </div>
     </div>
   )
 }
@@ -49,7 +66,7 @@ function Example() {
 export default Example
 ```
 
-### Label
+### Label & Sublabels
 
 Primary identification of a dropdown comes through the label. Usage hints are given in the placeholder. Supporting text and error messaging is set in the subLabel.
 
@@ -103,7 +120,7 @@ const Comp = () => (
 export default Comp
 ```
 
-### Smaller dropdowns in tables
+### Sizes
 
 For table rows, step down to the `small` size.
 
@@ -181,42 +198,6 @@ const Comp = () => (
 export default Comp
 ```
 
-### Menu scrolling
-
-The dropdown component menu has a max height of 400px and will scroll for content needing more vertical space.
-
-```typescript
-import React from 'react'
-import Dropdown from '@pluralsight/ps-design-system-dropdown'
-
-const Example = () => (
-  <Dropdown
-    label="Max height example"
-    menu={
-       <>
-          <Dropdown.Item>One item</Dropdown.Item>
-          <Dropdown.Item>Two item</Dropdown.Item>
-          <Dropdown.Item>Three item</Dropdown.Item>
-          <Dropdown.Item>Four item</Dropdown.Item>
-          <Dropdown.Item>Five item</Dropdown.Item>
-          <Dropdown.Item>Six item</Dropdown.Item>
-          <Dropdown.Item>Seven item</Dropdown.Item>
-          <Dropdown.Item>Eight item</Dropdown.Item>
-          <Dropdown.Item>Nine item</Dropdown.Item>
-          <Dropdown.Item>Ten item</Dropdown.Item>
-          <Dropdown.Item>Eleven item</Dropdown.Item>
-          <Dropdown.Item>Twelve item</Dropdown.Item>
-          <Dropdown.Item>Thirteen item</Dropdown.Item>
-          <Dropdown.Item>Fourteen item</Dropdown.Item>
-          <Dropdown.Item>Fifteen item</Dropdown.Item>
-        </>
-    }
-  />
-)
-
-export default Example
-```
-
 ### Customizing with icon
 
 ```typescript
@@ -229,31 +210,32 @@ interface DropdownWithIconProps extends HTMLAttributes<HTMLButtonElement> {
   menu: React.ReactNode
 }
 
-const DropdownWithIcon = React.forwardRef<HTMLButtonElement, DropdownWithIconProps>(
-  ({ icon, ...props }, forwardedRef) => {
-    const allProps = useDropdown(props, forwardedRef)
-    return (
-      <Dropdown.Layout
-        {...allProps.layout}
-        label={<Dropdown.Label {...allProps.label} />}
-        menu={
-          <DropdownContext.Provider {...allProps.value}>
-            <Dropdown.Menu {...allProps.menu} />
-          </DropdownContext.Provider>
-        }
-        subLabel={<Dropdown.SubLabel {...allProps.subLabel} />}
-        button={
-          <Dropdown.Button {...allProps.button}>
-            {icon}
-            <div style={{ height: '100%', position: 'relative', flex: 1 }}>
-              <Dropdown.Selected {...allProps.selected} />
-            </div>
-          </Dropdown.Button>
-        }
-      />
-    )
-  }
-)
+const DropdownWithIcon = React.forwardRef<
+  HTMLButtonElement,
+  DropdownWithIconProps
+>(({ icon, ...props }, forwardedRef) => {
+  const allProps = useDropdown(props, forwardedRef)
+  return (
+    <Dropdown.Layout
+      {...allProps.layout}
+      label={<Dropdown.Label {...allProps.label} />}
+      menu={
+        <DropdownContext.Provider {...allProps.value}>
+          <Dropdown.Menu {...allProps.menu} />
+        </DropdownContext.Provider>
+      }
+      subLabel={<Dropdown.SubLabel {...allProps.subLabel} />}
+      button={
+        <Dropdown.Button {...allProps.button}>
+          {icon}
+          <div style={{ height: '100%', position: 'relative', flex: 1 }}>
+            <Dropdown.Selected {...allProps.selected} />
+          </div>
+        </Dropdown.Button>
+      }
+    />
+  )
+})
 function Example() {
   return (
     <DropdownWithIcon
@@ -281,39 +263,41 @@ import React, { HTMLAttributes } from 'react'
 import Dropdown, { useDropdown } from '@pluralsight/ps-design-system-dropdown'
 import { CalendarIcon } from '@pluralsight/ps-design-system-icon'
 
-interface DropdownWithIconProps extends Omit<HTMLAttributes<HTMLButtonElement>, 'onChange'> {
+interface DropdownWithIconProps
+  extends Omit<HTMLAttributes<HTMLButtonElement>, 'onChange'> {
   icon: React.ReactNode
   onChange?: (e: React.MouseEvent, value: React.ReactText) => void
   menu: React.ReactNode
 }
 
-const DropdownWithIcon = React.forwardRef<HTMLButtonElement, DropdownWithIconProps>(
-  ({ icon, ...props }, forwardedRef) => {
-    const allProps = useDropdown(props, forwardedRef)
-    return (
-      <Dropdown.Layout
-        {...allProps.layout}
-        label={<Dropdown.Label {...allProps.label} />}
-        menu={
-          <DropdownContext.Provider {...allProps.value}>
-            <Dropdown.Menu {...allProps.menu} />
-          </DropdownContext.Provider>
-        }
-        subLabel={<Dropdown.SubLabel {...allProps.subLabel} />}
-        button={
-          <Dropdown.Button {...allProps.button}>
-            {icon}
-            <div style={{ height: '100%', position: 'relative', flex: 1 }}>
-              <Dropdown.Selected {...allProps.selected} />
-            </div>
-          </Dropdown.Button>
-        }
-      />
-    )
-  }
-)
+const DropdownWithIcon = React.forwardRef<
+  HTMLButtonElement,
+  DropdownWithIconProps
+>(({ icon, ...props }, forwardedRef) => {
+  const allProps = useDropdown(props, forwardedRef)
+  return (
+    <Dropdown.Layout
+      {...allProps.layout}
+      label={<Dropdown.Label {...allProps.label} />}
+      menu={
+        <DropdownContext.Provider {...allProps.value}>
+          <Dropdown.Menu {...allProps.menu} />
+        </DropdownContext.Provider>
+      }
+      subLabel={<Dropdown.SubLabel {...allProps.subLabel} />}
+      button={
+        <Dropdown.Button {...allProps.button}>
+          {icon}
+          <div style={{ height: '100%', position: 'relative', flex: 1 }}>
+            <Dropdown.Selected {...allProps.selected} />
+          </div>
+        </Dropdown.Button>
+      }
+    />
+  )
+})
 function Example() {
-  const [selected, setSelected] = React.useState<null| string>()
+  const [selected, setSelected] = React.useState<null | string>()
   const values = {
     channel: {
       value: 'channel',
@@ -359,32 +343,52 @@ function Example() {
 export default Example
 ```
 
-## Accessibility summary
+### Menu scrolling
 
-### WCAG 2.1 AA
+The dropdown component menu has a max height of 400px and will scroll for content needing more vertical space.
 
-<CheckCircleFillIcon color="green" /> 100% axe-core tests
+```typescript
+import React from 'react'
+import Dropdown from '@pluralsight/ps-design-system-dropdown'
 
-Last manual audit Jun 14, 2021
+const Example = () => (
+  <Dropdown
+    label="Max height example"
+    menu={
+      <>
+        <Dropdown.Item>One item</Dropdown.Item>
+        <Dropdown.Item>Two item</Dropdown.Item>
+        <Dropdown.Item>Three item</Dropdown.Item>
+        <Dropdown.Item>Four item</Dropdown.Item>
+        <Dropdown.Item>Five item</Dropdown.Item>
+        <Dropdown.Item>Six item</Dropdown.Item>
+        <Dropdown.Item>Seven item</Dropdown.Item>
+        <Dropdown.Item>Eight item</Dropdown.Item>
+        <Dropdown.Item>Nine item</Dropdown.Item>
+        <Dropdown.Item>Ten item</Dropdown.Item>
+        <Dropdown.Item>Eleven item</Dropdown.Item>
+        <Dropdown.Item>Twelve item</Dropdown.Item>
+        <Dropdown.Item>Thirteen item</Dropdown.Item>
+        <Dropdown.Item>Fourteen item</Dropdown.Item>
+        <Dropdown.Item>Fifteen item</Dropdown.Item>
+      </>
+    }
+  />
+)
 
-### ARIA roles
+export default Example
+```
 
-<Button href="https://jaketrent.com" iconAlign="right" icon={<ExternalLinkIcon />} appearance="secondary">menu (default)</Button>
+## Accessibility
 
-### Accessibility notes
+**WCAG 2.1 AA Partial Compliance**
 
-List additional details.
+<CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests. <br />
+<WarningFilledIcon color="red" size="xSmall" /> No manual audit.
 
-Keep it terse.
+Adheres to the WAI-ARIA <A href="https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox" target="_blank">Listbox</A> pattern.
 
-## Usage & Types
-
-<Usage
-  install="npm install @pluralsight/ps-design-system-dropdown"
-  import="import Dropdown from '@pluralsight/ps-design-system-dropdown'"
-  packageName="dropdown"
-  version={props.version}
-/>
+## Props
 
 ### Dropdown
 


### PR DESCRIPTION
Brian, as I looked at this, I thought that the a11y module design I had made and what is accomplishable just with markdown were so close that I'd lean on the latter for the moment and see what we thought.

I think it's a fine experience. 

Two big reasons I like it: 1) It avoids having to deal with the API for a summary module. 2) Not having a set API allows for one-off descriptions of a11y as needed per component.

There are two commits. The first with the MDX capability. The second, giving an example on the Dropdown page. If I was you, and you end up liking this approach, I'd just copy the first commit into my own branch, ignore the 2nd commit and then close this PR when you're well on your way.

This is what it looks like rendered:
<img width="632" alt="Screen Shot 2021-08-30 at 2 49 27 PM" src="https://user-images.githubusercontent.com/552044/131404006-7cfca84f-bc39-4c4f-a7aa-6be6a2ca67cd.png">
