### PR TITLE
Docs a11y - Content Display & Feedback pages

### DIFF
--- a/docs/src/content/components/avatar.mdx
+++ b/docs/src/content/components/avatar.mdx
@@ -9,6 +9,16 @@ import Avatar from '@pluralsight/ps-design-system-avatar'
 
 <TableOfContents {...props} />
 
+<Intro>An avatar is a thumbnail representation of a user or an organization.</Intro>
+
+<Usage
+  figmaUrl="https://www.figma.com/file/YsTklBecdddy9RZ3HXddIseD/?node-id=10235%3A29929"
+  install="npm install @pluralsight/ps-design-system-avatar"
+  import="import Avatar from '@pluralsight/ps-design-system-avatar'"
+  packageName="avatar"
+  version={props.version}
+/>
+
 ## Examples
 
 ### Sizes
@@ -82,14 +92,15 @@ function Example() {
 export default Example
 ```
 
-## Usage & Types
+## Accessibility
 
-<Usage
-  install="npm install @pluralsight/ps-design-system-avatar"
-  import="import Avatar from '@pluralsight/ps-design-system-avatar'"
-  packageName="avatar"
-  version={props.version}
-/>
+**WCAG 2.1 AA Compliance**
+
+<CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests
+<br />
+<WarningFilledIcon color="red" size="xSmall" /> Manual audit
+
+## Props
 
 <TypesTable>
   <TypesProp

--- a/docs/src/content/components/badge.mdx
+++ b/docs/src/content/components/badge.mdx
@@ -7,9 +7,19 @@ import Badge from '@pluralsight/ps-design-system-badge'
 
 # Badge
 
-## Examples
-
 <TableOfContents {...props} />
+
+<Intro>Badges are for showing a small amount of color-categorized metadata. They're ideal for getting a user's attention.</Intro>
+
+<Usage
+  figmaUrl="https://www.figma.com/file/YsTklBecdddy9RZ3HXddIseD/?node-id=10241%3A5"
+  install="npm install @pluralsight/ps-design-system-badge"
+  import="import Badge from '@pluralsight/ps-design-system-badge'"
+  packageName="badge"
+  version={props.version}
+/>
+
+## Examples
 
 ### Color
 
@@ -49,14 +59,15 @@ function Example() {
 export default Example
 ```
 
-## Usage & Types
+## Accessibility
 
-<Usage
-  install="npm install @pluralsight/ps-design-system-badge"
-  import="import Badge from '@pluralsight/ps-design-system-badge'"
-  packageName="badge"
-  version={props.version}
-/>
+**WCAG 2.1 AA Compliance**
+
+<CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests
+<br />
+<WarningFilledIcon color="red" size="xSmall" /> Manual audit
+
+## Props
 
 <TypesTable>
   <TypesProp

--- a/docs/src/content/components/banner.mdx
+++ b/docs/src/content/components/banner.mdx
@@ -7,11 +7,19 @@ import Banner from '@pluralsight/ps-design-system-banner'
 
 # Banner
 
-## Examples
-
 <TableOfContents {...props} />
 
-### Color
+<Intro>Banners show pressing and high-signal messages, such as system alerts. They are meant to be noticed and prompt users to take action.</Intro>
+
+<Usage
+  figmaUrl="https://www.figma.com/file/YsTklBecdddy9RZ3HXddIseD/?node-id=10235%3A29931"
+  install="npm install @pluralsight/ps-design-system-banner"
+  import="import Banner from '@pluralsight/ps-design-system-banner'"
+  packageName="banner"
+  version={props.version}
+/>
+
+## Examples
 
 Banners come in 4 colors. Banner colors change based on message displayed.
 
@@ -33,14 +41,15 @@ function Example() {
 export default Example
 ```
 
-## Usage & Types
+## Accessibility
 
-<Usage
-  install="npm install @pluralsight/ps-design-system-banner"
-  import="import Banner from '@pluralsight/ps-design-system-banner'"
-  packageName="banner"
-  version={props.version}
-/>
+**WCAG 2.1 AA Compliance**
+
+<CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests
+<br />
+<WarningFilledIcon color="red" size="xSmall" /> Manual audit
+
+## Props
 
 ### Banner
 

--- a/docs/src/content/components/card.mdx
+++ b/docs/src/content/components/card.mdx
@@ -9,6 +9,16 @@ import Card from '@pluralsight/ps-design-system-card'
 
 <TableOfContents {...props} />
 
+<Intro>A card is a summary representation of a piece of content and typically is used in a horizontal row or grid of related content.</Intro>
+
+<Usage
+  figmaUrl="https://www.figma.com/file/YsTklBecdddy9RZ3HXddIseD/?node-id=10235%3A29844"
+  install="npm install @pluralsight/ps-design-system-card"
+  import="import Avatar from '@pluralsight/ps-design-system-card'"
+  packageName="card"
+  version={props.version}
+/>
+
 ## Examples
 
 ### In-app example
@@ -435,14 +445,15 @@ function Example() {
 export default Example
 ```
 
-## Usage & Types
+## Accessibility
 
-<Usage
-  install="npm install @pluralsight/ps-design-system-card"
-  import="import Avatar from '@pluralsight/ps-design-system-card'"
-  packageName="card"
-  version={props.version}
-/>
+**WCAG 2.1 AA Compliance**
+
+<CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests
+<br />
+<WarningFilledIcon color="red" size="xSmall" /> Manual audit
+
+## Props
 
 ### Card
 

--- a/docs/src/content/components/carousel.mdx
+++ b/docs/src/content/components/carousel.mdx
@@ -12,12 +12,20 @@ import { MockItem } from '../../components/carousel'
 
 # Carousel
 
+<TableOfContents {...props} />
+
 <Intro>
   Carousels are for displaying a related set of content items in a row. Items
   can be paged using the next/previous buttons or by a swipe gesture.
 </Intro>
 
-<TableOfContents {...props} />
+<Usage
+  figmaUrl="https://www.figma.com/file/YsTklBecdddy9RZ3HXddIseD/?node-id=10235%3A30030"
+  install="npm install @pluralsight/ps-design-system-carousel"
+  import="import Carousel from '@pluralsight/ps-design-system-carousel'"
+  packageName="carousel"
+  version={props.version}
+/>
 
 ## Examples
 
@@ -418,14 +426,16 @@ The height of the carousel adapts to the height of the content it contains, but 
   }
 />
 
-## Usage & types
+## Accessibility
 
-<Usage
-  install="npm install @pluralsight/ps-design-system-carousel"
-  import="import Carousel from '@pluralsight/ps-design-system-carousel'"
-  packageName="carousel"
-  version={props.version}
-/>
+**WCAG 2.1 AA Compliance**
+
+<CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests<br />
+<WarningFilledIcon color="red" size="xSmall" /> Manual audit
+
+WAI-ARIA Patterns: <A href="https://www.w3.org/TR/wai-aria-practices-1.2/#carousel" target="_blank" rel="noreferrer">Carousel</A>
+
+## Props
 
 ### Carousel
 

--- a/docs/src/content/components/datawell.mdx
+++ b/docs/src/content/components/datawell.mdx
@@ -9,6 +9,16 @@ import DataWell from '@pluralsight/ps-design-system-datawell'
 
 <TableOfContents {...props} />
 
+<Intro>Data well is for displaying a large numeric value with supporting labels.</Intro>
+
+<Usage
+  figmaUrl="https://www.figma.com/file/YsTklBecdddy9RZ3HXddIseD/?node-id=10235%3A29840"
+  install="npm install @pluralsight/ps-design-system-datawell"
+  import="import DataWell from '@pluralsight/ps-design-system-datawell'"
+  packageName="datawell"
+  version={props.version}
+/>
+
 ## Examples
 
 ### Labels
@@ -56,14 +66,14 @@ Keep labels, sublabels, and values short as possible.
   }
 />
 
-## Usage & types
+## Accessibility
 
-<Usage
-  install="npm install @pluralsight/ps-design-system-datawell"
-  import="import DataWell from '@pluralsight/ps-design-system-datawell'"
-  packageName="datawell"
-  version={props.version}
-/>
+**WCAG 2.1 AA Compliance**
+
+<CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests<br />
+<WarningFilledIcon color="red" size="xSmall" /> Manual audit
+
+## Props
 
 <TypesTable>
   <TypesProp

--- a/docs/src/content/components/icon.mdx
+++ b/docs/src/content/components/icon.mdx
@@ -10,6 +10,14 @@ import IconCommonSet from './icon-common-set'
 
 <TableOfContents {...props} />
 
+<Usage
+  figmaUrl="https://www.figma.com/file/HVFUT0XlrkfsTMde6PMWLITj/PSDS---Icons"
+  install="npm install @pluralsight/ps-design-system-icon"
+  import="import Icon from '@pluralsight/ps-design-system-icon'"
+  packageName="icon"
+  version={props.version}
+/>
+
 ## Examples
 
 ### Size
@@ -143,15 +151,14 @@ const Comp = () => (
 
 export default Comp
 ```
+## Accessibility
 
-## Usage & Types
+**WCAG 2.1 AA Compliance**
 
-<Usage
-  install="npm install @pluralsight/ps-design-system-icon"
-  import="import Icon from '@pluralsight/ps-design-system-icon'"
-  packageName="icon"
-  version={props.version}
-/>
+<CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests<br />
+<WarningFilledIcon color="red" size="xSmall" /> Manual audit
+
+## Props
 
 <TypesTable>
   <TypesProp

--- a/docs/src/content/components/note.mdx
+++ b/docs/src/content/components/note.mdx
@@ -7,12 +7,20 @@ import Note from '@pluralsight/ps-design-system-theme'
 
 # Note
 
+<TableOfContents {...props} />
+
 <Intro>
   Use the note component for conversational elements. A note may have an author,
   metadata and available actions.
 </Intro>
 
-<TableOfContents {...props} />
+<Usage
+  figmaUrl="https://www.figma.com/file/YsTklBecdddy9RZ3HXddIseD/?node-id=10235%3A30024"
+  install="npm install @pluralsight/ps-design-system-note"
+  import="import Note from '@pluralsight/ps-design-system-note'"
+  packageName="note"
+  version={props.version}
+/>
 
 ## Examples
 
@@ -236,14 +244,14 @@ const Example: React.FC = props => {
 export default Example
 ```
 
-## Usage & types
+## Accessibility
 
-<Usage
-  install="npm install @pluralsight/ps-design-system-note"
-  import="import Note from '@pluralsight/ps-design-system-note'"
-  packageName="note"
-  version={props.version}
-/>
+**WCAG 2.1 AA Compliance**
+
+<CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests<br />
+<WarningFilledIcon color="red" size="xSmall" /> Manual audit
+
+## Props
 
 ### Note
 

--- a/docs/src/content/components/row.mdx
+++ b/docs/src/content/components/row.mdx
@@ -9,6 +9,16 @@ import Row from '@pluralsight/ps-design-system-row'
 
 <TableOfContents {...props} />
 
+<Intro>A row is a summary representation of a piece of content in a vertical list of related content.</Intro>
+
+<Usage
+  figmaUrl="https://www.figma.com/file/YsTklBecdddy9RZ3HXddIseD/?node-id=10235%3A29994"
+  install="npm install @pluralsight/ps-design-system-row"
+  import="import Row from '@pluralsight/ps-design-system-row'"
+  packageName="row"
+  version={props.version}
+/>
+
 ## Examples
 
 ### Flexibility
@@ -428,14 +438,15 @@ function Example() {
 export default Example
 ```
 
-## Usage & types
+## Accessibility
 
-<Usage
-  install="npm install @pluralsight/ps-design-system-row"
-  import="import Row from '@pluralsight/ps-design-system-row'"
-  packageName="row"
-  version={props.version}
-/>
+**WCAG 2.1 AA Compliance**
+
+<CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests
+<br />
+<WarningFilledIcon color="red" size="xSmall" /> Manual audit
+
+## Props
 
 ### Row
 

--- a/docs/src/content/components/table.mdx
+++ b/docs/src/content/components/table.mdx
@@ -9,6 +9,16 @@ import Table from '@pluralsight/ps-design-system-table'
 
 <TableOfContents {...props} />
 
+<Intro>Tables are containers for displaying information. They allow users to quickly scan, sort, compare, and take action on large amounts of data.</Intro>
+
+<Usage
+  figmaUrl="https://www.figma.com/file/YsTklBecdddy9RZ3HXddIseD/?node-id=10235%3A29842"
+  install="npm install @pluralsight/ps-design-system-table"
+  import="import Table from '@pluralsight/ps-design-system-table'"
+  packageName="table"
+  version={props.version}
+/>
+
 ## Examples
 
 ### Basic table
@@ -1175,14 +1185,15 @@ const reorder = (list: unknown[], startIndex: number, endIndex: number): any[] =
 export default Example
 ```
 
-## Usage & types
+## Accessibility
 
-<Usage
-  install="npm install @pluralsight/ps-design-system-table"
-  import="import Table from '@pluralsight/ps-design-system-table'"
-  packageName="table"
-  version={props.version}
-/>
+**WCAG 2.1 AA Compliance**
+
+<CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests
+<br />
+<WarningFilledIcon color="red" size="xSmall" /> Manual audit
+
+## Props
 
 ### Table
 

--- a/docs/src/content/components/tag.mdx
+++ b/docs/src/content/components/tag.mdx
@@ -9,6 +9,16 @@ import Tag from '@pluralsight/ps-design-system-tag'
 
 <TableOfContents {...props} />
 
+<Intro>Tags allow users to categorize content. They can represent keywords or people.</Intro>
+
+<Usage
+  figmaUrl="https://www.figma.com/file/YsTklBecdddy9RZ3HXddIseD/?node-id=10232%3A1"
+  install="npm install @pluralsight/ps-design-system-tag"
+  import="import Tag from '@pluralsight/ps-design-system-tag'"
+  packageName="tag"
+  version={props.version}
+/>
+
 ## Examples
 
 ### Size
@@ -122,14 +132,15 @@ const Example: React.FC = props => {
 export default Example
 ```
 
-## Usage & types
+## Accessibility
 
-<Usage
-  install="npm install @pluralsight/ps-design-system-tag"
-  import="import Tag from '@pluralsight/ps-design-system-tag'"
-  packageName="tag"
-  version={props.version}
-/>
+**WCAG 2.1 AA Compliance**
+
+<CheckCircleFillIcon color="green" size="xSmall" /> 100% axe-core tests
+<br />
+<WarningFilledIcon color="red" size="xSmall" /> Manual audit
+
+## Props
 
 <TypesTable>
   <TypesProp


### PR DESCRIPTION
Added a11y sections, Figma links, and reorganized contents of docs pages in the Content Display and Feedback nav sections.