### PR TITLE
fix(drawer): border-top on row on light-theme removed

### DIFF
--- a/packages/drawer/src/css/index.css
+++ b/packages/drawer/src/css/index.css
@@ -48,7 +48,8 @@
 }
 
 .psds-drawer__summary>*,
-.psds-drawer__summary>.psds-row {
+.psds-drawer__summary>.psds-row,
+.psds-drawer__summary>.psds-row.psds-theme--light {
   border-top: none
 }
 


### PR DESCRIPTION
https://pluralsight.slack.com/archives/C70HPSJPP/p1630095874000800