### PR TITLE
ci: add dependabot.yml to scope checks to packages only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: npm
+    directory: /packages
+    schedule:
+      interval: daily


### PR DESCRIPTION
### What You're Solving
Dependabot keeps reporting security vulnerabilities for non-package workspaces (examples, etc.). Adding configuration to try and scope to only packages we are shipping.
