### PR TITLE
fix(datepicker): remove unnecessary forced focus

### DIFF
--- a/packages/datepicker/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/datepicker/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -51,7 +51,7 @@ Array [
           </button>
           <h2
             className="psds-calendar__header-month"
-            id="psds-datepicker-grid--4/2020-2"
+            id="psds-datepicker-grid--4/2020-4"
           >
             May
              
@@ -156,7 +156,7 @@ Array [
           />
           <button
             aria-label="Fri May 01 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -169,7 +169,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 02 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -182,7 +182,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 03 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -195,7 +195,7 @@ Array [
           </button>
           <button
             aria-label="Mon May 04 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -208,7 +208,7 @@ Array [
           </button>
           <button
             aria-label="Tue May 05 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -221,7 +221,7 @@ Array [
           </button>
           <button
             aria-label="Wed May 06 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -234,7 +234,7 @@ Array [
           </button>
           <button
             aria-label="Thu May 07 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -247,7 +247,7 @@ Array [
           </button>
           <button
             aria-label="Fri May 08 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -260,7 +260,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 09 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -273,7 +273,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 10 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -286,7 +286,7 @@ Array [
           </button>
           <button
             aria-label="Mon May 11 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -299,7 +299,7 @@ Array [
           </button>
           <button
             aria-label="Tue May 12 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -312,7 +312,7 @@ Array [
           </button>
           <button
             aria-label="Wed May 13 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -325,7 +325,7 @@ Array [
           </button>
           <button
             aria-label="Thu May 14 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -338,7 +338,7 @@ Array [
           </button>
           <button
             aria-label="Fri May 15 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -351,7 +351,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 16 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -364,7 +364,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 17 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -377,7 +377,7 @@ Array [
           </button>
           <button
             aria-label="Mon May 18 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -390,7 +390,7 @@ Array [
           </button>
           <button
             aria-label="Tue May 19 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -403,7 +403,7 @@ Array [
           </button>
           <button
             aria-label="Wed May 20 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -416,7 +416,7 @@ Array [
           </button>
           <button
             aria-label="Thu May 21 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -429,7 +429,7 @@ Array [
           </button>
           <button
             aria-label="Fri May 22 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -442,7 +442,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 23 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -455,7 +455,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 24 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -468,7 +468,7 @@ Array [
           </button>
           <button
             aria-label="Mon May 25 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -481,7 +481,7 @@ Array [
           </button>
           <button
             aria-label="Tue May 26 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -494,7 +494,7 @@ Array [
           </button>
           <button
             aria-label="Wed May 27 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -507,7 +507,7 @@ Array [
           </button>
           <button
             aria-label="Thu May 28 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -520,7 +520,7 @@ Array [
           </button>
           <button
             aria-label="Fri May 29 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -533,7 +533,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 30 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -546,7 +546,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 31 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-2"
+            aria-labelledby="psds-datepicker-grid--4/2020-4"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -662,8 +662,8 @@ exports[`Storyshots Components/DatePicker Date Picker Change Value 1`] = `
     >
       <label
         className="psds-field__label psds-theme--dark"
-        htmlFor="psds-datepicker-text-input__input-28"
-        id="psds-datepicker-text-input__label-27"
+        htmlFor="psds-datepicker-text-input__input-30"
+        id="psds-datepicker-text-input__label-29"
       >
         Controlled component, set to 31 Dec 1999
       </label>
@@ -702,7 +702,7 @@ exports[`Storyshots Components/DatePicker Date Picker Change Value 1`] = `
           >
             <input
               className="psds-field__input psds-field__input--medium"
-              id="psds-datepicker-text-input__input-28"
+              id="psds-datepicker-text-input__input-30"
               onChange={[Function]}
               onFocus={[Function]}
               placeholder="mm/dd/yyyy"
@@ -732,8 +732,8 @@ exports[`Storyshots Components/DatePicker Date Picker Disabled 1`] = `
   >
     <label
       className="psds-field__label psds-theme--dark"
-      htmlFor="psds-datepicker-text-input__input-4"
-      id="psds-datepicker-text-input__label-3"
+      htmlFor="psds-datepicker-text-input__input-6"
+      id="psds-datepicker-text-input__label-5"
     >
       Disabled
     </label>
@@ -773,7 +773,7 @@ exports[`Storyshots Components/DatePicker Date Picker Disabled 1`] = `
           <input
             className="psds-field__input psds-field__input--medium"
             disabled={true}
-            id="psds-datepicker-text-input__input-4"
+            id="psds-datepicker-text-input__input-6"
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="mm/dd/yyyy"
@@ -802,8 +802,8 @@ exports[`Storyshots Components/DatePicker Date Picker Error 1`] = `
   >
     <label
       className="psds-field__label psds-theme--dark"
-      htmlFor="psds-datepicker-text-input__input-6"
-      id="psds-datepicker-text-input__label-5"
+      htmlFor="psds-datepicker-text-input__input-8"
+      id="psds-datepicker-text-input__label-7"
     >
       Errored
     </label>
@@ -842,7 +842,7 @@ exports[`Storyshots Components/DatePicker Date Picker Error 1`] = `
         >
           <input
             className="psds-field__input psds-field__input--medium"
-            id="psds-datepicker-text-input__input-6"
+            id="psds-datepicker-text-input__input-8"
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="mm/dd/yyyy"
@@ -928,7 +928,7 @@ exports[`Storyshots Components/DatePicker Date Picker Field Label 1`] = `
         >
           <input
             className="psds-field__input psds-field__input--medium"
-            id="psds-datepicker-text-input__input-10"
+            id="psds-datepicker-text-input__input-12"
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="mm/dd/yyyy"
@@ -957,8 +957,8 @@ exports[`Storyshots Components/DatePicker Date Picker Initial Value 1`] = `
   >
     <label
       className="psds-field__label psds-theme--dark"
-      htmlFor="psds-datepicker-text-input__input-26"
-      id="psds-datepicker-text-input__label-25"
+      htmlFor="psds-datepicker-text-input__input-28"
+      id="psds-datepicker-text-input__label-27"
     >
       Controlled component, set to 31 Dec 1999
     </label>
@@ -997,7 +997,7 @@ exports[`Storyshots Components/DatePicker Date Picker Initial Value 1`] = `
         >
           <input
             className="psds-field__input psds-field__input--medium"
-            id="psds-datepicker-text-input__input-26"
+            id="psds-datepicker-text-input__input-28"
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="mm/dd/yyyy"
@@ -1026,8 +1026,8 @@ exports[`Storyshots Components/DatePicker Date Picker Prefix 1`] = `
   >
     <label
       className="psds-field__label psds-theme--dark"
-      htmlFor="psds-datepicker-text-input__input-12"
-      id="psds-datepicker-text-input__label-11"
+      htmlFor="psds-datepicker-text-input__input-14"
+      id="psds-datepicker-text-input__label-13"
     >
       Prefix
     </label>
@@ -1062,7 +1062,7 @@ exports[`Storyshots Components/DatePicker Date Picker Prefix 1`] = `
         >
           <input
             className="psds-field__input psds-field__input--medium"
-            id="psds-datepicker-text-input__input-12"
+            id="psds-datepicker-text-input__input-14"
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="mm/dd/yyyy"
@@ -1096,8 +1096,8 @@ exports[`Storyshots Components/DatePicker Date Picker Render Container 1`] = `
   >
     <label
       className="psds-field__label psds-theme--dark"
-      htmlFor="psds-datepicker-text-input__input-14"
-      id="psds-datepicker-text-input__label-13"
+      htmlFor="psds-datepicker-text-input__input-16"
+      id="psds-datepicker-text-input__label-15"
     >
       renderContainer
     </label>
@@ -1136,7 +1136,7 @@ exports[`Storyshots Components/DatePicker Date Picker Render Container 1`] = `
         >
           <input
             className="psds-field__input psds-field__input--medium"
-            id="psds-datepicker-text-input__input-14"
+            id="psds-datepicker-text-input__input-16"
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="mm/dd/yyyy"
@@ -1165,8 +1165,8 @@ exports[`Storyshots Components/DatePicker Date Picker Render Tag 1`] = `
   >
     <label
       className="psds-field__label psds-theme--dark"
-      htmlFor="psds-datepicker-text-input__input-16"
-      id="psds-datepicker-text-input__label-15"
+      htmlFor="psds-datepicker-text-input__input-18"
+      id="psds-datepicker-text-input__label-17"
     >
       renderTag
     </label>
@@ -1206,7 +1206,7 @@ exports[`Storyshots Components/DatePicker Date Picker Render Tag 1`] = `
         >
           <input
             className="psds-field__input psds-field__input--medium"
-            id="psds-datepicker-text-input__input-16"
+            id="psds-datepicker-text-input__input-18"
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="mm/dd/yyyy"
@@ -1235,8 +1235,8 @@ exports[`Storyshots Components/DatePicker Date Picker Small Size 1`] = `
   >
     <label
       className="psds-field__label psds-theme--dark"
-      htmlFor="psds-datepicker-text-input__input-18"
-      id="psds-datepicker-text-input__label-17"
+      htmlFor="psds-datepicker-text-input__input-20"
+      id="psds-datepicker-text-input__label-19"
     >
       Small size
     </label>
@@ -1275,7 +1275,7 @@ exports[`Storyshots Components/DatePicker Date Picker Small Size 1`] = `
         >
           <input
             className="psds-field__input psds-field__input--small"
-            id="psds-datepicker-text-input__input-18"
+            id="psds-datepicker-text-input__input-20"
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="mm/dd/yyyy"
@@ -1304,8 +1304,8 @@ exports[`Storyshots Components/DatePicker Date Picker String Label 1`] = `
   >
     <label
       className="psds-field__label psds-theme--dark"
-      htmlFor="psds-datepicker-text-input__input-8"
-      id="psds-datepicker-text-input__label-7"
+      htmlFor="psds-datepicker-text-input__input-10"
+      id="psds-datepicker-text-input__label-9"
     >
       String label
     </label>
@@ -1344,7 +1344,7 @@ exports[`Storyshots Components/DatePicker Date Picker String Label 1`] = `
         >
           <input
             className="psds-field__input psds-field__input--medium"
-            id="psds-datepicker-text-input__input-8"
+            id="psds-datepicker-text-input__input-10"
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="mm/dd/yyyy"
@@ -1406,7 +1406,7 @@ exports[`Storyshots Components/DatePicker Date Picker Sub Label Field 1`] = `
         >
           <input
             className="psds-field__input psds-field__input--medium"
-            id="psds-datepicker-text-input__input-22"
+            id="psds-datepicker-text-input__input-24"
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="mm/dd/yyyy"
@@ -1473,7 +1473,7 @@ exports[`Storyshots Components/DatePicker Date Picker Sub Label String 1`] = `
         >
           <input
             className="psds-field__input psds-field__input--medium"
-            id="psds-datepicker-text-input__input-20"
+            id="psds-datepicker-text-input__input-22"
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="mm/dd/yyyy"
@@ -1507,8 +1507,8 @@ exports[`Storyshots Components/DatePicker Date Picker Suffix 1`] = `
   >
     <label
       className="psds-field__label psds-theme--dark"
-      htmlFor="psds-datepicker-text-input__input-24"
-      id="psds-datepicker-text-input__label-23"
+      htmlFor="psds-datepicker-text-input__input-26"
+      id="psds-datepicker-text-input__label-25"
     >
       Suffix
     </label>
@@ -1547,7 +1547,7 @@ exports[`Storyshots Components/DatePicker Date Picker Suffix 1`] = `
         >
           <input
             className="psds-field__input psds-field__input--medium"
-            id="psds-datepicker-text-input__input-24"
+            id="psds-datepicker-text-input__input-26"
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="mm/dd/yyyy"
@@ -1577,6 +1577,120 @@ exports[`Storyshots Components/DatePicker Date Picker Suffix 1`] = `
     </div>
   </div>
   <br />
+</div>
+`;
+
+exports[`Storyshots Components/DatePicker Example 1`] = `
+<div>
+  <div>
+    <label>
+      test
+      <label
+        className="psds-text-input"
+      >
+        <div
+          className="psds-text-input__field-container"
+        >
+          <div
+            className="psds-halo psds-theme--dark psds-halo--shape-default psds-halo--gap-size-small psds-halo--visible-on-focus"
+          >
+            <div
+              className="psds-text-input__field psds-text-input__field--appearance-default psds-theme--dark"
+            >
+              <input
+                className="psds-theme--dark psds-text-input__field-input--appearance-default psds-text-input__field-input"
+                disabled={false}
+                name="test"
+                placeholder="test"
+              />
+            </div>
+          </div>
+        </div>
+      </label>
+    </label>
+  </div>
+  <div>
+    <button
+      className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
+      disabled={false}
+      onClick={[Function]}
+    >
+      <span
+        aria-hidden={false}
+        className="psds-button__text"
+      >
+        Go Y2K!
+      </span>
+    </button>
+  </div>
+  <div>
+    <div
+      style={
+        Object {
+          "display": "inline-block",
+          "position": "relative",
+        }
+      }
+    >
+      <div
+        className="psds-field__container"
+        onClick={[Function]}
+      >
+        <label
+          className="psds-field__label psds-theme--dark"
+          htmlFor="psds-datepicker-text-input__input-1"
+          id="psds-datepicker-text-input__label-0"
+        >
+          Party time
+        </label>
+        <div
+          className="psds-halo psds-theme--light psds-halo--shape-default psds-halo--gap-size-small psds-halo--visible-on-focus psds-field__halo"
+        >
+          <div
+            className="psds-field psds-field--medium psds-field--prefix"
+            onKeyDown={[Function]}
+          >
+            <div
+              className="psds-field__prefix"
+            >
+              <div
+                className="psds-icon psds-icon--size-medium"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "cursor": "pointer",
+                  }
+                }
+              >
+                <svg
+                  aria-label="calendar icon"
+                  role="img"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M8.5 10a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h1zm4 0a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h1zm4 0a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h1zM20 3c.552 0 1 .444 1 .996v16.007A.997.997 0 0 1 20 21H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h2V1.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5V3h8V1.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5V3h2zm-1 16V8H5v11h14zM8.5 14a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h1zm4 0a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h1zm4 0a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5h1z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              className="psds-field__input__container"
+            >
+              <input
+                className="psds-field__input psds-field__input--medium"
+                id="psds-datepicker-text-input__input-1"
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder="mm/dd/yyyy"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <br />
+    </div>
+  </div>
 </div>
 `;
 
@@ -1625,7 +1739,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <h2
           className="psds-calendar__header-month"
-          id="psds-datepicker-grid--0/2021-34"
+          id="psds-datepicker-grid--0/2021-36"
         >
           Jan
            
@@ -1730,7 +1844,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         />
         <button
           aria-label="Fri Jan 01 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={true}
           className="psds-calendar__date psds-calendar__date--selected"
           disabled={false}
@@ -1742,7 +1856,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Sat Jan 02 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1755,7 +1869,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Sun Jan 03 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1768,7 +1882,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Mon Jan 04 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1781,7 +1895,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Tue Jan 05 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={true}
           className="psds-calendar__date psds-calendar__date--selected"
           disabled={false}
@@ -1793,7 +1907,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Wed Jan 06 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1806,7 +1920,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Thu Jan 07 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1819,7 +1933,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Fri Jan 08 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1832,7 +1946,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Sat Jan 09 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1845,7 +1959,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Sun Jan 10 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1858,7 +1972,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Mon Jan 11 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1871,7 +1985,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Tue Jan 12 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1884,7 +1998,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Wed Jan 13 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1897,7 +2011,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Thu Jan 14 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1910,7 +2024,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Fri Jan 15 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1923,7 +2037,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Sat Jan 16 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1936,7 +2050,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Sun Jan 17 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1949,7 +2063,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Mon Jan 18 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1962,7 +2076,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Tue Jan 19 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1975,7 +2089,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Wed Jan 20 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -1988,7 +2102,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Thu Jan 21 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2001,7 +2115,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Fri Jan 22 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2014,7 +2128,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Sat Jan 23 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2027,7 +2141,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Sun Jan 24 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2040,7 +2154,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Mon Jan 25 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2053,7 +2167,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Tue Jan 26 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2066,7 +2180,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Wed Jan 27 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2079,7 +2193,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Thu Jan 28 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2092,7 +2206,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Fri Jan 29 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2105,7 +2219,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Sat Jan 30 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2118,7 +2232,7 @@ exports[`Storyshots Components/DatePicker Multi Date 1`] = `
         </button>
         <button
           aria-label="Sun Jan 31 2021"
-          aria-labelledby="psds-datepicker-grid--0/2021-34"
+          aria-labelledby="psds-datepicker-grid--0/2021-36"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2199,7 +2313,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <h2
           className="psds-calendar__header-month"
-          id="psds-datepicker-grid--4/2020-29"
+          id="psds-datepicker-grid--4/2020-31"
         >
           May
            
@@ -2304,7 +2418,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         />
         <button
           aria-label="Fri May 01 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2318,7 +2432,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Sat May 02 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2332,7 +2446,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Sun May 03 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2346,7 +2460,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Mon May 04 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2360,7 +2474,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Tue May 05 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2374,7 +2488,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Wed May 06 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2388,7 +2502,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Thu May 07 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2402,7 +2516,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Fri May 08 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2416,7 +2530,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Sat May 09 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2430,7 +2544,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Sun May 10 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2444,7 +2558,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Mon May 11 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2458,7 +2572,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Tue May 12 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2472,7 +2586,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Wed May 13 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2486,7 +2600,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Thu May 14 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2500,7 +2614,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Fri May 15 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2514,7 +2628,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Sat May 16 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2528,7 +2642,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Sun May 17 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2542,7 +2656,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Mon May 18 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2556,7 +2670,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Tue May 19 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2570,7 +2684,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Wed May 20 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2584,7 +2698,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Thu May 21 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2598,7 +2712,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Fri May 22 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2612,7 +2726,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Sat May 23 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2626,7 +2740,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Sun May 24 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2640,7 +2754,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Mon May 25 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2654,7 +2768,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Tue May 26 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2668,7 +2782,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Wed May 27 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2682,7 +2796,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Thu May 28 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2696,7 +2810,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Fri May 29 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2710,7 +2824,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Sat May 30 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2724,7 +2838,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar 1`] = `
         </button>
         <button
           aria-label="Sun May 31 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-29"
+          aria-labelledby="psds-datepicker-grid--4/2020-31"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -2812,7 +2926,7 @@ Array [
           </button>
           <h2
             className="psds-calendar__header-month"
-            id="psds-datepicker-grid--4/2020-30"
+            id="psds-datepicker-grid--4/2020-32"
           >
             May
              
@@ -2917,7 +3031,7 @@ Array [
           />
           <button
             aria-label="Fri May 01 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -2931,7 +3045,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 02 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -2945,7 +3059,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 03 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -2959,7 +3073,7 @@ Array [
           </button>
           <button
             aria-label="Mon May 04 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -2973,7 +3087,7 @@ Array [
           </button>
           <button
             aria-label="Tue May 05 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -2987,7 +3101,7 @@ Array [
           </button>
           <button
             aria-label="Wed May 06 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3001,7 +3115,7 @@ Array [
           </button>
           <button
             aria-label="Thu May 07 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3015,7 +3129,7 @@ Array [
           </button>
           <button
             aria-label="Fri May 08 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3029,7 +3143,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 09 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3043,7 +3157,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 10 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3057,7 +3171,7 @@ Array [
           </button>
           <button
             aria-label="Mon May 11 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3071,7 +3185,7 @@ Array [
           </button>
           <button
             aria-label="Tue May 12 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3085,7 +3199,7 @@ Array [
           </button>
           <button
             aria-label="Wed May 13 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3099,7 +3213,7 @@ Array [
           </button>
           <button
             aria-label="Thu May 14 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3113,7 +3227,7 @@ Array [
           </button>
           <button
             aria-label="Fri May 15 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3127,7 +3241,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 16 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3141,7 +3255,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 17 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3155,7 +3269,7 @@ Array [
           </button>
           <button
             aria-label="Mon May 18 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3169,7 +3283,7 @@ Array [
           </button>
           <button
             aria-label="Tue May 19 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3183,7 +3297,7 @@ Array [
           </button>
           <button
             aria-label="Wed May 20 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3197,7 +3311,7 @@ Array [
           </button>
           <button
             aria-label="Thu May 21 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3211,7 +3325,7 @@ Array [
           </button>
           <button
             aria-label="Fri May 22 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3225,7 +3339,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 23 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3239,7 +3353,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 24 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3253,7 +3367,7 @@ Array [
           </button>
           <button
             aria-label="Mon May 25 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3267,7 +3381,7 @@ Array [
           </button>
           <button
             aria-label="Tue May 26 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3281,7 +3395,7 @@ Array [
           </button>
           <button
             aria-label="Wed May 27 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3295,7 +3409,7 @@ Array [
           </button>
           <button
             aria-label="Thu May 28 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3309,7 +3423,7 @@ Array [
           </button>
           <button
             aria-label="Fri May 29 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3323,7 +3437,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 30 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3337,7 +3451,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 31 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-30"
+            aria-labelledby="psds-datepicker-grid--4/2020-32"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3475,7 +3589,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <h2
             className="psds-calendar__header-month"
-            id="psds-datepicker-grid--4/2020-31"
+            id="psds-datepicker-grid--4/2020-33"
           >
             May
              
@@ -3580,7 +3694,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           />
           <button
             aria-label="Fri May 01 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3594,7 +3708,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Sat May 02 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3608,7 +3722,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Sun May 03 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3622,7 +3736,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Mon May 04 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3636,7 +3750,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Tue May 05 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3650,7 +3764,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Wed May 06 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3664,7 +3778,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Thu May 07 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3678,7 +3792,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Fri May 08 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3692,7 +3806,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Sat May 09 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3706,7 +3820,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Sun May 10 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3720,7 +3834,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Mon May 11 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3734,7 +3848,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Tue May 12 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3748,7 +3862,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Wed May 13 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3762,7 +3876,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Thu May 14 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3776,7 +3890,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Fri May 15 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3790,7 +3904,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Sat May 16 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3804,7 +3918,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Sun May 17 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3818,7 +3932,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Mon May 18 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3832,7 +3946,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Tue May 19 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3846,7 +3960,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Wed May 20 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3860,7 +3974,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Thu May 21 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3874,7 +3988,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Fri May 22 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3888,7 +4002,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Sat May 23 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3902,7 +4016,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Sun May 24 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3916,7 +4030,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Mon May 25 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3930,7 +4044,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Tue May 26 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3944,7 +4058,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Wed May 27 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3958,7 +4072,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Thu May 28 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3972,7 +4086,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Fri May 29 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -3986,7 +4100,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Sat May 30 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4000,7 +4114,7 @@ exports[`Storyshots Components/DatePicker Range Date Calendar With Input 1`] = `
           </button>
           <button
             aria-label="Sun May 31 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-31"
+            aria-labelledby="psds-datepicker-grid--4/2020-33"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4138,7 +4252,7 @@ Array [
           </button>
           <h2
             className="psds-calendar__header-month"
-            id="psds-datepicker-grid--4/2020-32"
+            id="psds-datepicker-grid--4/2020-34"
           >
             May
              
@@ -4195,7 +4309,7 @@ Array [
           />
           <h2
             className="psds-calendar__header-month"
-            id="psds-datepicker-grid--5/2020-33"
+            id="psds-datepicker-grid--5/2020-35"
           >
             Jun
              
@@ -4300,7 +4414,7 @@ Array [
           />
           <button
             aria-label="Fri May 01 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4314,7 +4428,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 02 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4328,7 +4442,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 03 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4342,7 +4456,7 @@ Array [
           </button>
           <button
             aria-label="Mon May 04 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4356,7 +4470,7 @@ Array [
           </button>
           <button
             aria-label="Tue May 05 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4370,7 +4484,7 @@ Array [
           </button>
           <button
             aria-label="Wed May 06 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4384,7 +4498,7 @@ Array [
           </button>
           <button
             aria-label="Thu May 07 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4398,7 +4512,7 @@ Array [
           </button>
           <button
             aria-label="Fri May 08 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4412,7 +4526,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 09 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4426,7 +4540,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 10 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4440,7 +4554,7 @@ Array [
           </button>
           <button
             aria-label="Mon May 11 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4454,7 +4568,7 @@ Array [
           </button>
           <button
             aria-label="Tue May 12 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4468,7 +4582,7 @@ Array [
           </button>
           <button
             aria-label="Wed May 13 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4482,7 +4596,7 @@ Array [
           </button>
           <button
             aria-label="Thu May 14 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4496,7 +4610,7 @@ Array [
           </button>
           <button
             aria-label="Fri May 15 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4510,7 +4624,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 16 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4524,7 +4638,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 17 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4538,7 +4652,7 @@ Array [
           </button>
           <button
             aria-label="Mon May 18 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4552,7 +4666,7 @@ Array [
           </button>
           <button
             aria-label="Tue May 19 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4566,7 +4680,7 @@ Array [
           </button>
           <button
             aria-label="Wed May 20 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4580,7 +4694,7 @@ Array [
           </button>
           <button
             aria-label="Thu May 21 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4594,7 +4708,7 @@ Array [
           </button>
           <button
             aria-label="Fri May 22 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4608,7 +4722,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 23 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4622,7 +4736,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 24 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4636,7 +4750,7 @@ Array [
           </button>
           <button
             aria-label="Mon May 25 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4650,7 +4764,7 @@ Array [
           </button>
           <button
             aria-label="Tue May 26 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4664,7 +4778,7 @@ Array [
           </button>
           <button
             aria-label="Wed May 27 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4678,7 +4792,7 @@ Array [
           </button>
           <button
             aria-label="Thu May 28 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4692,7 +4806,7 @@ Array [
           </button>
           <button
             aria-label="Fri May 29 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4706,7 +4820,7 @@ Array [
           </button>
           <button
             aria-label="Sat May 30 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4720,7 +4834,7 @@ Array [
           </button>
           <button
             aria-label="Sun May 31 2020"
-            aria-labelledby="psds-datepicker-grid--4/2020-32"
+            aria-labelledby="psds-datepicker-grid--4/2020-34"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4759,7 +4873,7 @@ Array [
           />
           <button
             aria-label="Mon Jun 01 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4773,7 +4887,7 @@ Array [
           </button>
           <button
             aria-label="Tue Jun 02 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4787,7 +4901,7 @@ Array [
           </button>
           <button
             aria-label="Wed Jun 03 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4801,7 +4915,7 @@ Array [
           </button>
           <button
             aria-label="Thu Jun 04 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4815,7 +4929,7 @@ Array [
           </button>
           <button
             aria-label="Fri Jun 05 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4829,7 +4943,7 @@ Array [
           </button>
           <button
             aria-label="Sat Jun 06 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4843,7 +4957,7 @@ Array [
           </button>
           <button
             aria-label="Sun Jun 07 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4857,7 +4971,7 @@ Array [
           </button>
           <button
             aria-label="Mon Jun 08 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4871,7 +4985,7 @@ Array [
           </button>
           <button
             aria-label="Tue Jun 09 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4885,7 +4999,7 @@ Array [
           </button>
           <button
             aria-label="Wed Jun 10 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4899,7 +5013,7 @@ Array [
           </button>
           <button
             aria-label="Thu Jun 11 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4913,7 +5027,7 @@ Array [
           </button>
           <button
             aria-label="Fri Jun 12 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4927,7 +5041,7 @@ Array [
           </button>
           <button
             aria-label="Sat Jun 13 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4941,7 +5055,7 @@ Array [
           </button>
           <button
             aria-label="Sun Jun 14 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4955,7 +5069,7 @@ Array [
           </button>
           <button
             aria-label="Mon Jun 15 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4969,7 +5083,7 @@ Array [
           </button>
           <button
             aria-label="Tue Jun 16 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4983,7 +5097,7 @@ Array [
           </button>
           <button
             aria-label="Wed Jun 17 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -4997,7 +5111,7 @@ Array [
           </button>
           <button
             aria-label="Thu Jun 18 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5011,7 +5125,7 @@ Array [
           </button>
           <button
             aria-label="Fri Jun 19 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5025,7 +5139,7 @@ Array [
           </button>
           <button
             aria-label="Sat Jun 20 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5039,7 +5153,7 @@ Array [
           </button>
           <button
             aria-label="Sun Jun 21 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5053,7 +5167,7 @@ Array [
           </button>
           <button
             aria-label="Mon Jun 22 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5067,7 +5181,7 @@ Array [
           </button>
           <button
             aria-label="Tue Jun 23 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5081,7 +5195,7 @@ Array [
           </button>
           <button
             aria-label="Wed Jun 24 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5095,7 +5209,7 @@ Array [
           </button>
           <button
             aria-label="Thu Jun 25 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5109,7 +5223,7 @@ Array [
           </button>
           <button
             aria-label="Fri Jun 26 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5123,7 +5237,7 @@ Array [
           </button>
           <button
             aria-label="Sat Jun 27 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5137,7 +5251,7 @@ Array [
           </button>
           <button
             aria-label="Sun Jun 28 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5151,7 +5265,7 @@ Array [
           </button>
           <button
             aria-label="Mon Jun 29 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5165,7 +5279,7 @@ Array [
           </button>
           <button
             aria-label="Tue Jun 30 2020"
-            aria-labelledby="psds-datepicker-grid--5/2020-33"
+            aria-labelledby="psds-datepicker-grid--5/2020-35"
             aria-pressed={false}
             className="psds-calendar__date"
             disabled={false}
@@ -5241,7 +5355,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <h2
           className="psds-calendar__header-month"
-          id="psds-datepicker-grid--5/2020-1"
+          id="psds-datepicker-grid--5/2020-3"
         >
           Jun
            
@@ -5334,7 +5448,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         />
         <button
           aria-label="Mon Jun 01 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5347,7 +5461,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Tue Jun 02 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5360,7 +5474,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Wed Jun 03 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5373,7 +5487,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Thu Jun 04 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5386,7 +5500,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Fri Jun 05 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5399,7 +5513,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Sat Jun 06 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5412,7 +5526,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Sun Jun 07 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5425,7 +5539,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Mon Jun 08 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5438,7 +5552,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Tue Jun 09 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5451,7 +5565,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Wed Jun 10 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5464,7 +5578,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Thu Jun 11 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5477,7 +5591,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Fri Jun 12 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5490,7 +5604,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Sat Jun 13 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5503,7 +5617,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Sun Jun 14 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5516,7 +5630,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Mon Jun 15 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5529,7 +5643,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Tue Jun 16 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5542,7 +5656,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Wed Jun 17 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5555,7 +5669,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Thu Jun 18 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5568,7 +5682,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Fri Jun 19 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5581,7 +5695,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Sat Jun 20 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5594,7 +5708,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Sun Jun 21 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5607,7 +5721,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Mon Jun 22 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5620,7 +5734,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Tue Jun 23 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5633,7 +5747,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Wed Jun 24 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5646,7 +5760,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Thu Jun 25 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5659,7 +5773,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Fri Jun 26 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5672,7 +5786,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Sat Jun 27 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5685,7 +5799,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Sun Jun 28 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5698,7 +5812,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Mon Jun 29 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5711,7 +5825,7 @@ exports[`Storyshots Components/DatePicker Single Date Previous Month 1`] = `
         </button>
         <button
           aria-label="Tue Jun 30 2020"
-          aria-labelledby="psds-datepicker-grid--5/2020-1"
+          aria-labelledby="psds-datepicker-grid--5/2020-3"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5785,7 +5899,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <h2
           className="psds-calendar__header-month"
-          id="psds-datepicker-grid--4/2020-0"
+          id="psds-datepicker-grid--4/2020-2"
         >
           May
            
@@ -5890,7 +6004,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         />
         <button
           aria-label="Fri May 01 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5903,7 +6017,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Sat May 02 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5916,7 +6030,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Sun May 03 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5929,7 +6043,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Mon May 04 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5942,7 +6056,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Tue May 05 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5955,7 +6069,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Wed May 06 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5968,7 +6082,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Thu May 07 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5981,7 +6095,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Fri May 08 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -5994,7 +6108,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Sat May 09 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6007,7 +6121,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Sun May 10 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6020,7 +6134,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Mon May 11 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6033,7 +6147,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Tue May 12 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6046,7 +6160,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Wed May 13 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={true}
           className="psds-calendar__date psds-calendar__date--selected"
           disabled={false}
@@ -6058,7 +6172,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Thu May 14 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6071,7 +6185,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Fri May 15 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6084,7 +6198,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Sat May 16 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6097,7 +6211,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Sun May 17 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6110,7 +6224,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Mon May 18 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6123,7 +6237,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Tue May 19 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6136,7 +6250,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Wed May 20 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6149,7 +6263,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Thu May 21 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6162,7 +6276,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Fri May 22 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6175,7 +6289,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Sat May 23 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6188,7 +6302,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Sun May 24 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6201,7 +6315,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Mon May 25 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6214,7 +6328,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Tue May 26 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6227,7 +6341,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Wed May 27 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6240,7 +6354,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Thu May 28 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6253,7 +6367,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Fri May 29 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6266,7 +6380,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Sat May 30 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}
@@ -6279,7 +6393,7 @@ exports[`Storyshots Components/DatePicker Single Date Selected Date 1`] = `
         </button>
         <button
           aria-label="Sun May 31 2020"
-          aria-labelledby="psds-datepicker-grid--4/2020-0"
+          aria-labelledby="psds-datepicker-grid--4/2020-2"
           aria-pressed={false}
           className="psds-calendar__date"
           disabled={false}

--- a/packages/datepicker/src/react/__stories__/index.story.tsx
+++ b/packages/datepicker/src/react/__stories__/index.story.tsx
@@ -1,6 +1,7 @@
 import Field from '@pluralsight/ps-design-system-field'
 import { HomeIcon, CalendarIcon } from '@pluralsight/ps-design-system-icon'
 import TextInput from '@pluralsight/ps-design-system-textinput'
+import Button from '@pluralsight/ps-design-system-button'
 import { Meta, Story } from '@storybook/react/types-6-0'
 import React from 'react'
 import { DateObj, useDayzed } from 'dayzed'
@@ -22,6 +23,27 @@ export default {
   title: 'Components/DatePicker',
   component: DatePicker
 } as Meta
+
+export const Example = () => {
+  const [date, setDate] = React.useState(new Date(1999, 11, 31))
+  return (
+    <div>
+      <div>
+        <TextInput />
+      </div>
+      <div>
+        <Button onClick={() => setDate(new Date(2000, 0, 1))}>Go Y2K!</Button>
+      </div>
+      <div>
+        <DatePicker
+          label="Party time"
+          onSelect={(evt, dateObj) => setDate(dateObj.date)}
+          value={date}
+        />
+      </div>
+    </div>
+  )
+}
 
 export const SingleDateSelectedDate: Story = () => {
   const [selected, setSelected] = React.useState<Date | undefined>(

--- a/packages/datepicker/src/react/__stories__/index.story.tsx
+++ b/packages/datepicker/src/react/__stories__/index.story.tsx
@@ -29,7 +29,10 @@ export const Example = () => {
   return (
     <div>
       <div>
-        <TextInput />
+        <label>
+          test
+          <TextInput name="test" placeholder="test" />
+        </label>
       </div>
       <div>
         <Button onClick={() => setDate(new Date(2000, 0, 1))}>Go Y2K!</Button>

--- a/packages/datepicker/src/react/datepicker.tsx
+++ b/packages/datepicker/src/react/datepicker.tsx
@@ -87,18 +87,20 @@ export const DatePicker: React.FC<DatePickerProps> = ({
       if (evt.target instanceof HTMLElement) {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         if ((ref.current as HTMLDivElement).contains(evt.target)) return
-        focusInput()
         setOpen(false)
       }
     }
+
     document.addEventListener('click', handleClickOutsideMenu, {
       capture: true
     })
+
     return () =>
       document.removeEventListener('click', handleClickOutsideMenu, {
         capture: true
       })
   }, [setOpen])
+
   const labelId = generateId('psds-datepicker-text-input__label-')
   const inputId = generateId('psds-datepicker-text-input__input-')
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = evt => {
@@ -111,6 +113,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
       dateFormat
     })
   }
+
   return (
     <div
       style={{ display: 'inline-block', position: 'relative' }}


### PR DESCRIPTION
### What You're Solving
closes #2026 

DatePicker was stealing focus from other inputs when sharing a page view. This PR solves that issue.

### How to Verify
- Fire up ol' DatePicker SB and go to the "Example" option which mimicks the docs page
- DatePicker input should allow focus to itself and other inputs sharing the view without causing issues of each working independently and correclty
