### PR TITLE
fix(checkbox): prefer onChange over onCheck

### DIFF
--- a/packages/checkbox/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/checkbox/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -19,6 +19,7 @@ exports[`Storyshots Components/Checkbox Basic 1`] = `
       <input
         className="psds-screenreader-only psds-checkbox__input"
         name="colorRed"
+        onChange={[Function]}
         type="checkbox"
         value="red"
       />
@@ -55,6 +56,7 @@ exports[`Storyshots Components/Checkbox Checked 1`] = `
         checked={true}
         className="psds-screenreader-only psds-checkbox__input"
         name="colorRed"
+        onChange={[Function]}
         type="checkbox"
         value="red"
       />
@@ -104,6 +106,7 @@ exports[`Storyshots Components/Checkbox Checked Error 1`] = `
         checked={true}
         className="psds-screenreader-only psds-checkbox__input"
         name="colorRed"
+        onChange={[Function]}
         type="checkbox"
         value="red"
       />
@@ -153,6 +156,7 @@ exports[`Storyshots Components/Checkbox Checked Indeterminate 1`] = `
         checked={true}
         className="psds-screenreader-only psds-checkbox__input"
         name="colorRed"
+        onChange={[Function]}
         type="checkbox"
         value="red"
       />
@@ -205,6 +209,7 @@ exports[`Storyshots Components/Checkbox Disabled 1`] = `
         className="psds-screenreader-only psds-checkbox__input"
         disabled={true}
         name="colorRed"
+        onChange={[Function]}
         type="checkbox"
         value="red"
       />
@@ -240,6 +245,7 @@ exports[`Storyshots Components/Checkbox Error 1`] = `
       <input
         className="psds-screenreader-only psds-checkbox__input"
         name="colorRed"
+        onChange={[Function]}
         type="checkbox"
         value="red"
       />
@@ -287,6 +293,7 @@ exports[`Storyshots Components/Checkbox Example State Demo 1`] = `
           checked={false}
           className="psds-screenreader-only psds-checkbox__input"
           name="colorRed"
+          onChange={[Function]}
           type="checkbox"
           value="red"
         />
@@ -312,6 +319,7 @@ exports[`Storyshots Components/Checkbox Example State Demo 1`] = `
           checked={false}
           className="psds-screenreader-only psds-checkbox__input"
           name="colorGreen"
+          onChange={[Function]}
           type="checkbox"
           value="green"
         />
@@ -337,6 +345,7 @@ exports[`Storyshots Components/Checkbox Example State Demo 1`] = `
           checked={false}
           className="psds-screenreader-only psds-checkbox__input"
           name="colorBlue"
+          onChange={[Function]}
           type="checkbox"
           value="blue"
         />
@@ -373,6 +382,7 @@ exports[`Storyshots Components/Checkbox Indeterminate 1`] = `
       <input
         className="psds-screenreader-only psds-checkbox__input"
         name="colorRed"
+        onChange={[Function]}
         type="checkbox"
         value="red"
       />

--- a/packages/checkbox/src/react/__stories__/index.story.tsx
+++ b/packages/checkbox/src/react/__stories__/index.story.tsx
@@ -84,7 +84,7 @@ export const ExampleStateDemo: Story = () => {
         checked={checked('colorRed')}
         label="Red"
         name="colorRed"
-        onCheck={handleCheck}
+        onChange={handleCheck}
         value="red"
       />
 
@@ -92,7 +92,7 @@ export const ExampleStateDemo: Story = () => {
         checked={checked('colorGreen')}
         label="Green"
         name="colorGreen"
-        onCheck={handleCheck}
+        onChange={handleCheck}
         value="green"
       />
 
@@ -100,7 +100,7 @@ export const ExampleStateDemo: Story = () => {
         checked={checked('colorBlue')}
         label="Blue"
         name="colorBlue"
-        onCheck={handleCheck}
+        onChange={handleCheck}
         value="blue"
       />
     </div>

--- a/packages/checkbox/src/react/index.tsx
+++ b/packages/checkbox/src/react/index.tsx
@@ -10,6 +10,17 @@ import React, { SyntheticEvent } from 'react'
 
 import '../css/index.css'
 
+type ChangeFn = (
+  evt:
+    | React.KeyboardEvent<HTMLLabelElement>
+    | React.MouseEvent<HTMLLabelElement, MouseEvent>,
+  checked: boolean,
+  value: React.ReactText,
+  name: string | undefined
+) => void
+
+type DefaultChangeFn = (evt: SyntheticEvent) => void
+
 interface CheckboxProps
   extends React.HTMLAttributes<HTMLDivElement>,
     Record<string, unknown> {
@@ -19,21 +30,15 @@ interface CheckboxProps
   indeterminate?: boolean
   label: React.ReactNode
   name?: string
-  onChange?: (evt: SyntheticEvent) => void
-  onCheck?: (
-    evt:
-      | React.KeyboardEvent<HTMLLabelElement>
-      | React.MouseEvent<HTMLLabelElement, MouseEvent>,
-    checked: boolean,
-    value: React.ReactText,
-    name: string | undefined
-  ) => void
+  onChange?: DefaultChangeFn
+  onCheck?: ChangeFn
   value: string | number
 }
 
 const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   (props, forwardedRef) => {
-    const { checked, disabled, indeterminate, name, value, onCheck } = props
+    const { checked, disabled, indeterminate, name, value, onCheck, onChange } =
+      props
 
     const themeName = useTheme()
 
@@ -56,7 +61,16 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
         | React.MouseEvent<HTMLLabelElement>
         | React.KeyboardEvent<HTMLLabelElement>
     ) => {
-      if (onCheck && isFunction(onCheck)) onCheck(evt, !checked, value, name)
+      const changeFn = onChange as ChangeFn
+
+      if (onChange) {
+        changeFn(evt, !checked, value, name)
+        return
+      }
+
+      if (onCheck && isFunction(onCheck)) {
+        onCheck(evt, !checked, value, name)
+      }
     }
 
     const handleClick: React.MouseEventHandler<HTMLLabelElement> = evt => {
@@ -102,7 +116,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
             ref={ref}
             type="checkbox"
             checked={checked}
-            onChange={props.onChange}
+            onChange={handleClick as DefaultChangeFn}
             className="psds-screenreader-only psds-checkbox__input"
             {...omit(props, [
               'className',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
closes #2035 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Checkbox component was logging syntax errors due to missing `onChange` prop perference.

## What is the new behavior?
Updates the components to favor `onChange` over `onCheck` to prevent console errors from being logged as well as releasing a  breaking change.

## Other information
