### PR TITLE
fix: add missing deps to core, dropdown, and util packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,9 +25,11 @@
   "sideEffects": false,
   "style": "dist/css/index.css",
   "types": "dist/esm/index.d.ts",
+  "dependencies": {
+    "@pluralsight/ps-design-system-util": "^10.1.0"
+  },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",
-    "@pluralsight/ps-design-system-util": "^10.1.0",
     "globby": "^11.0.2",
     "postcss": "^8.2.10",
     "postcss-import": "^12.0.1",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -33,6 +33,7 @@
     "@pluralsight/ps-design-system-core": "^10.0.1",
     "@pluralsight/ps-design-system-halo": "^12.0.3",
     "@pluralsight/ps-design-system-icon": "^25.1.0",
+    "@pluralsight/ps-design-system-screenreaderonly": "^5.0.6",
     "@pluralsight/ps-design-system-util": "^10.1.0",
     "react-innertext": "^1.1.5"
   },

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -31,7 +31,8 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
-    "react": "^17.0.1"
+    "react": "*",
+    "react-dom": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
contributes to #2018 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Core, Dropdown, and Util packages were missing some devDeps which were breaking code sandboxes along with causing bad installs for people using Yarn Berry with PnP

## What is the new behavior?
Adds missing deps to packages.

## Other information
