### PR TITLE
build: correct all peerDeps to use standard wildcard

### DIFF
--- a/packages/appframe/package.json
+++ b/packages/appframe/package.json
@@ -40,9 +40,9 @@
     "focus-within": "^3.0.2"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -35,8 +35,8 @@
     "tiny-hashes": "^1.0.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -33,9 +33,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -37,8 +37,8 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -35,8 +35,8 @@
     "@pluralsight/ps-design-system-icon": "^25.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -35,9 +35,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.15",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -37,9 +37,9 @@
     "shiitake": "^3.0.2"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -38,9 +38,9 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-actionmenu": "^18.0.11",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -35,9 +35,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/circularprogress/package.json
+++ b/packages/circularprogress/package.json
@@ -35,9 +35,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -26,7 +26,7 @@
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",
   "peerDependencies": {
-    "react": "^17.0.1"
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0"

--- a/packages/datawell/package.json
+++ b/packages/datawell/package.json
@@ -36,9 +36,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -42,9 +42,9 @@
     "dayzed": "^3.2.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -35,9 +35,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -38,9 +38,9 @@
     "element-closest": "^3.0.2"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/emptystate/package.json
+++ b/packages/emptystate/package.json
@@ -39,9 +39,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -42,9 +42,9 @@
     "camelize": "^1.0.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/featureflags/package.json
+++ b/packages/featureflags/package.json
@@ -26,7 +26,7 @@
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",
   "peerDependencies": {
-    "react": "^17.0.1"
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0"

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -42,9 +42,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/focusmanager/package.json
+++ b/packages/focusmanager/package.json
@@ -27,8 +27,8 @@
   "sideEffects": false,
   "types": "dist/esm/index.d.ts",
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -38,9 +38,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-actionmenu": "^18.0.11",

--- a/packages/halo/package.json
+++ b/packages/halo/package.json
@@ -37,9 +37,9 @@
     "hoist-non-react-statics": "^3.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -46,8 +46,8 @@
     "svgo": "^2.3.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -39,8 +39,8 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/linearprogress/package.json
+++ b/packages/linearprogress/package.json
@@ -36,9 +36,9 @@
     "@pluralsight/ps-design-system-screenreaderonly": "^5.0.7"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -34,9 +34,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -36,9 +36,9 @@
     "focus-within": "^3.0.2"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/multiselect/package.json
+++ b/packages/multiselect/package.json
@@ -40,9 +40,9 @@
     "downshift": "^6.1.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/navbar/package.json
+++ b/packages/navbar/package.json
@@ -37,9 +37,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-actionmenu": "^18.0.11",

--- a/packages/navbrand/package.json
+++ b/packages/navbrand/package.json
@@ -36,9 +36,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/navcookiebanner/package.json
+++ b/packages/navcookiebanner/package.json
@@ -37,9 +37,9 @@
     "react-cookie": "^4.0.3"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "8",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/navitem/package.json
+++ b/packages/navitem/package.json
@@ -37,9 +37,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-actionmenu": "^18.0.11",

--- a/packages/navuser/package.json
+++ b/packages/navuser/package.json
@@ -37,9 +37,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-actionmenu": "^18.0.11",

--- a/packages/note/package.json
+++ b/packages/note/package.json
@@ -36,9 +36,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-actionmenu": "^18.0.11",

--- a/packages/position/package.json
+++ b/packages/position/package.json
@@ -32,8 +32,8 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -35,9 +35,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -34,9 +34,9 @@
     "shave": "^2.5.6"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/screenreaderonly/package.json
+++ b/packages/screenreaderonly/package.json
@@ -35,8 +35,8 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/scrollable/package.json
+++ b/packages/scrollable/package.json
@@ -35,8 +35,8 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/searchinput/package.json
+++ b/packages/searchinput/package.json
@@ -39,9 +39,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -37,9 +37,9 @@
     "downshift": "^6.1.2"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/starrating/package.json
+++ b/packages/starrating/package.json
@@ -38,9 +38,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -35,9 +35,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -35,9 +35,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -35,9 +35,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -38,9 +38,9 @@
     "invariant": "^2.2.4"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@emotion/css": "^11.1.3",

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -36,9 +36,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/tagsinput/package.json
+++ b/packages/tagsinput/package.json
@@ -39,8 +39,8 @@
     "downshift": "^6.1.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -34,9 +34,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -36,9 +36,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/textinput/package.json
+++ b/packages/textinput/package.json
@@ -37,9 +37,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -29,8 +29,8 @@
     "hoist-non-react-statics": "^3.3.0"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "react": "*"
   },
   "gitHead": "0c5576456d80ae8d6dfb82da74320f3e8266c35a"
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -34,8 +34,8 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/typeahead/package.json
+++ b/packages/typeahead/package.json
@@ -39,9 +39,9 @@
     "downshift": "^6.1.2"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/verticaltabs/package.json
+++ b/packages/verticaltabs/package.json
@@ -34,9 +34,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",

--- a/packages/viewtoggle/package.json
+++ b/packages/viewtoggle/package.json
@@ -35,9 +35,9 @@
     "@pluralsight/ps-design-system-util": "^10.1.1"
   },
   "peerDependencies": {
-    "@pluralsight/ps-design-system-normalize": "^6.0.0",
-    "@pluralsight/ps-design-system-theme": "^8.1.4",
-    "react": "^17.0.1"
+    "@pluralsight/ps-design-system-normalize": "*",
+    "@pluralsight/ps-design-system-theme": "*",
+    "react": "*"
   },
   "devDependencies": {
     "@pluralsight/ps-design-system-build": "^4.0.0",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
All packages using `peerDeps` are not using the standard wildcard sytnax which messes up the deps tree.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Updates all packages to use wildcard.

## Other information
