### PR TITLE
Fix/2012/dropdown close inconsistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "start": "yarn docs",
     "start:button": "yarn workspace @pluralsight/ps-design-system-button run storybook",
     "start:circularprogress": "yarn workspace @pluralsight/ps-design-system-circularprogress run storybook",
+    "start:dropdown": "yarn workspace @pluralsight/ps-design-system-dropdown run storybook",
     "test": "jest",
     "test:ci": "jest --ci"
   },

--- a/packages/dropdown/src/react/__specs__/index.spec.tsx
+++ b/packages/dropdown/src/react/__specs__/index.spec.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import Dropdown from '../index'
 
 import * as stories from '../__stories__/index.story'
+import * as examples from '../__stories__/examples.story'
 
 const pressArrowDown = (el = document?.activeElement) => {
   fireEvent.keyDown(el as HTMLElement, { key: 'ArrowDown', code: 'ArrowDown' })
@@ -148,6 +149,21 @@ describe('Dropdown', () => {
 
       const menu = screen.getByRole('listbox')
       expect(menu).toBeInTheDocument()
+    })
+
+    it('caret down click closes other open menus', () => {
+      const { StyleFixedWidth } = examples
+      render(<StyleFixedWidth {...StyleFixedWidth.args} />)
+
+      const caretDowns = screen.getAllByRole('img', { name: 'caret down icon' })
+      userEvent.click(caretDowns[0])
+
+      const menus1 = screen.getAllByRole('listbox')
+      expect(menus1.length).toEqual(1)
+
+      userEvent.click(caretDowns[1])
+      const menus2 = screen.getAllByRole('listbox')
+      expect(menus2.length).toEqual(1)
     })
 
     it('items are selectable by mouse click', () => {

--- a/packages/steps/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/steps/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -434,7 +434,7 @@ exports[`Storyshots Components/Steps/Step Custom Marker 1`] = `
             cy="24"
             r={22}
             strokeDasharray="138.23007675795088 138.23007675795088"
-            strokeDashoffset={103.67255756846316}
+            strokeDashoffset={138.23007675795088}
           />
         </svg>
       </div>

--- a/packages/util/src/use-close-on-document-events.ts
+++ b/packages/util/src/use-close-on-document-events.ts
@@ -110,7 +110,7 @@ export const onGlobalEventsClose: EventHandler = (el, callback) => {
   if (!canUseDOM()) return noop
 
   const handleClickOutsideMenu = (evt: MouseEvent) => {
-    if (evt.target instanceof HTMLElement) {
+    if (evt.target instanceof HTMLElement || evt.target instanceof SVGElement) {
       if (el.contains(evt.target)) return
       callback(evt)
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

#2012 Pressing caret does not close other menus, while pressing the menu does.  

## What is the new behavior?

Pressing caret icon will close other menus

## Other information

Problem was a check that the event came from an HTML element, which didn't match since it was an SVG element.