### PR TITLE
Fix/1609/dropdown reopen on press

### DIFF
--- a/packages/dropdown/src/js/index.ts
+++ b/packages/dropdown/src/js/index.ts
@@ -225,10 +225,18 @@ export const useDropdown = (
           evt: Event
         ) => {
           if (
-            !(evt.target instanceof HTMLElement) ||
-            !ref.current?.contains(evt.target)
-          )
+            !(
+              evt.target instanceof HTMLElement ||
+              evt.target instanceof SVGElement
+            ) ||
+            !(
+              ref.current?.contains(evt.target as Node) ||
+              evt.target === buttonRef.current ||
+              buttonRef.current?.contains(evt.target as Node)
+            )
+          ) {
             setOpen(false)
+          }
         },
         onMenuClick: handleMenuItemClick,
         selectedItem

--- a/packages/dropdown/src/react/__specs__/index.spec.tsx
+++ b/packages/dropdown/src/react/__specs__/index.spec.tsx
@@ -138,6 +138,18 @@ describe('Dropdown', () => {
       expect(menu).toBeInTheDocument()
     })
 
+    it('subsequent button click closes the open menu', () => {
+      render(<Basic {...Basic.args} placeholder="Select" />)
+
+      const button = screen.getByRole('button', { name: /Select/ })
+      userEvent.click(button)
+
+      const menu = screen.queryByRole('listbox')
+      expect(menu).toBeInTheDocument()
+      userEvent.click(button)
+      expect(menu).not.toBeInTheDocument()
+    })
+
     it('caret down click opens the menu', () => {
       render(<Basic {...Basic.args} />)
 

--- a/packages/steps/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
+++ b/packages/steps/src/react/__specs__/__snapshots__/storyshots.spec.tsx.snap
@@ -434,7 +434,7 @@ exports[`Storyshots Components/Steps/Step Custom Marker 1`] = `
             cy="24"
             r={22}
             strokeDasharray="138.23007675795088 138.23007675795088"
-            strokeDashoffset={103.67255756846316}
+            strokeDashoffset={138.23007675795088}
           />
         </svg>
       </div>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

#1609 - Click the dropdown button when menu is open -> Closes and immediately reopens.

## What is the new behavior?

Clicking on the dropdown when the menu is open will close the menu

## Other information

This was due to the global handler for clicks outside the menu closing the menu, then the button toggling the state back from closed to open.
