### PR TITLE
deps: move all custom storybook addon deps to dev

### DIFF
--- a/packages/storybook-addon-center/package.json
+++ b/packages/storybook-addon-center/package.json
@@ -15,7 +15,7 @@
     "build:watch": "yarn build --watch"
   },
   "types": "dist/index.d.ts",
-  "dependencies": {
+  "devDependencies": {
     "@storybook/addons": "^6.1.10"
   },
   "peerDependencies": {

--- a/packages/storybook-addon-theme/package.json
+++ b/packages/storybook-addon-theme/package.json
@@ -16,7 +16,7 @@
     "build:watch": "yarn build --watch"
   },
   "types": "dist/index.d.ts",
-  "dependencies": {
+  "devDependencies": {
     "@pluralsight/ps-design-system-core": "^10.0.3",
     "@pluralsight/ps-design-system-theme": "^8.1.23",
     "@storybook/addons": "^6.0.26",

--- a/packages/storybook-preset/package.json
+++ b/packages/storybook-preset/package.json
@@ -14,7 +14,7 @@
     "build:watch": "yarn build --watch"
   },
   "types": "dist/index.d.ts",
-  "dependencies": {
+  "devDependencies": {
     "@pluralsight/ps-design-system-storybook-addon-center": "^5.1.7",
     "@pluralsight/ps-design-system-storybook-addon-theme": "^9.1.23",
     "@storybook/addon-a11y": "^6.0.21",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Storybook addon packages had all dependencies installed as prod

## What is the new behavior?

Dependencies for these packages moved to dev, since they are only needed for building the package

## Other information
