### PR TITLE
fix(dialog): Adding dark theme to dialog

### DIFF
--- a/packages/dialog/src/css/index.css
+++ b/packages/dialog/src/css/index.css
@@ -7,7 +7,6 @@
 .psds-dialog {
   animation: psds-dialog__keyframes__fade var(--ps-motion-speed-fast) ease-out
     forwards;
-  background: var(--ps-colors-white);
   border-radius: 2px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
   display: inline-flex;
@@ -15,11 +14,16 @@
   position: relative;
   transform: translateY(var(--ps-layout-spacing-xsmall));
 }
+.psds-dialog.psds-theme--light {
+  background: var(--ps-colors-white);
+}
+.psds-dialog.psds-theme--dark {
+  background: var(--ps-colors-background-dark-2);
+}
 .psds-dialog:focus {
   outline: 0;
 }
 .psds-dialog__content {
-  color: var(--ps-colors-text-icon-high-on-light);
   font-size: var(--ps-type-font-size-200);
   font-weight: var(--ps-type-font-weight-500);
   line-height: var(--ps-type-line-height-tight);
@@ -27,8 +31,13 @@
   flex: 1 1 auto;
   overflow-y: auto;
 }
+.psds-dialog__content.psds-theme--light {
+  color: var(--ps-colors-text-icon-high-on-light);
+}
+.psds-dialog__content.psds-theme--dark {
+  color: var(--ps-colors-text-icon-high-on-dark);
+}
 .psds-dialog--with-tail:after {
-  background-color: var(--ps-colors-white);
   content: ' ';
   display: block;
   height: 14px;
@@ -37,6 +46,12 @@
   transform: rotate(45deg);
   white-space: pre;
   width: 14px;
+}
+.psds-dialog--with-tail.psds-theme--light:after {
+  background-color: var(--ps-colors-white);
+}
+.psds-dialog--with-tail.psds-theme--dark:after {
+  background-color: var(--ps-colors-background-dark-2);
 }
 .psds-dialog--tail-position-top-left:after {
   left: 14px;
@@ -92,7 +107,6 @@
   width: 32px;
   border: none;
   background: 0 0;
-  color: var(--ps-colors-text-icon-low-on-light);
 }
 .psds-dialog__close:not([disabled]):focus,
 .psds-dialog__close:not([disabled]):hover {
@@ -111,13 +125,17 @@
   transform: scale(0.98);
 }
 .psds-dialog__close svg {
-  fill: var(--ps-colors-text-icon-low-on-light);
   height: 24px;
   width: 24px;
 }
+.psds-dialog__close.psds-theme--light svg {
+  fill: var(--ps-colors-text-icon-low-on-light);
+}
+.psds-dialog__close.psds-theme--dark svg {
+  fill: var(--ps-colors-text-icon-high-on-dark);
+}
 .psds-dialog__overlay {
   align-items: center;
-  background-color: rgba(0, 0, 0, 0.5);
   display: flex;
   height: 100%;
   justify-content: center;
@@ -125,4 +143,10 @@
   position: fixed;
   top: 0;
   width: 100%;
+}
+.psds-dialog__overlay.psds-theme--light {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+.psds-dialog__overlay.psds-theme--dark {
+  background-color: rgba(255, 255, 255, 0.5);
 }

--- a/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -43,26 +43,26 @@ exports[`Storyshots Components/Dialog Focus On Heading 1`] = `
   </p>
   <div
     aria-label="Storybook Modal"
-    className="psds-dialog__overlay"
+    className="psds-dialog__overlay psds-theme--dark"
     id="psds-dialog__overlay"
     onClick={[Function]}
     role="region"
   >
     <div
-      className="psds-dialog psds-dialog--modal"
+      className="psds-dialog psds-theme--dark psds-dialog--modal"
       onKeyUp={[Function]}
     >
       <div
         className="psds-dialog__content"
       >
         <h2
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
           tabIndex={0}
         >
           Heading should receive focus
         </h2>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -82,7 +82,7 @@ exports[`Storyshots Components/Dialog Focus On Heading 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -100,7 +100,7 @@ exports[`Storyshots Components/Dialog Focus On Heading 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -113,8 +113,9 @@ exports[`Storyshots Components/Dialog Focus On Heading 1`] = `
         </div>
         <button
           aria-label="Close dialog"
-          className="psds-dialog__close"
+          className="psds-dialog__close psds-theme--dark"
           onClick={[Function]}
+          theme="dark"
         >
           <svg
             aria-label="close icon"
@@ -176,13 +177,13 @@ exports[`Storyshots Components/Dialog Focus On Hidden Heading 1`] = `
   </p>
   <div
     aria-label="Storybook Modal"
-    className="psds-dialog__overlay"
+    className="psds-dialog__overlay psds-theme--dark"
     id="psds-dialog__overlay"
     onClick={[Function]}
     role="region"
   >
     <div
-      className="psds-dialog psds-dialog--modal"
+      className="psds-dialog psds-theme--dark psds-dialog--modal"
       onKeyUp={[Function]}
     >
       <div
@@ -198,7 +199,7 @@ exports[`Storyshots Components/Dialog Focus On Hidden Heading 1`] = `
           </h2>
         </div>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -218,7 +219,7 @@ exports[`Storyshots Components/Dialog Focus On Hidden Heading 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -236,7 +237,7 @@ exports[`Storyshots Components/Dialog Focus On Hidden Heading 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -249,8 +250,9 @@ exports[`Storyshots Components/Dialog Focus On Hidden Heading 1`] = `
         </div>
         <button
           aria-label="Close dialog"
-          className="psds-dialog__close"
+          className="psds-dialog__close psds-theme--dark"
           onClick={[Function]}
+          theme="dark"
         >
           <svg
             aria-label="close icon"
@@ -312,25 +314,25 @@ exports[`Storyshots Components/Dialog Modal Default 1`] = `
   </p>
   <div
     aria-label="Storybook Modal"
-    className="psds-dialog__overlay"
+    className="psds-dialog__overlay psds-theme--dark"
     id="psds-dialog__overlay"
     onClick={[Function]}
     role="region"
   >
     <div
-      className="psds-dialog psds-dialog--modal"
+      className="psds-dialog psds-theme--dark psds-dialog--modal"
       onKeyUp={[Function]}
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -346,7 +348,7 @@ exports[`Storyshots Components/Dialog Modal Default 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -366,7 +368,7 @@ exports[`Storyshots Components/Dialog Modal Default 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -384,7 +386,7 @@ exports[`Storyshots Components/Dialog Modal Default 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -397,8 +399,9 @@ exports[`Storyshots Components/Dialog Modal Default 1`] = `
         </div>
         <button
           aria-label="Close dialog"
-          className="psds-dialog__close"
+          className="psds-dialog__close psds-theme--dark"
           onClick={[Function]}
+          theme="dark"
         >
           <svg
             aria-label="close icon"
@@ -460,25 +463,25 @@ exports[`Storyshots Components/Dialog Modal No Click Overlay 1`] = `
   </p>
   <div
     aria-label="Storybook Modal"
-    className="psds-dialog__overlay"
+    className="psds-dialog__overlay psds-theme--dark"
     id="psds-dialog__overlay"
     onClick={[Function]}
     role="region"
   >
     <div
-      className="psds-dialog psds-dialog--modal"
+      className="psds-dialog psds-theme--dark psds-dialog--modal"
       onKeyUp={[Function]}
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -494,7 +497,7 @@ exports[`Storyshots Components/Dialog Modal No Click Overlay 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -514,7 +517,7 @@ exports[`Storyshots Components/Dialog Modal No Click Overlay 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -532,7 +535,7 @@ exports[`Storyshots Components/Dialog Modal No Click Overlay 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -545,8 +548,9 @@ exports[`Storyshots Components/Dialog Modal No Click Overlay 1`] = `
         </div>
         <button
           aria-label="Close dialog"
-          className="psds-dialog__close"
+          className="psds-dialog__close psds-theme--dark"
           onClick={[Function]}
+          theme="dark"
         >
           <svg
             aria-label="close icon"
@@ -608,25 +612,25 @@ exports[`Storyshots Components/Dialog Modal No Closebutton 1`] = `
   </p>
   <div
     aria-label="Storybook Modal"
-    className="psds-dialog__overlay"
+    className="psds-dialog__overlay psds-theme--dark"
     id="psds-dialog__overlay"
     onClick={[Function]}
     role="region"
   >
     <div
-      className="psds-dialog psds-dialog--modal"
+      className="psds-dialog psds-theme--dark psds-dialog--modal"
       onKeyUp={[Function]}
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -642,7 +646,7 @@ exports[`Storyshots Components/Dialog Modal No Closebutton 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -662,7 +666,7 @@ exports[`Storyshots Components/Dialog Modal No Closebutton 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -680,7 +684,7 @@ exports[`Storyshots Components/Dialog Modal No Closebutton 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -740,24 +744,24 @@ exports[`Storyshots Components/Dialog Modal No Escape Key 1`] = `
   </p>
   <div
     aria-label="Storybook Modal"
-    className="psds-dialog__overlay"
+    className="psds-dialog__overlay psds-theme--dark"
     id="psds-dialog__overlay"
     onClick={[Function]}
     role="region"
   >
     <div
-      className="psds-dialog psds-dialog--modal"
+      className="psds-dialog psds-theme--dark psds-dialog--modal"
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -773,7 +777,7 @@ exports[`Storyshots Components/Dialog Modal No Escape Key 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -793,7 +797,7 @@ exports[`Storyshots Components/Dialog Modal No Escape Key 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -811,7 +815,7 @@ exports[`Storyshots Components/Dialog Modal No Escape Key 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -824,8 +828,9 @@ exports[`Storyshots Components/Dialog Modal No Escape Key 1`] = `
         </div>
         <button
           aria-label="Close dialog"
-          className="psds-dialog__close"
+          className="psds-dialog__close psds-theme--dark"
           onClick={[Function]}
+          theme="dark"
         >
           <svg
             aria-label="close icon"
@@ -887,25 +892,25 @@ exports[`Storyshots Components/Dialog Modal No Focus On Mount 1`] = `
   </p>
   <div
     aria-label="Storybook Modal"
-    className="psds-dialog__overlay"
+    className="psds-dialog__overlay psds-theme--dark"
     id="psds-dialog__overlay"
     onClick={[Function]}
     role="region"
   >
     <div
-      className="psds-dialog psds-dialog--modal"
+      className="psds-dialog psds-theme--dark psds-dialog--modal"
       onKeyUp={[Function]}
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -921,7 +926,7 @@ exports[`Storyshots Components/Dialog Modal No Focus On Mount 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -941,7 +946,7 @@ exports[`Storyshots Components/Dialog Modal No Focus On Mount 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -959,7 +964,7 @@ exports[`Storyshots Components/Dialog Modal No Focus On Mount 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -972,8 +977,9 @@ exports[`Storyshots Components/Dialog Modal No Focus On Mount 1`] = `
         </div>
         <button
           aria-label="Close dialog"
-          className="psds-dialog__close"
+          className="psds-dialog__close psds-theme--dark"
           onClick={[Function]}
+          theme="dark"
         >
           <svg
             aria-label="close icon"
@@ -1035,27 +1041,28 @@ exports[`Storyshots Components/Dialog Modal No Focusable Child Elements 1`] = `
   </p>
   <div
     aria-label="Storybook Modal"
-    className="psds-dialog__overlay"
+    className="psds-dialog__overlay psds-theme--dark"
     id="psds-dialog__overlay"
     onClick={[Function]}
     role="region"
   >
     <div
-      className="psds-dialog psds-dialog--modal"
+      className="psds-dialog psds-theme--dark psds-dialog--modal"
       onKeyUp={[Function]}
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <button
           aria-label="Close dialog"
-          className="psds-dialog__close"
+          className="psds-dialog__close psds-theme--dark"
           onClick={[Function]}
+          theme="dark"
         >
           <svg
             aria-label="close icon"
@@ -1117,20 +1124,20 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
   </p>
   <div
     aria-label="Storybook Modal"
-    className="psds-dialog__overlay"
+    className="psds-dialog__overlay psds-theme--dark"
     id="psds-dialog__overlay"
     onClick={[Function]}
     role="region"
   >
     <div
-      className="psds-dialog psds-dialog--modal psds-dialog--with-tail psds-dialog--tail-position-top-center"
+      className="psds-dialog psds-theme--dark psds-dialog--modal psds-dialog--with-tail psds-dialog--tail-position-top-center"
       onKeyUp={[Function]}
     >
       <div
         className="psds-dialog__content"
       >
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1147,7 +1154,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1164,7 +1171,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1181,7 +1188,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1198,7 +1205,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1215,7 +1222,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1232,7 +1239,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1249,7 +1256,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1266,7 +1273,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1283,7 +1290,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1300,7 +1307,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1317,7 +1324,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1334,7 +1341,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1351,7 +1358,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1368,7 +1375,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1385,7 +1392,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1402,7 +1409,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1419,7 +1426,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1436,7 +1443,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1453,7 +1460,7 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1471,8 +1478,9 @@ exports[`Storyshots Components/Dialog Modal Overflow Y With Tail 1`] = `
         </p>
         <button
           aria-label="Close dialog"
-          className="psds-dialog__close"
+          className="psds-dialog__close psds-theme--dark"
           onClick={[Function]}
+          theme="dark"
         >
           <svg
             aria-label="close icon"
@@ -1534,20 +1542,20 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
   </p>
   <div
     aria-label="Storybook Modal"
-    className="psds-dialog__overlay"
+    className="psds-dialog__overlay psds-theme--dark"
     id="psds-dialog__overlay"
     onClick={[Function]}
     role="region"
   >
     <div
-      className="psds-dialog psds-dialog--modal"
+      className="psds-dialog psds-theme--dark psds-dialog--modal"
       onKeyUp={[Function]}
     >
       <div
         className="psds-dialog__content"
       >
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1564,7 +1572,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1581,7 +1589,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1598,7 +1606,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1615,7 +1623,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1632,7 +1640,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1649,7 +1657,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1666,7 +1674,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1683,7 +1691,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1700,7 +1708,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1717,7 +1725,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1734,7 +1742,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1751,7 +1759,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1768,7 +1776,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1785,7 +1793,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1802,7 +1810,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1819,7 +1827,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1836,7 +1844,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1853,7 +1861,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1870,7 +1878,7 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -1888,8 +1896,9 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
         </p>
         <button
           aria-label="Close dialog"
-          className="psds-dialog__close"
+          className="psds-dialog__close psds-theme--dark"
           onClick={[Function]}
+          theme="dark"
         >
           <svg
             aria-label="close icon"
@@ -1910,19 +1919,19 @@ exports[`Storyshots Components/Dialog Modal Overlow Y 1`] = `
 
 exports[`Storyshots Components/Dialog On Close 1`] = `
 <div
-  className="psds-dialog"
+  className="psds-dialog psds-theme--dark"
   onKeyUp={[Function]}
 >
   <div
     className="psds-dialog__content"
   >
     <h1
-      className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+      className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
     >
       Wowzers, a Dialog
     </h1>
     <p
-      className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+      className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
     >
       <a
         href="#"
@@ -1938,7 +1947,7 @@ exports[`Storyshots Components/Dialog On Close 1`] = `
        lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
     </p>
     <p
-      className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+      className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
     >
       Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
        
@@ -1958,7 +1967,7 @@ exports[`Storyshots Components/Dialog On Close 1`] = `
       }
     >
       <button
-        className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+        className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
         disabled={false}
       >
         <span
@@ -1976,7 +1985,7 @@ exports[`Storyshots Components/Dialog On Close 1`] = `
         }
       />
       <button
-        className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+        className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
         disabled={false}
       >
         <span
@@ -1989,8 +1998,9 @@ exports[`Storyshots Components/Dialog On Close 1`] = `
     </div>
     <button
       aria-label="Close dialog"
-      className="psds-dialog__close"
+      className="psds-dialog__close psds-theme--dark"
       onClick={[Function]}
+      theme="dark"
     >
       <svg
         aria-label="close icon"
@@ -2009,13 +2019,13 @@ exports[`Storyshots Components/Dialog On Close 1`] = `
 
 exports[`Storyshots Components/Dialog On Close Disable Closebutton 1`] = `
 <div
-  className="psds-dialog"
+  className="psds-dialog psds-theme--dark"
 >
   <div
     className="psds-dialog__content"
   >
     <h1
-      className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+      className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
     >
       Wowzers, a Dialog
     </h1>
@@ -2046,18 +2056,18 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
       none
     </div>
     <div
-      className="psds-dialog"
+      className="psds-dialog psds-theme--dark"
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -2073,7 +2083,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -2093,7 +2103,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2111,7 +2121,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2128,18 +2138,18 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
       topLeft
     </div>
     <div
-      className="psds-dialog psds-dialog--with-tail psds-dialog--tail-position-top-left"
+      className="psds-dialog psds-theme--dark psds-dialog--with-tail psds-dialog--tail-position-top-left"
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -2155,7 +2165,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -2175,7 +2185,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2193,7 +2203,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2210,18 +2220,18 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
       topCenter
     </div>
     <div
-      className="psds-dialog psds-dialog--with-tail psds-dialog--tail-position-top-center"
+      className="psds-dialog psds-theme--dark psds-dialog--with-tail psds-dialog--tail-position-top-center"
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -2237,7 +2247,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -2257,7 +2267,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2275,7 +2285,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2292,18 +2302,18 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
       topRight
     </div>
     <div
-      className="psds-dialog psds-dialog--with-tail psds-dialog--tail-position-top-right"
+      className="psds-dialog psds-theme--dark psds-dialog--with-tail psds-dialog--tail-position-top-right"
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -2319,7 +2329,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -2339,7 +2349,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2357,7 +2367,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2374,18 +2384,18 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
       bottomLeft
     </div>
     <div
-      className="psds-dialog psds-dialog--with-tail psds-dialog--tail-position-bottom-left"
+      className="psds-dialog psds-theme--dark psds-dialog--with-tail psds-dialog--tail-position-bottom-left"
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -2401,7 +2411,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -2421,7 +2431,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2439,7 +2449,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2456,18 +2466,18 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
       bottomCenter
     </div>
     <div
-      className="psds-dialog psds-dialog--with-tail psds-dialog--tail-position-bottom-center"
+      className="psds-dialog psds-theme--dark psds-dialog--with-tail psds-dialog--tail-position-bottom-center"
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -2483,7 +2493,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -2503,7 +2513,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2521,7 +2531,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2538,18 +2548,18 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
       bottomRight
     </div>
     <div
-      className="psds-dialog psds-dialog--with-tail psds-dialog--tail-position-bottom-right"
+      className="psds-dialog psds-theme--dark psds-dialog--with-tail psds-dialog--tail-position-bottom-right"
     >
       <div
         className="psds-dialog__content"
       >
         <h1
-          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--dark"
         >
           Wowzers, a Dialog
         </h1>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           <a
             href="#"
@@ -2565,7 +2575,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
            lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
         </p>
         <p
-          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--dark"
         >
           Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
            
@@ -2585,7 +2595,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
           }
         >
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--dark"
             disabled={false}
           >
             <span
@@ -2603,7 +2613,7 @@ exports[`Storyshots Components/Dialog Tail Positions 1`] = `
             }
           />
           <button
-            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--dark"
             disabled={false}
           >
             <span

--- a/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
+++ b/packages/dialog/src/react/__specs__/__snapshots__/storyshots.spec.ts.snap
@@ -271,6 +271,619 @@ exports[`Storyshots Components/Dialog Focus On Hidden Heading 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Dialog Light Theme Dialog 1`] = `
+<div
+  className="psds-dialog psds-theme--light"
+>
+  <div
+    className="psds-dialog__content"
+  >
+    <h1
+      className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+    >
+      Wowzers, a Dialog
+    </h1>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components/Dialog Light Theme With Tail 1`] = `
+<div
+  style={
+    Object {
+      "margin": "0 auto",
+      "maxWidth": "50%",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "display": "grid",
+        "gap": "20px",
+        "gridTemplateColumns": "1fr 1fr",
+        "justifyItems": "left",
+      }
+    }
+  >
+    <div>
+      none
+    </div>
+    <div
+      className="psds-dialog psds-theme--light"
+    >
+      <div
+        className="psds-dialog__content"
+      >
+        <h1
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+        >
+          Wowzers, a Dialog
+        </h1>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          <a
+            href="#"
+          >
+            Brownie bear claw
+          </a>
+           liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice. 
+          <a
+            href="#"
+          >
+            Tart donut
+          </a>
+           lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+        </p>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
+           
+          <a
+            href="#"
+          >
+            cotton candy
+          </a>
+           muffin soufflé marshmallow biscuit.
+        </p>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "justifyContent": "flex-end",
+            }
+          }
+        >
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Secondary CTA
+            </span>
+          </button>
+          <span
+            style={
+              Object {
+                "marginLeft": 10,
+              }
+            }
+          />
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Primary CTA
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div>
+      topLeft
+    </div>
+    <div
+      className="psds-dialog psds-theme--light psds-dialog--with-tail psds-dialog--tail-position-top-left"
+    >
+      <div
+        className="psds-dialog__content"
+      >
+        <h1
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+        >
+          Wowzers, a Dialog
+        </h1>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          <a
+            href="#"
+          >
+            Brownie bear claw
+          </a>
+           liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice. 
+          <a
+            href="#"
+          >
+            Tart donut
+          </a>
+           lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+        </p>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
+           
+          <a
+            href="#"
+          >
+            cotton candy
+          </a>
+           muffin soufflé marshmallow biscuit.
+        </p>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "justifyContent": "flex-end",
+            }
+          }
+        >
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Secondary CTA
+            </span>
+          </button>
+          <span
+            style={
+              Object {
+                "marginLeft": 10,
+              }
+            }
+          />
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Primary CTA
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div>
+      topCenter
+    </div>
+    <div
+      className="psds-dialog psds-theme--light psds-dialog--with-tail psds-dialog--tail-position-top-center"
+    >
+      <div
+        className="psds-dialog__content"
+      >
+        <h1
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+        >
+          Wowzers, a Dialog
+        </h1>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          <a
+            href="#"
+          >
+            Brownie bear claw
+          </a>
+           liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice. 
+          <a
+            href="#"
+          >
+            Tart donut
+          </a>
+           lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+        </p>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
+           
+          <a
+            href="#"
+          >
+            cotton candy
+          </a>
+           muffin soufflé marshmallow biscuit.
+        </p>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "justifyContent": "flex-end",
+            }
+          }
+        >
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Secondary CTA
+            </span>
+          </button>
+          <span
+            style={
+              Object {
+                "marginLeft": 10,
+              }
+            }
+          />
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Primary CTA
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div>
+      topRight
+    </div>
+    <div
+      className="psds-dialog psds-theme--light psds-dialog--with-tail psds-dialog--tail-position-top-right"
+    >
+      <div
+        className="psds-dialog__content"
+      >
+        <h1
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+        >
+          Wowzers, a Dialog
+        </h1>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          <a
+            href="#"
+          >
+            Brownie bear claw
+          </a>
+           liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice. 
+          <a
+            href="#"
+          >
+            Tart donut
+          </a>
+           lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+        </p>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
+           
+          <a
+            href="#"
+          >
+            cotton candy
+          </a>
+           muffin soufflé marshmallow biscuit.
+        </p>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "justifyContent": "flex-end",
+            }
+          }
+        >
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Secondary CTA
+            </span>
+          </button>
+          <span
+            style={
+              Object {
+                "marginLeft": 10,
+              }
+            }
+          />
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Primary CTA
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div>
+      bottomLeft
+    </div>
+    <div
+      className="psds-dialog psds-theme--light psds-dialog--with-tail psds-dialog--tail-position-bottom-left"
+    >
+      <div
+        className="psds-dialog__content"
+      >
+        <h1
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+        >
+          Wowzers, a Dialog
+        </h1>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          <a
+            href="#"
+          >
+            Brownie bear claw
+          </a>
+           liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice. 
+          <a
+            href="#"
+          >
+            Tart donut
+          </a>
+           lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+        </p>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
+           
+          <a
+            href="#"
+          >
+            cotton candy
+          </a>
+           muffin soufflé marshmallow biscuit.
+        </p>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "justifyContent": "flex-end",
+            }
+          }
+        >
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Secondary CTA
+            </span>
+          </button>
+          <span
+            style={
+              Object {
+                "marginLeft": 10,
+              }
+            }
+          />
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Primary CTA
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div>
+      bottomCenter
+    </div>
+    <div
+      className="psds-dialog psds-theme--light psds-dialog--with-tail psds-dialog--tail-position-bottom-center"
+    >
+      <div
+        className="psds-dialog__content"
+      >
+        <h1
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+        >
+          Wowzers, a Dialog
+        </h1>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          <a
+            href="#"
+          >
+            Brownie bear claw
+          </a>
+           liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice. 
+          <a
+            href="#"
+          >
+            Tart donut
+          </a>
+           lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+        </p>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
+           
+          <a
+            href="#"
+          >
+            cotton candy
+          </a>
+           muffin soufflé marshmallow biscuit.
+        </p>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "justifyContent": "flex-end",
+            }
+          }
+        >
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Secondary CTA
+            </span>
+          </button>
+          <span
+            style={
+              Object {
+                "marginLeft": 10,
+              }
+            }
+          />
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Primary CTA
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div>
+      bottomRight
+    </div>
+    <div
+      className="psds-dialog psds-theme--light psds-dialog--with-tail psds-dialog--tail-position-bottom-right"
+    >
+      <div
+        className="psds-dialog__content"
+      >
+        <h1
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+        >
+          Wowzers, a Dialog
+        </h1>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          <a
+            href="#"
+          >
+            Brownie bear claw
+          </a>
+           liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice. 
+          <a
+            href="#"
+          >
+            Tart donut
+          </a>
+           lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+        </p>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
+           
+          <a
+            href="#"
+          >
+            cotton candy
+          </a>
+           muffin soufflé marshmallow biscuit.
+        </p>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "justifyContent": "flex-end",
+            }
+          }
+        >
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Secondary CTA
+            </span>
+          </button>
+          <span
+            style={
+              Object {
+                "marginLeft": 10,
+              }
+            }
+          />
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Primary CTA
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Dialog Modal Default 1`] = `
 <div>
   <p
@@ -402,6 +1015,155 @@ exports[`Storyshots Components/Dialog Modal Default 1`] = `
           className="psds-dialog__close psds-theme--dark"
           onClick={[Function]}
           theme="dark"
+        >
+          <svg
+            aria-label="close icon"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M18 7.41L16.59 6 12 10.59 7.41 6 6 7.41 10.59 12 6 16.59 7.41 18 12 13.41 16.59 18 18 16.59 13.41 12"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components/Dialog Modal Light Theme 1`] = `
+<div>
+  <p
+    className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+  >
+    Macaroon danish I love candy macaroon danish toffee muffin. Cotton candy chupa chups cupcake I love. Chocolate I love bonbon carrot cake cupcake cookie muffin liquorice. I love I love I love jelly-o fruitcake
+    <a
+      href="#"
+    >
+      I love chocolate cake
+    </a>
+     wafer chupa chups.
+  </p>
+  <p
+    className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+  >
+    Sesame snaps cake pudding I love chupa chups I love. Cotton candy biscuit oat cake dessert donut I love lemon drops. Cookie croissant dragée tootsie roll marzipan I love. Apple pie cheesecake jelly-o cheesecake I love cheesecake.
+  </p>
+  <button
+    className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+    disabled={false}
+    onClick={[Function]}
+  >
+    <span
+      aria-hidden={false}
+      className="psds-button__text"
+    >
+      close modal
+    </span>
+  </button>
+  <p
+    className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+  >
+    Sweet soufflé 
+    <a
+      href="#"
+    >
+      apple pie
+    </a>
+    . Halvah icing pudding pastry ice cream gingerbread tart candy canes dragée. Pie gingerbread icing.
+  </p>
+  <div
+    aria-label="Storybook Modal"
+    className="psds-dialog__overlay psds-theme--light"
+    id="psds-dialog__overlay"
+    onClick={[Function]}
+    role="region"
+  >
+    <div
+      className="psds-dialog psds-theme--light psds-dialog--modal"
+      onKeyUp={[Function]}
+    >
+      <div
+        className="psds-dialog__content"
+      >
+        <h1
+          className="psds-text__heading psds-text__heading--size-large psds-text__heading--color-primary psds-theme--light"
+        >
+          Wowzers, a Dialog
+        </h1>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          <a
+            href="#"
+          >
+            Brownie bear claw
+          </a>
+           liquorice dragée candy canes pastry topping. Chocolate cake soufflé sweet roll jelly beans oat cake donut. Wafer chocolate cake pastry chocolate bar fruitcake. Cupcake jelly-o croissant lollipop liquorice. 
+          <a
+            href="#"
+          >
+            Tart donut
+          </a>
+           lollipop dragée tootsie roll wafer lemon drops cupcake chocolate bar.
+        </p>
+        <p
+          className="psds-text__p psds-text__p--size-medium psds-text__p--color-primary psds-theme--light"
+        >
+          Powder apple pie cookie lemon drops marzipan gummies. Chocolate lemon drops tiramisu. Cotton candy powder oat cake toffee
+           
+          <a
+            href="#"
+          >
+            cotton candy
+          </a>
+           muffin soufflé marshmallow biscuit.
+        </p>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "justifyContent": "flex-end",
+            }
+          }
+        >
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-stroke psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Secondary CTA
+            </span>
+          </button>
+          <span
+            style={
+              Object {
+                "marginLeft": 10,
+              }
+            }
+          />
+          <button
+            className="psds-button psds-button--layout-inline psds-button--size-medium psds-button--appearance-primary psds-theme--light"
+            disabled={false}
+          >
+            <span
+              aria-hidden={false}
+              className="psds-button__text"
+            >
+              Primary CTA
+            </span>
+          </button>
+        </div>
+        <button
+          aria-label="Close dialog"
+          className="psds-dialog__close psds-theme--light"
+          onClick={[Function]}
+          theme="light"
         >
           <svg
             aria-label="close icon"

--- a/packages/dialog/src/react/__stories__/index.story.tsx
+++ b/packages/dialog/src/react/__stories__/index.story.tsx
@@ -6,6 +6,7 @@ import { Meta, Story } from '@storybook/react/types-6-0'
 import Button from '@pluralsight/ps-design-system-button'
 import ScreenReaderOnly from '@pluralsight/ps-design-system-screenreaderonly'
 import * as Text from '@pluralsight/ps-design-system-text'
+import Theme from '@pluralsight/ps-design-system-theme'
 
 import Dialog from '../../index'
 
@@ -49,6 +50,16 @@ export default {
   component: Dialog
 } as Meta
 
+export const LightThemeDialog: Story = () => (
+  <Theme name={Theme.names.light}>
+    <MockDialog>
+      <Text.Heading>
+        <h1>Wowzers, a Dialog</h1>
+      </Text.Heading>
+    </MockDialog>
+  </Theme>
+)
+
 export const OnClose: Story = () => <MockDialog onClose={closeAction} />
 
 export const OnCloseDisableClosebutton: Story = () => (
@@ -72,6 +83,23 @@ export const TailPositions: Story = () => (
       ))}
     </StoryGrid>
   </div>
+)
+
+export const LightThemeWithTail: Story = () => (
+  <Theme name={Theme.names.light}>
+    <div style={{ maxWidth: '50%', margin: '0 auto' }}>
+      <StoryGrid>
+        <div>none</div>
+        <MockDialog />
+        {Object.values(Dialog.tailPositions).map(position => (
+          <React.Fragment key={position}>
+            <div>{position}</div>
+            <MockDialog tailPosition={position} />
+          </React.Fragment>
+        ))}
+      </StoryGrid>
+    </div>
+  </Theme>
 )
 
 interface ModalStoryProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -132,6 +160,12 @@ const ModalStory: React.FC<ModalStoryProps> = ({ children }) => {
 
 export const ModalDefault: Story = () => (
   <ModalStory>{props => <MockDialog {...props} />}</ModalStory>
+)
+
+export const ModalLightTheme: Story = () => (
+  <Theme name={Theme.names.light}>
+    <ModalStory>{props => <MockDialog {...props} />}</ModalStory>
+  </Theme>
 )
 
 export const ModalNoClosebutton: Story = () => (

--- a/packages/dialog/src/react/index.tsx
+++ b/packages/dialog/src/react/index.tsx
@@ -1,5 +1,5 @@
 import FocusManager from '@pluralsight/ps-design-system-focusmanager'
-import Theme from '@pluralsight/ps-design-system-theme'
+import Theme, { useTheme } from '@pluralsight/ps-design-system-theme'
 import {
   RefForwardingComponent,
   ValueOf,
@@ -17,19 +17,24 @@ import * as vars from '../vars/index'
 /* eslint-disable-next-line camelcase */
 const MODAL_OVERLAY_ID = 'psds-dialog__overlay'
 
-const CloseButton: React.FC<React.HTMLAttributes<HTMLButtonElement>> =
-  props => (
-    <button {...props} className="psds-dialog__close" aria-label="Close dialog">
-      <svg
-        aria-label="close icon"
-        role="img"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path d="M18 7.41L16.59 6 12 10.59 7.41 6 6 7.41 10.59 12 6 16.59 7.41 18 12 13.41 16.59 18 18 16.59 13.41 12" />
-      </svg>
-    </button>
-  )
+const CloseButton: React.FC<
+  React.HTMLAttributes<HTMLButtonElement> & { theme: 'dark' | 'light' }
+> = props => (
+  <button
+    {...props}
+    className={classNames('psds-dialog__close', `psds-theme--${props.theme}`)}
+    aria-label="Close dialog"
+  >
+    <svg
+      aria-label="close icon"
+      role="img"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M18 7.41L16.59 6 12 10.59 7.41 6 6 7.41 10.59 12 6 16.59 7.41 18 12 13.41 16.59 18 18 16.59 13.41 12" />
+    </svg>
+  </button>
+)
 
 interface OverlayProps extends React.HTMLAttributes<HTMLDivElement> {
   'aria-label'?: string
@@ -42,6 +47,8 @@ const Overlay: React.FC<OverlayProps> = ({
   onClose,
   ...props
 }) => {
+  const theme = useTheme()
+
   function handleOverlayClick(evt: React.MouseEvent) {
     if (disableCloseOnOverlayClick) return
     if ((evt.target as HTMLDivElement).id === MODAL_OVERLAY_ID)
@@ -51,7 +58,7 @@ const Overlay: React.FC<OverlayProps> = ({
   return (
     <div
       {...props}
-      className="psds-dialog__overlay"
+      className={classNames('psds-dialog__overlay', `psds-theme--${theme}`)}
       id={MODAL_OVERLAY_ID}
       onClick={handleOverlayClick}
       role="region"
@@ -96,6 +103,7 @@ const Dialog = React.forwardRef((props, ref) => {
   const trapped = !!modal || !!onClose
   const closeOnEscape = isFunction(onClose) && !disableCloseOnEscape
 
+  const theme = useTheme()
   const portal = usePortal() as React.MutableRefObject<HTMLDivElement>
 
   // TODO: combine fns
@@ -109,6 +117,7 @@ const Dialog = React.forwardRef((props, ref) => {
       {...rest}
       className={classNames(
         'psds-dialog',
+        `psds-theme--${theme}`,
         modal && 'psds-dialog--modal',
         typeof tailPosition !== 'undefined' &&
           `psds-dialog--with-tail psds-dialog--tail-position-${dashify(
@@ -123,12 +132,12 @@ const Dialog = React.forwardRef((props, ref) => {
       returnFocus={returnFocus}
       ref={ref}
     >
-      <Theme name={Theme.names.light}>
+      <Theme name={theme}>
         <div className="psds-dialog__content">
           {children}
           {!disableCloseButton && isFunction(onClose) && (
             // eslint-disable-next-line react/jsx-handler-names
-            <CloseButton onClick={onClose} />
+            <CloseButton onClick={onClose} theme={theme} />
           )}
         </div>
       </Theme>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current dialog ignores theme provider's theme setting and force light theme on all dialogs.

## What is the new behavior?

The new change will read the theme from theme provider and change the colors to appropriate colors.

## Other information

There is one accessibility check failing on dark theme, but it's because of the `<a>` tag color. I assumed that `<a>` tags should be replaced with `ps-design-system-link`, and that'd make it accessible. Let me know if I should change the `<a>` tag color to `--ps-colors-primary-action-text-dark-theme` in storybook.

Thanks! 🙏🏼 
